### PR TITLE
feat: implement ruins delete command

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -41,7 +41,7 @@ const commands: Command[] = [
       },
       {
         name: "delete",
-        description: "Delete a ruin",
+        description: "Delete a ruin (use --force for dirty ruins)",
         handler: ruinsDeleteHandler,
       },
     ],


### PR DESCRIPTION
## Summary
Implement the `ruins delete` command to safely remove ruins (git worktrees) and their associated branches.

## Features
- **Validation**: Checks if ruin exists before attempting deletion
- **Safety warnings**: Detects and warns about uncommitted changes
- **Robust removal**: Uses `git worktree remove` with force fallback
- **Branch cleanup**: Removes associated `phantom/ruins/{name}` branch
- **Error handling**: Graceful handling of all failure scenarios

## User Experience
```bash
# Normal deletion
$ phantom ruins delete my-ruin  
Deleted ruin 'my-ruin' and its branch 'phantom/ruins/my-ruin'

# Ruin with uncommitted changes
$ phantom ruins delete dirty-ruin
Warning: Ruin 'dirty-ruin' had uncommitted changes (2 files)
Deleted ruin 'dirty-ruin' and its branch 'phantom/ruins/dirty-ruin'

# Non-existent ruin
$ phantom ruins delete nonexistent
Error: Ruin 'nonexistent' does not exist
```

## Technical Implementation
- **Existence check**: Uses `fs/promises.access()` to verify ruin exists
- **Status detection**: Uses `git status --porcelain` to detect uncommitted changes
- **Worktree removal**: Uses `git worktree remove` with `--force` fallback
- **Branch deletion**: Uses `git branch -D phantom/ruins/{name}`
- **Error resilience**: Handles missing branches and worktree removal failures

## Comprehensive Test Coverage
- ✅ Input validation (empty name)
- ✅ Non-existent ruin handling
- ✅ Clean ruin deletion
- ✅ Dirty ruin deletion with warnings
- ✅ Worktree removal failure with force fallback
- ✅ Missing branch handling
- ✅ Complete worktree removal failure
- ✅ Git status error handling

**Test Results**: All 19 tests passing (createRuin: 5, deleteRuin: 8, listRuins: 6)

## Files Changed
- `src/ruins/commands/delete.ts` - Core implementation
- `src/ruins/commands/delete.test.ts` - Comprehensive tests (8 test cases)
- `src/bin.ts` - Updated to use new handler

## Benefits
- **Complete CRUD**: Now have Create, Read (List), and Delete for ruins
- **Safe cleanup**: Prevents accumulation of stale worktrees
- **User-friendly**: Clear warnings and error messages
- **Robust**: Handles edge cases and failures gracefully

## Impact
This completes the basic ruins lifecycle management. Users can now:
1. `ruins create` - Create new worktrees
2. `ruins list` - View all ruins with status
3. `ruins delete` - Clean up unused ruins

Closes #11

🤖 Generated with [Claude Code](https://claude.ai/code)