### PR TITLE
refactor: rename src/commands to src/phantom/command

### DIFF
--- a/src/bin/phantom.ts
+++ b/src/bin/phantom.ts
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 
 import { argv, exit } from "node:process";
-import { execHandler } from "../commands/exec.ts";
-import { shellHandler } from "../commands/shell.ts";
 import { gardensCreateHandler } from "../gardens/commands/create.ts";
 import { gardensDeleteHandler } from "../gardens/commands/delete.ts";
 import { gardensListHandler } from "../gardens/commands/list.ts";
 import { gardensWhereHandler } from "../gardens/commands/where.ts";
+import { execHandler } from "../phantom/command/exec.ts";
+import { shellHandler } from "../phantom/command/shell.ts";
 
 interface Command {
   name: string;

--- a/src/phantom/command/shell.test.ts
+++ b/src/phantom/command/shell.test.ts
@@ -1,10 +1,11 @@
 import { strictEqual } from "node:assert";
 import { before, describe, it, mock } from "node:test";
 
-describe("execInGarden", () => {
+describe("shellInGarden", () => {
   let spawnMock: ReturnType<typeof mock.fn>;
   let whereGardenMock: ReturnType<typeof mock.fn>;
-  let execInGarden: typeof import("./exec.ts").execInGarden;
+  let shellInGarden: typeof import("./shell.ts").shellInGarden;
+  const originalEnv = process.env;
 
   before(async () => {
     spawnMock = mock.fn();
@@ -16,25 +17,19 @@ describe("execInGarden", () => {
       },
     });
 
-    mock.module("../gardens/commands/where.ts", {
+    mock.module("../../gardens/commands/where.ts", {
       namedExports: {
         whereGarden: whereGardenMock,
       },
     });
 
-    ({ execInGarden } = await import("./exec.ts"));
+    ({ shellInGarden } = await import("./shell.ts"));
   });
 
   it("should return error when garden name is not provided", async () => {
-    const result = await execInGarden("", ["echo", "test"]);
+    const result = await shellInGarden("");
     strictEqual(result.success, false);
     strictEqual(result.message, "Error: garden name required");
-  });
-
-  it("should return error when command is not provided", async () => {
-    const result = await execInGarden("test-garden", []);
-    strictEqual(result.success, false);
-    strictEqual(result.message, "Error: command required");
   });
 
   it("should return error when garden does not exist", async () => {
@@ -48,13 +43,13 @@ describe("execInGarden", () => {
       }),
     );
 
-    const result = await execInGarden("nonexistent", ["echo", "test"]);
+    const result = await shellInGarden("nonexistent");
 
     strictEqual(result.success, false);
     strictEqual(result.message, "Error: Garden 'nonexistent' does not exist");
   });
 
-  it("should execute command successfully with exit code 0", async () => {
+  it("should start shell successfully with exit code 0", async () => {
     whereGardenMock.mock.resetCalls();
     spawnMock.mock.resetCalls();
 
@@ -66,7 +61,7 @@ describe("execInGarden", () => {
       }),
     );
 
-    // Mock successful command execution
+    // Mock successful shell session
     const mockChildProcess = {
       on: mock.fn(
         (
@@ -74,7 +69,7 @@ describe("execInGarden", () => {
           callback: (code: number | null, signal: string | null) => void,
         ) => {
           if (event === "exit") {
-            // Simulate successful command (exit code 0)
+            // Simulate successful shell exit
             setTimeout(() => callback(0, null), 0);
           }
         },
@@ -83,25 +78,75 @@ describe("execInGarden", () => {
 
     spawnMock.mock.mockImplementation(() => mockChildProcess);
 
-    const result = await execInGarden("test-garden", ["echo", "hello"]);
+    const result = await shellInGarden("test-garden");
 
     strictEqual(result.success, true);
     strictEqual(result.exitCode, 0);
 
     // Verify spawn was called with correct arguments
     strictEqual(spawnMock.mock.calls.length, 1);
-    const [cmd, args, options] = spawnMock.mock.calls[0].arguments as [
+    const [shell, args, options] = spawnMock.mock.calls[0].arguments as [
       string,
       string[],
-      { cwd: string; stdio: string },
+      { cwd: string; stdio: string; env: NodeJS.ProcessEnv },
     ];
-    strictEqual(cmd, "echo");
-    strictEqual(args[0], "hello");
+    strictEqual(shell, process.env.SHELL || "/bin/sh");
+    strictEqual(args.length, 0);
     strictEqual(options.cwd, "/test/repo/.git/phantom/gardens/test-garden");
     strictEqual(options.stdio, "inherit");
+    strictEqual(options.env.PHANTOM_GARDEN, "test-garden");
+    strictEqual(
+      options.env.PHANTOM_GARDEN_PATH,
+      "/test/repo/.git/phantom/gardens/test-garden",
+    );
   });
 
-  it("should handle command execution failure with non-zero exit code", async () => {
+  it("should use /bin/sh when SHELL is not set", async () => {
+    whereGardenMock.mock.resetCalls();
+    spawnMock.mock.resetCalls();
+
+    // Temporarily remove SHELL env var
+    const originalShell = process.env.SHELL;
+    // biome-ignore lint/performance/noDelete: Need to actually delete for test
+    delete process.env.SHELL;
+
+    // Mock successful garden location
+    whereGardenMock.mock.mockImplementation(() =>
+      Promise.resolve({
+        success: true,
+        path: "/test/repo/.git/phantom/gardens/test-garden",
+      }),
+    );
+
+    // Mock successful shell session
+    const mockChildProcess = {
+      on: mock.fn(
+        (
+          event: string,
+          callback: (code: number | null, signal: string | null) => void,
+        ) => {
+          if (event === "exit") {
+            setTimeout(() => callback(0, null), 0);
+          }
+        },
+      ),
+    };
+
+    spawnMock.mock.mockImplementation(() => mockChildProcess);
+
+    await shellInGarden("test-garden");
+
+    // Verify /bin/sh was used
+    const [shell] = spawnMock.mock.calls[0].arguments as [string, unknown];
+    strictEqual(shell, "/bin/sh");
+
+    // Restore SHELL env var
+    if (originalShell !== undefined) {
+      process.env.SHELL = originalShell;
+    }
+  });
+
+  it("should handle shell execution failure with non-zero exit code", async () => {
     whereGardenMock.mock.resetCalls();
     spawnMock.mock.resetCalls();
 
@@ -113,7 +158,7 @@ describe("execInGarden", () => {
       }),
     );
 
-    // Mock failed command execution
+    // Mock failed shell session
     const mockChildProcess = {
       on: mock.fn(
         (
@@ -121,7 +166,7 @@ describe("execInGarden", () => {
           callback: (code: number | null, signal: string | null) => void,
         ) => {
           if (event === "exit") {
-            // Simulate failed command (exit code 1)
+            // Simulate failed shell exit
             setTimeout(() => callback(1, null), 0);
           }
         },
@@ -130,13 +175,13 @@ describe("execInGarden", () => {
 
     spawnMock.mock.mockImplementation(() => mockChildProcess);
 
-    const result = await execInGarden("test-garden", ["false"]);
+    const result = await shellInGarden("test-garden");
 
     strictEqual(result.success, false);
     strictEqual(result.exitCode, 1);
   });
 
-  it("should handle command execution error", async () => {
+  it("should handle shell startup error", async () => {
     whereGardenMock.mock.resetCalls();
     spawnMock.mock.resetCalls();
 
@@ -148,21 +193,21 @@ describe("execInGarden", () => {
       }),
     );
 
-    // Mock command execution error
+    // Mock shell startup error
     const mockChildProcess = {
       on: mock.fn((event: string, callback: (error: Error) => void) => {
         if (event === "error") {
-          setTimeout(() => callback(new Error("Command not found")), 0);
+          setTimeout(() => callback(new Error("Shell not found")), 0);
         }
       }),
     };
 
     spawnMock.mock.mockImplementation(() => mockChildProcess);
 
-    const result = await execInGarden("test-garden", ["nonexistent-command"]);
+    const result = await shellInGarden("test-garden");
 
     strictEqual(result.success, false);
-    strictEqual(result.message, "Error executing command: Command not found");
+    strictEqual(result.message, "Error starting shell: Shell not found");
   });
 
   it("should handle signal termination", async () => {
@@ -194,63 +239,10 @@ describe("execInGarden", () => {
 
     spawnMock.mock.mockImplementation(() => mockChildProcess);
 
-    const result = await execInGarden("test-garden", ["long-running-command"]);
+    const result = await shellInGarden("test-garden");
 
     strictEqual(result.success, false);
-    strictEqual(result.message, "Command terminated by signal: SIGTERM");
+    strictEqual(result.message, "Shell terminated by signal: SIGTERM");
     strictEqual(result.exitCode, 143); // 128 + 15 (SIGTERM)
-  });
-
-  it("should parse complex commands with multiple arguments", async () => {
-    whereGardenMock.mock.resetCalls();
-    spawnMock.mock.resetCalls();
-
-    // Mock successful garden location
-    whereGardenMock.mock.mockImplementation(() =>
-      Promise.resolve({
-        success: true,
-        path: "/test/repo/.git/phantom/gardens/test-garden",
-      }),
-    );
-
-    // Mock successful command execution
-    const mockChildProcess = {
-      on: mock.fn(
-        (
-          event: string,
-          callback: (code: number | null, signal: string | null) => void,
-        ) => {
-          if (event === "exit") {
-            setTimeout(() => callback(0, null), 0);
-          }
-        },
-      ),
-    };
-
-    spawnMock.mock.mockImplementation(() => mockChildProcess);
-
-    const result = await execInGarden("test-garden", [
-      "npm",
-      "run",
-      "test",
-      "--",
-      "--verbose",
-    ]);
-
-    strictEqual(result.success, true);
-    strictEqual(result.exitCode, 0);
-
-    // Verify spawn was called with correct arguments
-    const [cmd, args] = spawnMock.mock.calls[0].arguments as [
-      string,
-      string[],
-      object,
-    ];
-    strictEqual(cmd, "npm");
-    strictEqual(args.length, 4);
-    strictEqual(args[0], "run");
-    strictEqual(args[1], "test");
-    strictEqual(args[2], "--");
-    strictEqual(args[3], "--verbose");
   });
 });


### PR DESCRIPTION
## Summary
- Restructures the codebase by moving command files from `src/commands/` to `src/phantom/command/`
- Updates all import paths throughout the codebase to reflect the new directory structure
- Maintains backward compatibility and ensures all tests continue to pass

## Changes
- Created new directory structure `src/phantom/command`
- Moved all files from `src/commands/` to `src/phantom/command/`
- Updated imports in `src/bin/phantom.ts` to point to the new location
- Updated relative imports in moved files to account for the additional directory level
- Updated test file mocks to use the correct import paths

## Test plan
- [x] Run `pnpm ready` - all tests pass, linting clean, type checking passes
- [x] Verify directory structure matches the proposed layout
- [x] Confirm all imports are correctly updated

Closes #31

🤖 Generated with [Claude Code](https://claude.ai/code)