### PR TITLE
fix: remove phantom/gardens/ prefix from branch names

### DIFF
--- a/src/gardens/commands/create.test.ts
+++ b/src/gardens/commands/create.test.ts
@@ -102,7 +102,7 @@ describe("createGarden", () => {
     );
     strictEqual(
       execMock.mock.calls[1].arguments[0],
-      'git worktree add "/test/repo/.git/phantom/gardens/test-garden" -b "phantom/gardens/test-garden" HEAD',
+      'git worktree add "/test/repo/.git/phantom/gardens/test-garden" -b "test-garden" HEAD',
     );
   });
 

--- a/src/gardens/commands/create.ts
+++ b/src/gardens/commands/create.ts
@@ -37,7 +37,7 @@ export async function createGarden(name: string): Promise<{
 
     await addWorktree({
       path: worktreePath,
-      branch: `phantom/gardens/${name}`,
+      branch: name,
       commitish: "HEAD",
     });
 


### PR DESCRIPTION
## Summary
- Removes the hardcoded "phantom/gardens/" prefix from branch names when creating gardens
- Branch names now match exactly what users specify

## Changes
- Changed `branch: `phantom/gardens/${name}`` to `branch: name` in create.ts
- Updated test expectations to match the new behavior

## Before & After
**Before:**
- Command: `phantom garden create test`
- Created branch: `phantom/gardens/test`

**After:**
- Command: `phantom garden create test`  
- Created branch: `test`

## Test plan
- [x] Run `pnpm ready` - all tests pass
- [x] Manually test creating a garden to verify branch name matches input
- [x] Verify existing functionality still works correctly

Closes #34

🤖 Generated with [Claude Code](https://claude.ai/code)