### PR TITLE
refactor: convert synchronous fs and child_process operations to async

### DIFF
--- a/src/git/libs/add-worktree.ts
+++ b/src/git/libs/add-worktree.ts
@@ -1,4 +1,7 @@
-import { type ExecSyncOptions, execSync } from "node:child_process";
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
+
+const execAsync = promisify(exec);
 
 export interface AddWorktreeOptions {
   path: string;
@@ -6,12 +9,8 @@ export interface AddWorktreeOptions {
   commitish?: string;
 }
 
-export function addWorktree(options: AddWorktreeOptions): void {
+export async function addWorktree(options: AddWorktreeOptions): Promise<void> {
   const { path, branch, commitish = "HEAD" } = options;
-  const execOptions: ExecSyncOptions = { stdio: "inherit" };
 
-  execSync(
-    `git worktree add "${path}" -b "${branch}" ${commitish}`,
-    execOptions,
-  );
+  await execAsync(`git worktree add "${path}" -b "${branch}" ${commitish}`);
 }

--- a/src/git/libs/get-current-branch.ts
+++ b/src/git/libs/get-current-branch.ts
@@ -1,5 +1,9 @@
-import { execSync } from "node:child_process";
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
 
-export function getCurrentBranch(): string {
-  return execSync("git branch --show-current", { encoding: "utf8" }).trim();
+const execAsync = promisify(exec);
+
+export async function getCurrentBranch(): Promise<string> {
+  const { stdout } = await execAsync("git branch --show-current");
+  return stdout.trim();
 }

--- a/src/git/libs/get-git-root.ts
+++ b/src/git/libs/get-git-root.ts
@@ -1,5 +1,9 @@
-import { execSync } from "node:child_process";
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
 
-export function getGitRoot(): string {
-  return execSync("git rev-parse --show-toplevel", { encoding: "utf8" }).trim();
+const execAsync = promisify(exec);
+
+export async function getGitRoot(): Promise<string> {
+  const { stdout } = await execAsync("git rev-parse --show-toplevel");
+  return stdout.trim();
 }

--- a/src/ruins/commands/create.test.ts
+++ b/src/ruins/commands/create.test.ts
@@ -2,63 +2,78 @@ import { deepStrictEqual, strictEqual } from "node:assert";
 import { before, describe, it, mock } from "node:test";
 
 describe("createRuin", () => {
-  let existsSyncMock: ReturnType<typeof mock.fn>;
-  let mkdirSyncMock: ReturnType<typeof mock.fn>;
-  let execSyncMock: ReturnType<typeof mock.fn>;
+  let accessMock: ReturnType<typeof mock.fn>;
+  let mkdirMock: ReturnType<typeof mock.fn>;
+  let execMock: ReturnType<typeof mock.fn>;
   let createRuin: typeof import("./create.ts").createRuin;
 
   before(async () => {
-    existsSyncMock = mock.fn(() => false);
-    mkdirSyncMock = mock.fn();
-    execSyncMock = mock.fn((cmd: string) => {
+    accessMock = mock.fn();
+    mkdirMock = mock.fn();
+    execMock = mock.fn((cmd: string) => {
       if (cmd === "git rev-parse --show-toplevel") {
-        return "/test/repo\n";
+        return Promise.resolve({ stdout: "/test/repo\n", stderr: "" });
       }
       if (cmd.startsWith("git worktree add")) {
-        return "";
+        return Promise.resolve({ stdout: "", stderr: "" });
       }
-      return "";
+      return Promise.resolve({ stdout: "", stderr: "" });
     });
 
-    mock.module("node:fs", {
+    mock.module("node:fs/promises", {
       namedExports: {
-        existsSync: existsSyncMock,
-        mkdirSync: mkdirSyncMock,
+        access: accessMock,
+        mkdir: mkdirMock,
       },
     });
 
     mock.module("node:child_process", {
       namedExports: {
-        execSync: execSyncMock,
+        exec: execMock,
+      },
+    });
+
+    mock.module("node:util", {
+      namedExports: {
+        promisify: (fn: unknown) => fn,
       },
     });
 
     ({ createRuin } = await import("./create.ts"));
   });
 
-  it("should return error when name is not provided", () => {
-    const result = createRuin("");
+  it("should return error when name is not provided", async () => {
+    const result = await createRuin("");
     strictEqual(result.success, false);
     strictEqual(result.message, "Error: ruin name required");
   });
 
-  it("should create ruin directory when it does not exist", () => {
-    existsSyncMock.mock.resetCalls();
-    mkdirSyncMock.mock.resetCalls();
-    execSyncMock.mock.resetCalls();
+  it("should create ruin directory when it does not exist", async () => {
+    accessMock.mock.resetCalls();
+    mkdirMock.mock.resetCalls();
+    execMock.mock.resetCalls();
 
-    existsSyncMock.mock.mockImplementation(() => false);
-    execSyncMock.mock.mockImplementation((cmd: string) => {
-      if (cmd === "git rev-parse --show-toplevel") {
-        return "/test/repo\n";
+    accessMock.mock.mockImplementation((path: string) => {
+      if (path === "/test/repo/.git/phantom/ruins") {
+        return Promise.reject(new Error("ENOENT"));
       }
-      if (cmd.startsWith("git worktree add")) {
-        return "";
+      if (path === "/test/repo/.git/phantom/ruins/test-ruin") {
+        return Promise.reject(new Error("ENOENT"));
       }
-      return "";
+      return Promise.resolve();
     });
 
-    const result = createRuin("test-ruin");
+    execMock.mock.mockImplementation((cmd: string) => {
+      if (cmd === "git rev-parse --show-toplevel") {
+        return Promise.resolve({ stdout: "/test/repo\n", stderr: "" });
+      }
+      if (cmd.startsWith("git worktree add")) {
+        return Promise.resolve({ stdout: "", stderr: "" });
+      }
+      return Promise.resolve({ stdout: "", stderr: "" });
+    });
+
+    const result = await createRuin("test-ruin");
 
     strictEqual(result.success, true);
     strictEqual(
@@ -67,82 +82,92 @@ describe("createRuin", () => {
     );
     strictEqual(result.path, "/test/repo/.git/phantom/ruins/test-ruin");
 
-    strictEqual(mkdirSyncMock.mock.calls.length, 1);
-    deepStrictEqual(mkdirSyncMock.mock.calls[0].arguments, [
+    strictEqual(mkdirMock.mock.calls.length, 1);
+    deepStrictEqual(mkdirMock.mock.calls[0].arguments, [
       "/test/repo/.git/phantom/ruins",
       { recursive: true },
     ]);
 
-    strictEqual(execSyncMock.mock.calls.length, 2);
+    strictEqual(execMock.mock.calls.length, 2);
     strictEqual(
-      execSyncMock.mock.calls[0].arguments[0],
+      execMock.mock.calls[0].arguments[0],
       "git rev-parse --show-toplevel",
     );
     strictEqual(
-      execSyncMock.mock.calls[1].arguments[0],
+      execMock.mock.calls[1].arguments[0],
       'git worktree add "/test/repo/.git/phantom/ruins/test-ruin" -b "phantom/ruins/test-ruin" HEAD',
     );
   });
 
-  it("should return error when ruin already exists", () => {
-    existsSyncMock.mock.resetCalls();
-    mkdirSyncMock.mock.resetCalls();
-    execSyncMock.mock.resetCalls();
+  it("should return error when ruin already exists", async () => {
+    accessMock.mock.resetCalls();
+    mkdirMock.mock.resetCalls();
+    execMock.mock.resetCalls();
 
-    existsSyncMock.mock.mockImplementation((path: string) => {
-      if (path === "/test/repo/.git/phantom/ruins") return true;
-      if (path === "/test/repo/.git/phantom/ruins/existing-ruin") return true;
-      return false;
-    });
-    execSyncMock.mock.mockImplementation((cmd: string) => {
-      if (cmd === "git rev-parse --show-toplevel") {
-        return "/test/repo\n";
+    accessMock.mock.mockImplementation((path: string) => {
+      if (path === "/test/repo/.git/phantom/ruins") {
+        return Promise.resolve();
       }
-      return "";
+      if (path === "/test/repo/.git/phantom/ruins/existing-ruin") {
+        return Promise.resolve();
+      }
+      return Promise.reject(new Error("ENOENT"));
+    });
+    execMock.mock.mockImplementation((cmd: string) => {
+      if (cmd === "git rev-parse --show-toplevel") {
+        return Promise.resolve({ stdout: "/test/repo\n", stderr: "" });
+      }
+      return Promise.resolve({ stdout: "", stderr: "" });
     });
 
-    const result = createRuin("existing-ruin");
+    const result = await createRuin("existing-ruin");
 
     strictEqual(result.success, false);
     strictEqual(result.message, "Error: ruin 'existing-ruin' already exists");
   });
 
-  it("should handle git command errors", () => {
-    existsSyncMock.mock.resetCalls();
-    mkdirSyncMock.mock.resetCalls();
-    execSyncMock.mock.resetCalls();
+  it("should handle git command errors", async () => {
+    accessMock.mock.resetCalls();
+    mkdirMock.mock.resetCalls();
+    execMock.mock.resetCalls();
 
-    execSyncMock.mock.mockImplementation(() => {
-      throw new Error("Not a git repository");
+    execMock.mock.mockImplementation(() => {
+      return Promise.reject(new Error("Not a git repository"));
     });
 
-    const result = createRuin("test-ruin");
+    const result = await createRuin("test-ruin");
 
     strictEqual(result.success, false);
     strictEqual(result.message, "Error creating ruin: Not a git repository");
   });
 
-  it("should not create ruins directory if it already exists", () => {
-    existsSyncMock.mock.resetCalls();
-    mkdirSyncMock.mock.resetCalls();
-    execSyncMock.mock.resetCalls();
+  it("should not create ruins directory if it already exists", async () => {
+    accessMock.mock.resetCalls();
+    mkdirMock.mock.resetCalls();
+    execMock.mock.resetCalls();
 
-    existsSyncMock.mock.mockImplementation((path: string) => {
-      return path === "/test/repo/.git/phantom/ruins";
+    accessMock.mock.mockImplementation((path: string) => {
+      if (path === "/test/repo/.git/phantom/ruins") {
+        return Promise.resolve();
+      }
+      if (path === "/test/repo/.git/phantom/ruins/test-ruin") {
+        return Promise.reject(new Error("ENOENT"));
+      }
+      return Promise.reject(new Error("ENOENT"));
     });
-    execSyncMock.mock.mockImplementation((cmd: string) => {
+    execMock.mock.mockImplementation((cmd: string) => {
       if (cmd === "git rev-parse --show-toplevel") {
-        return "/test/repo\n";
+        return Promise.resolve({ stdout: "/test/repo\n", stderr: "" });
       }
       if (cmd.startsWith("git worktree add")) {
-        return "";
+        return Promise.resolve({ stdout: "", stderr: "" });
       }
-      return "";
+      return Promise.resolve({ stdout: "", stderr: "" });
     });
 
-    const result = createRuin("test-ruin");
+    const result = await createRuin("test-ruin");
 
     strictEqual(result.success, true);
-    strictEqual(mkdirSyncMock.mock.calls.length, 0);
+    strictEqual(mkdirMock.mock.calls.length, 0);
   });
 });


### PR DESCRIPTION
## Summary
- Convert all synchronous filesystem operations to async using `fs/promises`
- Convert all synchronous child_process operations to async using promisified `exec`
- Update function signatures throughout the codebase to use async/await
- Simplify bin.ts to use top-level await instead of main function wrapper
- Update all tests to handle async functions and new patterns

## Changes Made

### Filesystem Operations
- Replace `fs.existsSync` with `fs/promises.access` using try/catch pattern
- Replace `fs.mkdirSync` with `fs/promises.mkdir`

### Child Process Operations  
- Replace `execSync` with promisified `exec` in all git utility functions
- `getGitRoot()`, `getCurrentBranch()`, and `addWorktree()` now return Promises

### Function Signatures
- `createRuin()` → `async createRuin()` returning `Promise<...>`
- `ruinsCreateHandler()` → `async ruinsCreateHandler()` returning `Promise<void>`
- All git utility functions now return Promises

### Testing Updates
- Updated all test mocks to handle async operations
- Changed test implementations to use Promise-based patterns
- All test cases now use `async/await`

## Benefits
- Non-blocking operations improve application performance
- Prevents blocking of the Node.js event loop
- Consistent with modern Node.js best practices
- Better error handling with async/await pattern
- Maintains all existing functionality and error cases

## Test Results
- ✅ All 5 tests pass
- ✅ TypeScript compilation succeeds
- ✅ Linting passes without errors

Closes #4

🤖 Generated with [Claude Code](https://claude.ai/code)