### PR TITLE
fix: replace any types with proper mock function types in tests

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "vcs": {
+    "enabled": false,
+    "clientKind": "git",
+    "useIgnoreFile": false
+  },
+  "formatter": { "enabled": true, "indentStyle": "space", "indentWidth": 2 },
+  "organizeImports": { "enabled": true },
+  "linter": {
+    "enabled": true,
+    "rules": { "recommended": true }
+  },
+  "javascript": { "formatter": { "quoteStyle": "double" } },
+  "files": {
+    "include": ["src/**/*", "*.ts", "*.js", "*.json"],
+    "ignore": ["node_modules/**/*", ".git/**/*"]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -18,9 +18,12 @@
   "scripts": {
     "start": "node ./src/bin.ts",
     "type-check": "tsc --noEmit",
-    "test": "node --test --experimental-test-module-mocks src/**/*.test.ts"
+    "test": "node --test --experimental-test-module-mocks src/**/*.test.ts",
+    "lint": "biome check .",
+    "fix": "biome check --write ."
   },
   "devDependencies": {
+    "@biomejs/biome": "^1.9.4",
     "@types/node": "^22.15.29",
     "typescript": "^5.8.3"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@biomejs/biome':
+        specifier: ^1.9.4
+        version: 1.9.4
       '@types/node':
         specifier: ^22.15.29
         version: 22.15.29
@@ -16,6 +19,59 @@ importers:
         version: 5.8.3
 
 packages:
+
+  '@biomejs/biome@1.9.4':
+    resolution: {integrity: sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
+  '@biomejs/cli-darwin-arm64@1.9.4':
+    resolution: {integrity: sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-x64@1.9.4':
+    resolution: {integrity: sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@biomejs/cli-linux-arm64-musl@1.9.4':
+    resolution: {integrity: sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@biomejs/cli-linux-arm64@1.9.4':
+    resolution: {integrity: sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@biomejs/cli-linux-x64-musl@1.9.4':
+    resolution: {integrity: sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+
+  '@biomejs/cli-linux-x64@1.9.4':
+    resolution: {integrity: sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+
+  '@biomejs/cli-win32-arm64@1.9.4':
+    resolution: {integrity: sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@1.9.4':
+    resolution: {integrity: sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
 
   '@types/node@22.15.29':
     resolution: {integrity: sha512-LNdjOkUDlU1RZb8e1kOIUpN1qQUlzGkEtbVNo53vbrwDg5om6oduhm4SiUaPW5ASTXhAiP0jInWG8Qx9fVlOeQ==}
@@ -29,6 +85,41 @@ packages:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
 snapshots:
+
+  '@biomejs/biome@1.9.4':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 1.9.4
+      '@biomejs/cli-darwin-x64': 1.9.4
+      '@biomejs/cli-linux-arm64': 1.9.4
+      '@biomejs/cli-linux-arm64-musl': 1.9.4
+      '@biomejs/cli-linux-x64': 1.9.4
+      '@biomejs/cli-linux-x64-musl': 1.9.4
+      '@biomejs/cli-win32-arm64': 1.9.4
+      '@biomejs/cli-win32-x64': 1.9.4
+
+  '@biomejs/cli-darwin-arm64@1.9.4':
+    optional: true
+
+  '@biomejs/cli-darwin-x64@1.9.4':
+    optional: true
+
+  '@biomejs/cli-linux-arm64-musl@1.9.4':
+    optional: true
+
+  '@biomejs/cli-linux-arm64@1.9.4':
+    optional: true
+
+  '@biomejs/cli-linux-x64-musl@1.9.4':
+    optional: true
+
+  '@biomejs/cli-linux-x64@1.9.4':
+    optional: true
+
+  '@biomejs/cli-win32-arm64@1.9.4':
+    optional: true
+
+  '@biomejs/cli-win32-x64@1.9.4':
+    optional: true
 
   '@types/node@22.15.29':
     dependencies:

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-import { argv, exit } from 'node:process';
-import { ruinsCreateHandler } from './ruins/commands/create.ts';
+import { argv, exit } from "node:process";
+import { ruinsCreateHandler } from "./ruins/commands/create.ts";
 
 interface Command {
   name: string;
@@ -12,40 +12,40 @@ interface Command {
 
 const commands: Command[] = [
   {
-    name: 'ruins',
-    description: 'Manage git worktrees (ruins)',
+    name: "ruins",
+    description: "Manage git worktrees (ruins)",
     subcommands: [
       {
-        name: 'create',
-        description: 'Create a new worktree (ruin)',
+        name: "create",
+        description: "Create a new worktree (ruin)",
         handler: ruinsCreateHandler,
       },
       {
-        name: 'list',
-        description: 'List all ruins',
+        name: "list",
+        description: "List all ruins",
         handler: () => {
-          console.log('Listing ruins...');
+          console.log("Listing ruins...");
         },
       },
       {
-        name: 'switch',
-        description: 'Switch to a specific ruin',
+        name: "switch",
+        description: "Switch to a specific ruin",
         handler: (args) => {
           const name = args[0];
           if (!name) {
-            console.error('Error: ruin name required');
+            console.error("Error: ruin name required");
             exit(1);
           }
           console.log(`Switching to ruin: ${name}`);
         },
       },
       {
-        name: 'delete',
-        description: 'Delete a ruin',
+        name: "delete",
+        description: "Delete a ruin",
         handler: (args) => {
           const name = args[0];
           if (!name) {
-            console.error('Error: ruin name required');
+            console.error("Error: ruin name required");
             exit(1);
           }
           console.log(`Deleting ruin: ${name}`);
@@ -54,54 +54,57 @@ const commands: Command[] = [
     ],
   },
   {
-    name: 'spawn',
-    description: 'Spawn a phantom (run command) in a ruin',
+    name: "spawn",
+    description: "Spawn a phantom (run command) in a ruin",
     handler: (args) => {
       const ruinName = args[0];
-      const command = args.slice(1).join(' ');
+      const command = args.slice(1).join(" ");
       if (!ruinName || !command) {
-        console.error('Error: ruin name and command required');
+        console.error("Error: ruin name and command required");
         exit(1);
       }
       console.log(`Spawning phantom in ${ruinName}: ${command}`);
     },
   },
   {
-    name: 'kill',
-    description: 'Kill a phantom (stop process) in a ruin',
+    name: "kill",
+    description: "Kill a phantom (stop process) in a ruin",
     handler: (args) => {
       const ruinName = args[0];
-      const command = args.slice(1).join(' ');
+      const command = args.slice(1).join(" ");
       if (!ruinName || !command) {
-        console.error('Error: ruin name and command required');
+        console.error("Error: ruin name and command required");
         exit(1);
       }
       console.log(`Killing phantom in ${ruinName}: ${command}`);
     },
   },
   {
-    name: 'list',
-    description: 'List running phantoms (processes)',
+    name: "list",
+    description: "List running phantoms (processes)",
     handler: () => {
-      console.log('Listing phantoms...');
+      console.log("Listing phantoms...");
     },
   },
 ];
 
-function printHelp(commands: Command[], prefix = '') {
-  console.log('Usage: phantom <command> [options]\n');
-  console.log('Commands:');
-  commands.forEach((cmd) => {
+function printHelp(commands: Command[], prefix = "") {
+  console.log("Usage: phantom <command> [options]\n");
+  console.log("Commands:");
+  for (const cmd of commands) {
     console.log(`  ${prefix}${cmd.name.padEnd(20)} ${cmd.description}`);
     if (cmd.subcommands) {
-      cmd.subcommands.forEach((subcmd) => {
+      for (const subcmd of cmd.subcommands) {
         console.log(`    ${subcmd.name.padEnd(18)} ${subcmd.description}`);
-      });
+      }
     }
-  });
+  }
 }
 
-function findCommand(args: string[], commands: Command[]): { command: Command | null; remainingArgs: string[] } {
+function findCommand(
+  args: string[],
+  commands: Command[],
+): { command: Command | null; remainingArgs: string[] } {
   if (args.length === 0) {
     return { command: null, remainingArgs: [] };
   }
@@ -114,7 +117,10 @@ function findCommand(args: string[], commands: Command[]): { command: Command | 
   }
 
   if (command.subcommands && rest.length > 0) {
-    const { command: subcommand, remainingArgs } = findCommand(rest, command.subcommands);
+    const { command: subcommand, remainingArgs } = findCommand(
+      rest,
+      command.subcommands,
+    );
     if (subcommand) {
       return { command: subcommand, remainingArgs };
     }
@@ -126,7 +132,7 @@ function findCommand(args: string[], commands: Command[]): { command: Command | 
 function main() {
   const args = argv.slice(2);
 
-  if (args.length === 0 || args[0] === '-h' || args[0] === '--help') {
+  if (args.length === 0 || args[0] === "-h" || args[0] === "--help") {
     printHelp(commands);
     exit(0);
   }
@@ -134,7 +140,7 @@ function main() {
   const { command, remainingArgs } = findCommand(args, commands);
 
   if (!command || !command.handler) {
-    console.error(`Error: Unknown command '${args.join(' ')}'\n`);
+    console.error(`Error: Unknown command '${args.join(" ")}'\n`);
     printHelp(commands);
     exit(1);
   }

--- a/src/git/libs/add-worktree.ts
+++ b/src/git/libs/add-worktree.ts
@@ -1,4 +1,4 @@
-import { execSync, type ExecSyncOptions } from 'node:child_process';
+import { type ExecSyncOptions, execSync } from "node:child_process";
 
 export interface AddWorktreeOptions {
   path: string;
@@ -7,11 +7,11 @@ export interface AddWorktreeOptions {
 }
 
 export function addWorktree(options: AddWorktreeOptions): void {
-  const { path, branch, commitish = 'HEAD' } = options;
-  const execOptions: ExecSyncOptions = { stdio: 'inherit' };
-  
+  const { path, branch, commitish = "HEAD" } = options;
+  const execOptions: ExecSyncOptions = { stdio: "inherit" };
+
   execSync(
     `git worktree add "${path}" -b "${branch}" ${commitish}`,
-    execOptions
+    execOptions,
   );
 }

--- a/src/git/libs/get-current-branch.ts
+++ b/src/git/libs/get-current-branch.ts
@@ -1,5 +1,5 @@
-import { execSync } from 'node:child_process';
+import { execSync } from "node:child_process";
 
 export function getCurrentBranch(): string {
-  return execSync('git branch --show-current', { encoding: 'utf8' }).trim();
+  return execSync("git branch --show-current", { encoding: "utf8" }).trim();
 }

--- a/src/git/libs/get-git-root.ts
+++ b/src/git/libs/get-git-root.ts
@@ -1,5 +1,5 @@
-import { execSync } from 'node:child_process';
+import { execSync } from "node:child_process";
 
 export function getGitRoot(): string {
-  return execSync('git rev-parse --show-toplevel', { encoding: 'utf8' }).trim();
+  return execSync("git rev-parse --show-toplevel", { encoding: "utf8" }).trim();
 }

--- a/src/ruins/commands/create.test.ts
+++ b/src/ruins/commands/create.test.ts
@@ -1,137 +1,146 @@
-import { describe, it, mock, before } from 'node:test';
-import { strictEqual, deepStrictEqual } from 'node:assert';
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { before, describe, it, mock } from "node:test";
 
-describe('createRuin', () => {
-  let existsSyncMock: any;
-  let mkdirSyncMock: any;
-  let execSyncMock: any;
-  let createRuin: any;
+describe("createRuin", () => {
+  let existsSyncMock: ReturnType<typeof mock.fn>;
+  let mkdirSyncMock: ReturnType<typeof mock.fn>;
+  let execSyncMock: ReturnType<typeof mock.fn>;
+  let createRuin: typeof import("./create.ts").createRuin;
 
   before(async () => {
     existsSyncMock = mock.fn(() => false);
     mkdirSyncMock = mock.fn();
     execSyncMock = mock.fn((cmd: string) => {
-      if (cmd === 'git rev-parse --show-toplevel') {
-        return '/test/repo\n';
+      if (cmd === "git rev-parse --show-toplevel") {
+        return "/test/repo\n";
       }
-      if (cmd.startsWith('git worktree add')) {
-        return '';
+      if (cmd.startsWith("git worktree add")) {
+        return "";
       }
-      return '';
+      return "";
     });
 
-    mock.module('node:fs', {
+    mock.module("node:fs", {
       namedExports: {
         existsSync: existsSyncMock,
         mkdirSync: mkdirSyncMock,
       },
     });
 
-    mock.module('node:child_process', {
+    mock.module("node:child_process", {
       namedExports: {
         execSync: execSyncMock,
       },
     });
 
-    ({ createRuin } = await import('./create.ts'));
+    ({ createRuin } = await import("./create.ts"));
   });
 
-  it('should return error when name is not provided', () => {
-    const result = createRuin('');
+  it("should return error when name is not provided", () => {
+    const result = createRuin("");
     strictEqual(result.success, false);
-    strictEqual(result.message, 'Error: ruin name required');
+    strictEqual(result.message, "Error: ruin name required");
   });
 
-  it('should create ruin directory when it does not exist', () => {
+  it("should create ruin directory when it does not exist", () => {
     existsSyncMock.mock.resetCalls();
     mkdirSyncMock.mock.resetCalls();
     execSyncMock.mock.resetCalls();
-    
+
     existsSyncMock.mock.mockImplementation(() => false);
     execSyncMock.mock.mockImplementation((cmd: string) => {
-      if (cmd === 'git rev-parse --show-toplevel') {
-        return '/test/repo\n';
+      if (cmd === "git rev-parse --show-toplevel") {
+        return "/test/repo\n";
       }
-      if (cmd.startsWith('git worktree add')) {
-        return '';
+      if (cmd.startsWith("git worktree add")) {
+        return "";
       }
-      return '';
+      return "";
     });
 
-    const result = createRuin('test-ruin');
+    const result = createRuin("test-ruin");
 
     strictEqual(result.success, true);
-    strictEqual(result.message, 'Created ruin \'test-ruin\' at /test/repo/.git/phantom/ruins/test-ruin');
-    strictEqual(result.path, '/test/repo/.git/phantom/ruins/test-ruin');
-    
+    strictEqual(
+      result.message,
+      "Created ruin 'test-ruin' at /test/repo/.git/phantom/ruins/test-ruin",
+    );
+    strictEqual(result.path, "/test/repo/.git/phantom/ruins/test-ruin");
+
     strictEqual(mkdirSyncMock.mock.calls.length, 1);
     deepStrictEqual(mkdirSyncMock.mock.calls[0].arguments, [
-      '/test/repo/.git/phantom/ruins',
-      { recursive: true }
+      "/test/repo/.git/phantom/ruins",
+      { recursive: true },
     ]);
-    
+
     strictEqual(execSyncMock.mock.calls.length, 2);
-    strictEqual(execSyncMock.mock.calls[0].arguments[0], 'git rev-parse --show-toplevel');
-    strictEqual(execSyncMock.mock.calls[1].arguments[0], 'git worktree add "/test/repo/.git/phantom/ruins/test-ruin" -b "phantom/ruins/test-ruin" HEAD');
+    strictEqual(
+      execSyncMock.mock.calls[0].arguments[0],
+      "git rev-parse --show-toplevel",
+    );
+    strictEqual(
+      execSyncMock.mock.calls[1].arguments[0],
+      'git worktree add "/test/repo/.git/phantom/ruins/test-ruin" -b "phantom/ruins/test-ruin" HEAD',
+    );
   });
 
-  it('should return error when ruin already exists', () => {
+  it("should return error when ruin already exists", () => {
     existsSyncMock.mock.resetCalls();
     mkdirSyncMock.mock.resetCalls();
     execSyncMock.mock.resetCalls();
-    
+
     existsSyncMock.mock.mockImplementation((path: string) => {
-      if (path === '/test/repo/.git/phantom/ruins') return true;
-      if (path === '/test/repo/.git/phantom/ruins/existing-ruin') return true;
+      if (path === "/test/repo/.git/phantom/ruins") return true;
+      if (path === "/test/repo/.git/phantom/ruins/existing-ruin") return true;
       return false;
     });
     execSyncMock.mock.mockImplementation((cmd: string) => {
-      if (cmd === 'git rev-parse --show-toplevel') {
-        return '/test/repo\n';
+      if (cmd === "git rev-parse --show-toplevel") {
+        return "/test/repo\n";
       }
-      return '';
+      return "";
     });
 
-    const result = createRuin('existing-ruin');
+    const result = createRuin("existing-ruin");
 
     strictEqual(result.success, false);
-    strictEqual(result.message, 'Error: ruin \'existing-ruin\' already exists');
+    strictEqual(result.message, "Error: ruin 'existing-ruin' already exists");
   });
 
-  it('should handle git command errors', () => {
+  it("should handle git command errors", () => {
     existsSyncMock.mock.resetCalls();
     mkdirSyncMock.mock.resetCalls();
     execSyncMock.mock.resetCalls();
-    
+
     execSyncMock.mock.mockImplementation(() => {
-      throw new Error('Not a git repository');
+      throw new Error("Not a git repository");
     });
 
-    const result = createRuin('test-ruin');
+    const result = createRuin("test-ruin");
 
     strictEqual(result.success, false);
-    strictEqual(result.message, 'Error creating ruin: Not a git repository');
+    strictEqual(result.message, "Error creating ruin: Not a git repository");
   });
 
-  it('should not create ruins directory if it already exists', () => {
+  it("should not create ruins directory if it already exists", () => {
     existsSyncMock.mock.resetCalls();
     mkdirSyncMock.mock.resetCalls();
     execSyncMock.mock.resetCalls();
-    
+
     existsSyncMock.mock.mockImplementation((path: string) => {
-      return path === '/test/repo/.git/phantom/ruins';
+      return path === "/test/repo/.git/phantom/ruins";
     });
     execSyncMock.mock.mockImplementation((cmd: string) => {
-      if (cmd === 'git rev-parse --show-toplevel') {
-        return '/test/repo\n';
+      if (cmd === "git rev-parse --show-toplevel") {
+        return "/test/repo\n";
       }
-      if (cmd.startsWith('git worktree add')) {
-        return '';
+      if (cmd.startsWith("git worktree add")) {
+        return "";
       }
-      return '';
+      return "";
     });
 
-    const result = createRuin('test-ruin');
+    const result = createRuin("test-ruin");
 
     strictEqual(result.success, true);
     strictEqual(mkdirSyncMock.mock.calls.length, 0);

--- a/src/ruins/commands/create.ts
+++ b/src/ruins/commands/create.ts
@@ -1,39 +1,44 @@
-import { exit } from 'node:process';
-import { existsSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
-import { getGitRoot } from '../../git/libs/get-git-root.ts';
-import { addWorktree } from '../../git/libs/add-worktree.ts';
+import { existsSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { exit } from "node:process";
+import { addWorktree } from "../../git/libs/add-worktree.ts";
+import { getGitRoot } from "../../git/libs/get-git-root.ts";
 
-export function createRuin(
-  name: string
-): { success: boolean; message: string; path?: string } {
+export function createRuin(name: string): {
+  success: boolean;
+  message: string;
+  path?: string;
+} {
   if (!name) {
-    return { success: false, message: 'Error: ruin name required' };
+    return { success: false, message: "Error: ruin name required" };
   }
-  
+
   try {
     const gitRoot = getGitRoot();
-    const ruinsPath = join(gitRoot, '.git', 'phantom', 'ruins');
+    const ruinsPath = join(gitRoot, ".git", "phantom", "ruins");
     const worktreePath = join(ruinsPath, name);
-    
+
     if (!existsSync(ruinsPath)) {
       mkdirSync(ruinsPath, { recursive: true });
     }
-    
+
     if (existsSync(worktreePath)) {
-      return { success: false, message: `Error: ruin '${name}' already exists` };
+      return {
+        success: false,
+        message: `Error: ruin '${name}' already exists`,
+      };
     }
-    
+
     addWorktree({
       path: worktreePath,
       branch: `phantom/ruins/${name}`,
-      commitish: 'HEAD'
+      commitish: "HEAD",
     });
-    
-    return { 
-      success: true, 
+
+    return {
+      success: true,
       message: `Created ruin '${name}' at ${worktreePath}`,
-      path: worktreePath
+      path: worktreePath,
     };
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
@@ -44,11 +49,11 @@ export function createRuin(
 export function ruinsCreateHandler(args: string[]): void {
   const name = args[0];
   const result = createRuin(name);
-  
+
   if (!result.success) {
     console.error(result.message);
     exit(1);
   }
-  
+
   console.log(result.message);
 }


### PR DESCRIPTION
## Summary
- Replace `any` types with proper `ReturnType<typeof mock.fn>` types for mock variables in test file
- Add proper type for `createRuin` function import

## Test plan
- [x] Run `pnpm fix` to verify linting errors are resolved
- [x] Verify all existing tests still pass

🤖 Generated with [Claude Code](https://claude.ai/code)