### PR TITLE
Update Node.js requirement to v22+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,12 +37,15 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: ['22', '24']
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v3
       - uses: actions/setup-node@v4
         with:
-          node-version-file: .node-version
+          node-version: ${{ matrix.node-version }}
           cache: "pnpm"
       - name: Install dependencies
         run: pnpm install

--- a/build.ts
+++ b/build.ts
@@ -15,7 +15,7 @@ await build({
   outdir: "dist",
   format: "esm",
   platform: "node",
-  target: "node20",
+  target: "node22",
   sourcemap: true,
   external: ["node:*"],
 });

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "prepublishOnly": "pnpm ready:check && pnpm build"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "files": ["dist/", "README.md", "LICENSE"],
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "garden": "node ./src/bin/garden.ts",
     "build": "node build.ts",
     "type-check": "tsc --noEmit",
-    "test": "node --test --experimental-test-module-mocks src/**/*.test.ts",
+    "test": "node --test --experimental-strip-types --experimental-test-module-mocks src/**/*.test.ts",
     "lint": "biome check .",
     "fix": "biome check --write .",
     "ready": "pnpm fix && pnpm type-check && pnpm test",


### PR DESCRIPTION
## Summary
Updates the project to require Node.js v22 or higher as the minimum supported version.

## Changes
- Update `package.json` engines field to require Node.js v22+
- Update `build.ts` esbuild target from `node20` to `node22`
- Add matrix strategy to CI workflow to test against both Node.js v22 and v24

## Testing
- All tests pass locally
- CI will now test against both Node.js v22 (minimum) and v24 (current)

## Notes
- The `.node-version` file already uses v24.1.0
- The README.md uses dynamic npm badges that will automatically reflect the new requirement
- This ensures we're targeting a modern Node.js version while maintaining compatibility

Closes #27

🤖 Generated with [Claude Code](https://claude.ai/code)