### PR TITLE
feat: add --shell option to phantom garden create command

### DIFF
--- a/src/bin/phantom.ts
+++ b/src/bin/phantom.ts
@@ -22,7 +22,7 @@ const commands: Command[] = [
     subcommands: [
       {
         name: "create",
-        description: "Create a new worktree (garden)",
+        description: "Create a new worktree (garden) [--shell to open shell]",
         handler: gardensCreateHandler,
       },
       {

--- a/src/gardens/commands/create.test.ts
+++ b/src/gardens/commands/create.test.ts
@@ -30,12 +30,19 @@ describe("createGarden", () => {
     mock.module("node:child_process", {
       namedExports: {
         exec: execMock,
+        spawn: mock.fn(),
       },
     });
 
     mock.module("node:util", {
       namedExports: {
         promisify: (fn: unknown) => fn,
+      },
+    });
+
+    mock.module("../../gardens/commands/where.ts", {
+      namedExports: {
+        whereGarden: mock.fn(),
       },
     });
 


### PR DESCRIPTION
## Summary
- Adds a `--shell` option to the `phantom garden create` command that automatically opens an interactive shell in the newly created garden after creation
- Streamlines the workflow by combining garden creation and shell opening into a single command

## Changes
- Import `shellInGarden` function from the shell module in `create.ts`
- Add logic to parse `--shell` flag from command arguments
- After successful garden creation, if `--shell` is present, automatically open a shell in the new garden
- Update command description in `phantom.ts` to indicate the availability of the `--shell` option
- Fix test mocking to include `spawn` export to prevent import errors

## Test plan
- [x] Run `pnpm ready` - all tests pass
- [x] Manually test `phantom garden create test-garden` - creates garden without opening shell
- [x] Manually test `phantom garden create test-garden --shell` - creates garden and opens shell
- [x] Verify shell opens in the correct garden directory
- [x] Verify proper error handling when shell fails to open

## Example Usage
```bash
# Create a garden and immediately start working in it
phantom garden create feature-branch --shell

# Traditional behavior (no shell)
phantom garden create feature-branch
```

Closes #30

🤖 Generated with [Claude Code](https://claude.ai/code)