### PR TITLE
feat: implement ruins where command to output ruin paths

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -4,6 +4,7 @@ import { argv, exit } from "node:process";
 import { ruinsCreateHandler } from "./ruins/commands/create.ts";
 import { ruinsDeleteHandler } from "./ruins/commands/delete.ts";
 import { ruinsListHandler } from "./ruins/commands/list.ts";
+import { ruinsWhereHandler } from "./ruins/commands/where.ts";
 
 interface Command {
   name: string;
@@ -28,16 +29,9 @@ const commands: Command[] = [
         handler: ruinsListHandler,
       },
       {
-        name: "switch",
-        description: "Switch to a specific ruin",
-        handler: (args) => {
-          const name = args[0];
-          if (!name) {
-            console.error("Error: ruin name required");
-            exit(1);
-          }
-          console.log(`Switching to ruin: ${name}`);
-        },
+        name: "where",
+        description: "Output the path of a specific ruin",
+        handler: ruinsWhereHandler,
       },
       {
         name: "delete",

--- a/src/ruins/commands/where.test.ts
+++ b/src/ruins/commands/where.test.ts
@@ -1,0 +1,149 @@
+import { strictEqual } from "node:assert";
+import { before, describe, it, mock } from "node:test";
+
+describe("whereRuin", () => {
+  let accessMock: ReturnType<typeof mock.fn>;
+  let execMock: ReturnType<typeof mock.fn>;
+  let whereRuin: typeof import("./where.ts").whereRuin;
+
+  before(async () => {
+    accessMock = mock.fn();
+    execMock = mock.fn();
+
+    mock.module("node:fs/promises", {
+      namedExports: {
+        access: accessMock,
+      },
+    });
+
+    mock.module("node:child_process", {
+      namedExports: {
+        exec: execMock,
+      },
+    });
+
+    mock.module("node:util", {
+      namedExports: {
+        promisify: (fn: unknown) => fn,
+      },
+    });
+
+    ({ whereRuin } = await import("./where.ts"));
+  });
+
+  it("should return error when name is not provided", async () => {
+    const result = await whereRuin("");
+    strictEqual(result.success, false);
+    strictEqual(result.message, "Error: ruin name required");
+  });
+
+  it("should return error when ruin does not exist", async () => {
+    accessMock.mock.resetCalls();
+    execMock.mock.resetCalls();
+
+    // Mock getGitRoot
+    execMock.mock.mockImplementation((cmd: string) => {
+      if (cmd === "git rev-parse --show-toplevel") {
+        return Promise.resolve({ stdout: "/test/repo\n", stderr: "" });
+      }
+      return Promise.resolve({ stdout: "", stderr: "" });
+    });
+
+    // Mock ruin doesn't exist
+    accessMock.mock.mockImplementation(() => {
+      return Promise.reject(new Error("ENOENT"));
+    });
+
+    const result = await whereRuin("nonexistent-ruin");
+
+    strictEqual(result.success, false);
+    strictEqual(
+      result.message,
+      "Error: Ruin 'nonexistent-ruin' does not exist",
+    );
+  });
+
+  it("should return path when ruin exists", async () => {
+    accessMock.mock.resetCalls();
+    execMock.mock.resetCalls();
+
+    // Mock getGitRoot
+    execMock.mock.mockImplementation((cmd: string) => {
+      if (cmd === "git rev-parse --show-toplevel") {
+        return Promise.resolve({ stdout: "/test/repo\n", stderr: "" });
+      }
+      return Promise.resolve({ stdout: "", stderr: "" });
+    });
+
+    // Mock ruin exists
+    accessMock.mock.mockImplementation(() => Promise.resolve());
+
+    const result = await whereRuin("existing-ruin");
+
+    strictEqual(result.success, true);
+    strictEqual(result.path, "/test/repo/.git/phantom/ruins/existing-ruin");
+  });
+
+  it("should handle git root detection failures", async () => {
+    accessMock.mock.resetCalls();
+    execMock.mock.resetCalls();
+
+    // Mock getGitRoot failure
+    execMock.mock.mockImplementation(() => {
+      return Promise.reject(new Error("Not a git repository"));
+    });
+
+    const result = await whereRuin("some-ruin");
+
+    strictEqual(result.success, false);
+    strictEqual(result.message, "Error locating ruin: Not a git repository");
+  });
+
+  it("should handle different ruin names correctly", async () => {
+    accessMock.mock.resetCalls();
+    execMock.mock.resetCalls();
+
+    // Mock getGitRoot
+    execMock.mock.mockImplementation((cmd: string) => {
+      if (cmd === "git rev-parse --show-toplevel") {
+        return Promise.resolve({ stdout: "/different/repo\n", stderr: "" });
+      }
+      return Promise.resolve({ stdout: "", stderr: "" });
+    });
+
+    // Mock ruin exists
+    accessMock.mock.mockImplementation(() => Promise.resolve());
+
+    const result = await whereRuin("feature-branch-123");
+
+    strictEqual(result.success, true);
+    strictEqual(
+      result.path,
+      "/different/repo/.git/phantom/ruins/feature-branch-123",
+    );
+  });
+
+  it("should handle special characters in ruin names", async () => {
+    accessMock.mock.resetCalls();
+    execMock.mock.resetCalls();
+
+    // Mock getGitRoot
+    execMock.mock.mockImplementation((cmd: string) => {
+      if (cmd === "git rev-parse --show-toplevel") {
+        return Promise.resolve({ stdout: "/test/repo\n", stderr: "" });
+      }
+      return Promise.resolve({ stdout: "", stderr: "" });
+    });
+
+    // Mock ruin exists
+    accessMock.mock.mockImplementation(() => Promise.resolve());
+
+    const result = await whereRuin("feature-with-dashes_and_underscores");
+
+    strictEqual(result.success, true);
+    strictEqual(
+      result.path,
+      "/test/repo/.git/phantom/ruins/feature-with-dashes_and_underscores",
+    );
+  });
+});

--- a/src/ruins/commands/where.ts
+++ b/src/ruins/commands/where.ts
@@ -1,0 +1,53 @@
+import { access } from "node:fs/promises";
+import { join } from "node:path";
+import { exit } from "node:process";
+import { getGitRoot } from "../../git/libs/get-git-root.ts";
+
+export async function whereRuin(name: string): Promise<{
+  success: boolean;
+  message?: string;
+  path?: string;
+}> {
+  if (!name) {
+    return { success: false, message: "Error: ruin name required" };
+  }
+
+  try {
+    const gitRoot = await getGitRoot();
+    const ruinsPath = join(gitRoot, ".git", "phantom", "ruins");
+    const ruinPath = join(ruinsPath, name);
+
+    // Check if ruin exists
+    try {
+      await access(ruinPath);
+    } catch {
+      return {
+        success: false,
+        message: `Error: Ruin '${name}' does not exist`,
+      };
+    }
+
+    return {
+      success: true,
+      path: ruinPath,
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return {
+      success: false,
+      message: `Error locating ruin: ${errorMessage}`,
+    };
+  }
+}
+
+export async function ruinsWhereHandler(args: string[]): Promise<void> {
+  const name = args[0];
+  const result = await whereRuin(name);
+
+  if (!result.success) {
+    console.error(result.message);
+    exit(1);
+  }
+
+  console.log(result.path);
+}


### PR DESCRIPTION
## Summary
Implement the `ruins where` command to output the absolute path of a specified ruin, enabling easy directory navigation through shell command composition.

## Replaces Previous Approach
- Replaces non-functional `ruins switch` placeholder with practical `ruins where`
- Follows Unix philosophy: simple tool that does one thing well
- Enables composition with other shell commands

## Usage Examples
```bash
# Basic usage - output ruin path
$ phantom ruins where my-feature-ruin
/repo/.git/phantom/ruins/my-feature-ruin

# Navigate to ruin directory
$ cd $(phantom ruins where my-feature-ruin)
$ pwd
/repo/.git/phantom/ruins/my-feature-ruin

# Use in shell scripts
RUIN_PATH=$(phantom ruins where my-feature-ruin)
echo "Working in: $RUIN_PATH"

# Error handling
$ phantom ruins where nonexistent
Error: Ruin 'nonexistent' does not exist
```

## Technical Implementation
- **Path construction**: Uses `getGitRoot()` + `path.join()` for absolute paths
- **Validation**: Checks ruin existence with `fs/promises.access()`
- **Output**: Outputs path to stdout, errors to stderr
- **Exit codes**: 0 for success, 1 for errors (shell scripting friendly)
- **Composability**: Designed for use with command substitution

## Design Benefits
- **Shell agnostic**: Works with bash, zsh, fish, etc.
- **No setup required**: No shell functions or aliases needed
- **Composable**: Works with any command that accepts paths
- **Intuitive**: "where" naturally asks for location
- **Lightweight**: Minimal implementation, maximum utility

## Comprehensive Test Coverage
Added 6 new test cases covering:
- ✅ Input validation (empty name)
- ✅ Non-existent ruin handling
- ✅ Successful path output
- ✅ Git root detection failures
- ✅ Different ruin names
- ✅ Special characters in names

**Test Results**: All 26 tests passing (createRuin: 5, deleteRuin: 9, listRuins: 6, whereRuin: 6)

## Files Changed
- `src/ruins/commands/where.ts` - Core implementation
- `src/ruins/commands/where.test.ts` - Comprehensive tests
- `src/bin.ts` - Replace switch with where command

## User Experience
```bash
# Before (non-functional)
$ phantom ruins switch my-ruin
Switching to ruin: my-ruin
# (nothing actually happens)

# After (functional)
$ phantom ruins where my-ruin
/repo/.git/phantom/ruins/my-ruin
$ cd $(phantom ruins where my-ruin)  # actually changes directory
```

## Benefits
- **Practical navigation**: Actually enables ruin directory navigation
- **Scriptable**: Perfect for automation and shell scripts
- **Discoverable**: Natural command name that suggests its purpose
- **Extensible**: Foundation for more advanced navigation features

## Integration with Existing Commands
Works perfectly with existing ruins workflow:
1. `phantom ruins create my-feature` - Create ruin
2. `phantom ruins list` - See all ruins
3. `phantom ruins where my-feature` - Get ruin path
4. `cd $(phantom ruins where my-feature)` - Navigate to ruin
5. `phantom ruins delete my-feature` - Clean up when done

Closes #13

🤖 Generated with [Claude Code](https://claude.ai/code)