### PR TITLE
docs: add pnpm build command to build from source instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ yarn global add @aku11i/phantom
 git clone https://github.com/aku11i/phantom.git
 cd phantom
 pnpm install
+pnpm build
 npm link
 ```
 


### PR DESCRIPTION
## Summary
- Add missing `pnpm build` command to the "Build from source" section in README.md

## Details
The build step was missing from the installation instructions when building from source. This PR adds the `pnpm build` command after `pnpm install` to ensure the project is properly built before linking.

## Test plan
- [x] Verified the README renders correctly
- [x] Tested the build process follows the updated instructions