### PR TITLE
Refactor tests to use Node.js module mocking capabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "start": "node ./src/bin.ts",
     "type-check": "tsc --noEmit",
-    "test": "node --test src/**/*.test.ts"
+    "test": "node --test --experimental-test-module-mocks src/**/*.test.ts"
   },
   "devDependencies": {
     "@types/node": "^22.15.29",

--- a/src/git/libs/add-worktree.ts
+++ b/src/git/libs/add-worktree.ts
@@ -1,23 +1,16 @@
 import { execSync, type ExecSyncOptions } from 'node:child_process';
 
-export interface WorktreeExecutor {
-  execSync: typeof execSync;
-}
-
 export interface AddWorktreeOptions {
   path: string;
   branch: string;
   commitish?: string;
 }
 
-export function addWorktree(
-  options: AddWorktreeOptions,
-  executor: WorktreeExecutor = { execSync }
-): void {
+export function addWorktree(options: AddWorktreeOptions): void {
   const { path, branch, commitish = 'HEAD' } = options;
   const execOptions: ExecSyncOptions = { stdio: 'inherit' };
   
-  executor.execSync(
+  execSync(
     `git worktree add "${path}" -b "${branch}" ${commitish}`,
     execOptions
   );

--- a/src/git/libs/get-current-branch.ts
+++ b/src/git/libs/get-current-branch.ts
@@ -1,9 +1,5 @@
 import { execSync } from 'node:child_process';
 
-export interface GitExecutor {
-  execSync: typeof execSync;
-}
-
-export function getCurrentBranch(executor: GitExecutor = { execSync }): string {
-  return executor.execSync('git branch --show-current', { encoding: 'utf8' }).trim();
+export function getCurrentBranch(): string {
+  return execSync('git branch --show-current', { encoding: 'utf8' }).trim();
 }

--- a/src/git/libs/get-git-root.ts
+++ b/src/git/libs/get-git-root.ts
@@ -1,9 +1,5 @@
 import { execSync } from 'node:child_process';
 
-export interface GitExecutor {
-  execSync: typeof execSync;
-}
-
-export function getGitRoot(executor: GitExecutor = { execSync }): string {
-  return executor.execSync('git rev-parse --show-toplevel', { encoding: 'utf8' }).trim();
+export function getGitRoot(): string {
+  return execSync('git rev-parse --show-toplevel', { encoding: 'utf8' }).trim();
 }

--- a/src/ruins/commands/create.test.ts
+++ b/src/ruins/commands/create.test.ts
@@ -1,17 +1,16 @@
-import { describe, it, mock } from 'node:test';
+import { describe, it, mock, before } from 'node:test';
 import { strictEqual, deepStrictEqual } from 'node:assert';
-import { createRuin } from './create.ts';
 
 describe('createRuin', () => {
-  it('should return error when name is not provided', () => {
-    const result = createRuin('');
-    strictEqual(result.success, false);
-    strictEqual(result.message, 'Error: ruin name required');
-  });
+  let existsSyncMock: any;
+  let mkdirSyncMock: any;
+  let execSyncMock: any;
+  let createRuin: any;
 
-  it('should create ruin directory when it does not exist', () => {
-    const mkdirSyncMock = mock.fn();
-    const execSyncMock = mock.fn((cmd: string) => {
+  before(async () => {
+    existsSyncMock = mock.fn(() => false);
+    mkdirSyncMock = mock.fn();
+    execSyncMock = mock.fn((cmd: string) => {
       if (cmd === 'git rev-parse --show-toplevel') {
         return '/test/repo\n';
       }
@@ -20,14 +19,46 @@ describe('createRuin', () => {
       }
       return '';
     });
-    const existsSyncMock = mock.fn(() => false);
 
-    const result = createRuin('test-ruin', {
-      gitExecutor: { execSync: execSyncMock as any },
-      worktreeExecutor: { execSync: execSyncMock as any },
-      existsSync: existsSyncMock as any,
-      mkdirSync: mkdirSyncMock as any,
+    mock.module('node:fs', {
+      namedExports: {
+        existsSync: existsSyncMock,
+        mkdirSync: mkdirSyncMock,
+      },
     });
+
+    mock.module('node:child_process', {
+      namedExports: {
+        execSync: execSyncMock,
+      },
+    });
+
+    ({ createRuin } = await import('./create.ts'));
+  });
+
+  it('should return error when name is not provided', () => {
+    const result = createRuin('');
+    strictEqual(result.success, false);
+    strictEqual(result.message, 'Error: ruin name required');
+  });
+
+  it('should create ruin directory when it does not exist', () => {
+    existsSyncMock.mock.resetCalls();
+    mkdirSyncMock.mock.resetCalls();
+    execSyncMock.mock.resetCalls();
+    
+    existsSyncMock.mock.mockImplementation(() => false);
+    execSyncMock.mock.mockImplementation((cmd: string) => {
+      if (cmd === 'git rev-parse --show-toplevel') {
+        return '/test/repo\n';
+      }
+      if (cmd.startsWith('git worktree add')) {
+        return '';
+      }
+      return '';
+    });
+
+    const result = createRuin('test-ruin');
 
     strictEqual(result.success, true);
     strictEqual(result.message, 'Created ruin \'test-ruin\' at /test/repo/.git/phantom/ruins/test-ruin');
@@ -45,43 +76,52 @@ describe('createRuin', () => {
   });
 
   it('should return error when ruin already exists', () => {
-    const execSyncMock = mock.fn((cmd: string) => {
+    existsSyncMock.mock.resetCalls();
+    mkdirSyncMock.mock.resetCalls();
+    execSyncMock.mock.resetCalls();
+    
+    existsSyncMock.mock.mockImplementation((path: string) => {
+      if (path === '/test/repo/.git/phantom/ruins') return true;
+      if (path === '/test/repo/.git/phantom/ruins/existing-ruin') return true;
+      return false;
+    });
+    execSyncMock.mock.mockImplementation((cmd: string) => {
       if (cmd === 'git rev-parse --show-toplevel') {
         return '/test/repo\n';
       }
       return '';
     });
-    const existsSyncMock = mock.fn((path: string) => {
-      if (path === '/test/repo/.git/phantom/ruins') return true;
-      if (path === '/test/repo/.git/phantom/ruins/existing-ruin') return true;
-      return false;
-    });
 
-    const result = createRuin('existing-ruin', {
-      gitExecutor: { execSync: execSyncMock as any },
-      existsSync: existsSyncMock as any,
-    });
+    const result = createRuin('existing-ruin');
 
     strictEqual(result.success, false);
     strictEqual(result.message, 'Error: ruin \'existing-ruin\' already exists');
   });
 
   it('should handle git command errors', () => {
-    const execSyncMock = mock.fn(() => {
+    existsSyncMock.mock.resetCalls();
+    mkdirSyncMock.mock.resetCalls();
+    execSyncMock.mock.resetCalls();
+    
+    execSyncMock.mock.mockImplementation(() => {
       throw new Error('Not a git repository');
     });
 
-    const result = createRuin('test-ruin', {
-      gitExecutor: { execSync: execSyncMock as any },
-    });
+    const result = createRuin('test-ruin');
 
     strictEqual(result.success, false);
     strictEqual(result.message, 'Error creating ruin: Not a git repository');
   });
 
   it('should not create ruins directory if it already exists', () => {
-    const mkdirSyncMock = mock.fn();
-    const execSyncMock = mock.fn((cmd: string) => {
+    existsSyncMock.mock.resetCalls();
+    mkdirSyncMock.mock.resetCalls();
+    execSyncMock.mock.resetCalls();
+    
+    existsSyncMock.mock.mockImplementation((path: string) => {
+      return path === '/test/repo/.git/phantom/ruins';
+    });
+    execSyncMock.mock.mockImplementation((cmd: string) => {
       if (cmd === 'git rev-parse --show-toplevel') {
         return '/test/repo\n';
       }
@@ -90,16 +130,8 @@ describe('createRuin', () => {
       }
       return '';
     });
-    const existsSyncMock = mock.fn((path: string) => {
-      return path === '/test/repo/.git/phantom/ruins';
-    });
 
-    const result = createRuin('test-ruin', {
-      gitExecutor: { execSync: execSyncMock as any },
-      worktreeExecutor: { execSync: execSyncMock as any },
-      existsSync: existsSyncMock as any,
-      mkdirSync: mkdirSyncMock as any,
-    });
+    const result = createRuin('test-ruin');
 
     strictEqual(result.success, true);
     strictEqual(mkdirSyncMock.mock.calls.length, 0);

--- a/src/ruins/commands/create.ts
+++ b/src/ruins/commands/create.ts
@@ -1,43 +1,26 @@
 import { exit } from 'node:process';
 import { existsSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
-import { getGitRoot, type GitExecutor } from '../../git/libs/get-git-root.ts';
-import { addWorktree, type WorktreeExecutor } from '../../git/libs/add-worktree.ts';
-
-export interface RuinsCreateOptions {
-  gitExecutor?: GitExecutor;
-  worktreeExecutor?: WorktreeExecutor;
-  existsSync?: typeof existsSync;
-  mkdirSync?: typeof mkdirSync;
-  exit?: typeof exit;
-  console?: Pick<Console, 'log' | 'error'>;
-}
+import { getGitRoot } from '../../git/libs/get-git-root.ts';
+import { addWorktree } from '../../git/libs/add-worktree.ts';
 
 export function createRuin(
-  name: string, 
-  options: RuinsCreateOptions = {}
+  name: string
 ): { success: boolean; message: string; path?: string } {
-  const {
-    gitExecutor,
-    worktreeExecutor,
-    existsSync: exists = existsSync,
-    mkdirSync: mkdir = mkdirSync,
-  } = options;
-
   if (!name) {
     return { success: false, message: 'Error: ruin name required' };
   }
   
   try {
-    const gitRoot = getGitRoot(gitExecutor);
+    const gitRoot = getGitRoot();
     const ruinsPath = join(gitRoot, '.git', 'phantom', 'ruins');
     const worktreePath = join(ruinsPath, name);
     
-    if (!exists(ruinsPath)) {
-      mkdir(ruinsPath, { recursive: true });
+    if (!existsSync(ruinsPath)) {
+      mkdirSync(ruinsPath, { recursive: true });
     }
     
-    if (exists(worktreePath)) {
+    if (existsSync(worktreePath)) {
       return { success: false, message: `Error: ruin '${name}' already exists` };
     }
     
@@ -45,7 +28,7 @@ export function createRuin(
       path: worktreePath,
       branch: `phantom/ruins/${name}`,
       commitish: 'HEAD'
-    }, worktreeExecutor);
+    });
     
     return { 
       success: true, 
@@ -53,7 +36,8 @@ export function createRuin(
       path: worktreePath
     };
   } catch (error) {
-    return { success: false, message: `Error creating ruin: ${error.message}` };
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return { success: false, message: `Error creating ruin: ${errorMessage}` };
   }
 }
 


### PR DESCRIPTION
## Summary
- Refactor tests to utilize Node.js test runner's built-in module mocking capabilities
- Remove dependency injection pattern in favor of direct imports with module-level mocking

## Test plan
- [x] All existing tests pass with new module mocking implementation
- [x] TypeScript compilation succeeds without errors
- [x] Code follows existing project conventions and patterns

🤖 Generated with [Claude Code](https://claude.ai/code)