### PR TITLE
feat!: Remove garden terminology and flatten command structure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # Claude Context for phantom
 
 ## Project Overview
-Phantom is a CLI tool for managing Git worktrees (called "gardens") with enhanced functionality. For detailed project information, features, and usage, see [](./README.md).
+Phantom is a CLI tool for managing Git worktrees (called "phantoms") with enhanced functionality. For detailed project information, features, and usage, see [](./README.md).
 
 ## Development Guidelines
 - All files, issues, and pull requests in this repository must be written in English
@@ -16,16 +16,16 @@ Phantom is a CLI tool for managing Git worktrees (called "gardens") with enhance
 - `src/` - Source code
   - `bin/` - Executable entry points
     - `phantom.ts` - Main CLI entry point
-    - `garden.ts` - Alias command for garden management
+    - `phantom.ts` - Alias command for phantom management
   - `commands/` - Top-level commands
-    - `exec.ts` - Execute commands in a garden
-    - `shell.ts` - Open interactive shell in a garden
-  - `gardens/` - Garden (worktree) management
-    - `commands/` - Garden-specific commands
-      - `create.ts` - Create new gardens
-      - `delete.ts` - Delete gardens
-      - `list.ts` - List all gardens
-      - `where.ts` - Get garden path
+    - `exec.ts` - Execute commands in a phantom
+    - `shell.ts` - Open interactive shell in a phantom
+  - `phantoms/` - Phantom (worktree) management
+    - `commands/` - Phantom-specific commands
+      - `create.ts` - Create new phantoms
+      - `delete.ts` - Delete phantoms
+      - `list.ts` - List all phantoms
+      - `where.ts` - Get phantom path
   - `git/` - Git utility functions
     - `libs/` - Git helper libraries
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-**Git worktreeをファントムとして管理する並行開発のためのパワフルなCLIツール**
+**Git worktreeを使った並行開発のためのパワフルなCLIツール**
 
 [![npm version](https://img.shields.io/npm/v/@aku11i/phantom.svg)](https://www.npmjs.com/package/@aku11i/phantom)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
@@ -43,17 +43,17 @@
 # Phantomをインストール
 npm install -g @aku11i/phantom
 
-# 新しいファントム（worktree）を作成
+# 新しいworktreeを作成
 phantom create feature-awesome
 
-# 新しいスペースにジャンプ
+# worktreeにジャンプ
 phantom shell feature-awesome
 
 # または直接コマンドを実行
 phantom exec feature-awesome npm install
 phantom exec feature-awesome npm test
 
-# すべてのファントムをリスト表示
+# すべてのworktreeをリスト表示
 phantom list
 
 # 完了したらクリーンアップ
@@ -90,48 +90,48 @@ npm link
 
 ### コアコンセプト
 
-**ファントム（Phantoms）** 👻 - このツールによって管理されるGit worktree。各ファントムは特定のブランチや機能のための独立したワークスペースで、競合なしに並行開発が可能です。
+**Worktree** 🌳 - Phantomによって管理されるGit worktree。各worktreeは特定のブランチや機能のための独立したワークスペースで、競合なしに並行開発が可能です。
 
 ### コマンド概要
 
-#### ファントム管理
+#### Worktree管理
 
 ```bash
-# 対応するブランチを持つ新しいファントムを作成
+# 対応するブランチを持つ新しいworktreeを作成
 phantom create <name>
 
-# すべてのファントムとその現在のステータスをリスト表示
+# すべてのworktreeとその現在のステータスをリスト表示
 phantom list
 
-# ファントムへの絶対パスを取得
+# worktreeへの絶対パスを取得
 phantom where <name>
 
-# ファントムとそのブランチを削除
+# worktreeとそのブランチを削除
 phantom delete <name>
 phantom delete <name> --force  # コミットされていない変更がある場合の強制削除
 ```
 
-#### ファントムでの作業
+#### Worktreeでの作業
 
 ```bash
-# ファントムのコンテキストで任意のコマンドを実行
-phantom exec <phantom> <command> [args...]
+# worktreeのコンテキストで任意のコマンドを実行
+phantom exec <name> <command> [args...]
 
 # 例:
 phantom exec feature-auth npm install
 phantom exec feature-auth npm run test
 phantom exec feature-auth git status
 
-# ファントムでインタラクティブシェルセッションを開く
-phantom shell <phantom>
+# worktreeでインタラクティブシェルセッションを開く
+phantom shell <name>
 ```
 
 ### 環境変数
 
-Phantomコンテキスト内で作業する際、以下の環境変数が利用可能です：
+Phantomで管理されたworktree内で作業する際、以下の環境変数が利用可能です：
 
-- `PHANTOM_NAME` - 現在のファントムの名前
-- `PHANTOM_PATH` - ファントムディレクトリへの絶対パス
+- `PHANTOM_NAME` - 現在のworktreeの名前
+- `PHANTOM_PATH` - worktreeディレクトリへの絶対パス
 
 ## 🔄 Phantom vs Git Worktree
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-**Git worktreeを使った並行開発のためのパワフルなCLIツール**
+**Git worktreeをファントムとして管理する並行開発のためのパワフルなCLIツール**
 
 [![npm version](https://img.shields.io/npm/v/@aku11i/phantom.svg)](https://www.npmjs.com/package/@aku11i/phantom)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
@@ -32,7 +32,7 @@
 - 同じコードベースで並行してAIエージェントを実行するのは困難
 
 **Phantomの解決策：**
-- 1つのコマンドでworktreeとブランチの両方を作成: `phantom garden create feature-x`
+- 1つのコマンドでworktreeとブランチの両方を作成: `phantom create feature-x`
 - 即座にコンテキストを切り替え: `phantom shell feature-x`
 - ディレクトリを変更せずにコマンドを実行: `phantom exec feature-x npm test`
 - 複数のAIエージェントとの「並行バイブコーディング」に最適
@@ -43,8 +43,8 @@
 # Phantomをインストール
 npm install -g @aku11i/phantom
 
-# 新しい開発スペース（ガーデン）を作成
-phantom garden create feature-awesome
+# 新しいファントム（worktree）を作成
+phantom create feature-awesome
 
 # 新しいスペースにジャンプ
 phantom shell feature-awesome
@@ -53,11 +53,11 @@ phantom shell feature-awesome
 phantom exec feature-awesome npm install
 phantom exec feature-awesome npm test
 
-# すべてのガーデンをリスト表示
-phantom garden list
+# すべてのファントムをリスト表示
+phantom list
 
 # 完了したらクリーンアップ
-phantom garden delete feature-awesome
+phantom delete feature-awesome
 ```
 
 ## 📦 インストール
@@ -90,60 +90,58 @@ npm link
 
 ### コアコンセプト
 
-**ガーデン（Gardens）** 🌳 - Phantomによって管理されるGit worktree。各ガーデンは特定のブランチや機能のための独立したワークスペースです。
-
-**ファントム（Phantoms）** 👻 - ガーデン内で動作するプロセスやエージェント。
+**ファントム（Phantoms）** 👻 - このツールによって管理されるGit worktree。各ファントムは特定のブランチや機能のための独立したワークスペースで、競合なしに並行開発が可能です。
 
 ### コマンド概要
 
-#### ガーデン管理
+#### ファントム管理
 
 ```bash
-# 対応するブランチを持つ新しいガーデンを作成
-phantom garden create <name>
+# 対応するブランチを持つ新しいファントムを作成
+phantom create <name>
 
-# すべてのガーデンとその現在のステータスをリスト表示
-phantom garden list
+# すべてのファントムとその現在のステータスをリスト表示
+phantom list
 
-# ガーデンへの絶対パスを取得
-phantom garden where <name>
+# ファントムへの絶対パスを取得
+phantom where <name>
 
-# ガーデンとそのブランチを削除
-phantom garden delete <name>
-phantom garden delete <name> --force  # コミットされていない変更がある場合の強制削除
+# ファントムとそのブランチを削除
+phantom delete <name>
+phantom delete <name> --force  # コミットされていない変更がある場合の強制削除
 ```
 
-#### ガーデンでの作業
+#### ファントムでの作業
 
 ```bash
-# ガーデンのコンテキストで任意のコマンドを実行
-phantom exec <garden> <command> [args...]
+# ファントムのコンテキストで任意のコマンドを実行
+phantom exec <phantom> <command> [args...]
 
 # 例:
 phantom exec feature-auth npm install
 phantom exec feature-auth npm run test
 phantom exec feature-auth git status
 
-# ガーデンでインタラクティブシェルセッションを開く
-phantom shell <garden>
+# ファントムでインタラクティブシェルセッションを開く
+phantom shell <phantom>
 ```
 
 ### 環境変数
 
 Phantomコンテキスト内で作業する際、以下の環境変数が利用可能です：
 
-- `PHANTOM_GARDEN` - 現在のガーデンの名前
-- `PHANTOM_GARDEN_PATH` - ガーデンディレクトリへの絶対パス
+- `PHANTOM_NAME` - 現在のファントムの名前
+- `PHANTOM_PATH` - ファントムディレクトリへの絶対パス
 
 ## 🔄 Phantom vs Git Worktree
 
 | 機能 | Git Worktree | Phantom |
 |---------|--------------|---------|
-| worktree + ブランチの作成 | `git worktree add -b feature ../project-feature` | `phantom garden create feature` |
-| worktreeのリスト表示 | `git worktree list` | `phantom garden list` |
+| worktree + ブランチの作成 | `git worktree add -b feature ../project-feature` | `phantom create feature` |
+| worktreeのリスト表示 | `git worktree list` | `phantom list` |
 | worktreeへの移動 | `cd ../project-feature` | `phantom shell feature` |
 | worktreeでコマンド実行 | `cd ../project-feature && npm test` | `phantom exec feature npm test` |
-| worktreeの削除 | `git worktree remove ../project-feature` | `phantom garden delete feature` |
+| worktreeの削除 | `git worktree remove ../project-feature` | `phantom delete feature` |
 
 ## 🛠️ 開発
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-**A powerful CLI tool for managing Git worktrees as phantoms for parallel development**
+**A powerful CLI tool for seamless parallel development with Git worktrees**
 
 [![npm version](https://img.shields.io/npm/v/@aku11i/phantom.svg)](https://www.npmjs.com/package/@aku11i/phantom)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
@@ -43,17 +43,17 @@ Modern development workflows often require working on multiple features simultan
 # Install Phantom
 npm install -g @aku11i/phantom
 
-# Create a new phantom (worktree)
+# Create a new worktree
 phantom create feature-awesome
 
-# Jump into the new space
+# Jump into the worktree
 phantom shell feature-awesome
 
 # Or execute commands directly
 phantom exec feature-awesome npm install
 phantom exec feature-awesome npm test
 
-# List all your phantoms
+# List all your worktrees
 phantom list
 
 # Clean up when done
@@ -90,48 +90,48 @@ npm link
 
 ### Core Concepts
 
-**Phantoms** 👻 - Git worktrees managed by this tool. Each phantom is an isolated workspace for a specific branch or feature, allowing parallel development without conflicts.
+**Worktrees** 🌳 - Git worktrees managed by Phantom. Each worktree is an isolated workspace for a specific branch or feature, allowing parallel development without conflicts.
 
 ### Commands Overview
 
-#### Phantom Management
+#### Worktree Management
 
 ```bash
-# Create a new phantom with a matching branch
+# Create a new worktree with a matching branch
 phantom create <name>
 
-# List all phantoms with their current status
+# List all worktrees with their current status
 phantom list
 
-# Get the absolute path to a phantom
+# Get the absolute path to a worktree
 phantom where <name>
 
-# Delete a phantom and its branch
+# Delete a worktree and its branch
 phantom delete <name>
 phantom delete <name> --force  # Force delete with uncommitted changes
 ```
 
-#### Working with Phantoms
+#### Working with Worktrees
 
 ```bash
-# Execute any command in a phantom's context
-phantom exec <phantom> <command> [args...]
+# Execute any command in a worktree's context
+phantom exec <name> <command> [args...]
 
 # Examples:
 phantom exec feature-auth npm install
 phantom exec feature-auth npm run test
 phantom exec feature-auth git status
 
-# Open an interactive shell session in a phantom
-phantom shell <phantom>
+# Open an interactive shell session in a worktree
+phantom shell <name>
 ```
 
 ### Environment Variables
 
-When working within a Phantom context, these environment variables are available:
+When working within a worktree managed by Phantom, these environment variables are available:
 
-- `PHANTOM_NAME` - Name of the current phantom
-- `PHANTOM_PATH` - Absolute path to the phantom directory
+- `PHANTOM_NAME` - Name of the current worktree
+- `PHANTOM_PATH` - Absolute path to the worktree directory
 
 ## 🔄 Phantom vs Git Worktree
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-**A powerful CLI tool for seamless parallel development with Git worktrees**
+**A powerful CLI tool for managing Git worktrees as phantoms for parallel development**
 
 [![npm version](https://img.shields.io/npm/v/@aku11i/phantom.svg)](https://www.npmjs.com/package/@aku11i/phantom)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
@@ -32,7 +32,7 @@ Modern development workflows often require working on multiple features simultan
 - Running parallel AI agents on the same codebase is challenging
 
 **The Phantom Solution:**
-- One command to create both worktree and branch: `phantom garden create feature-x`
+- One command to create both worktree and branch: `phantom create feature-x`
 - Instant context switching: `phantom shell feature-x`
 - Execute commands without changing directories: `phantom exec feature-x npm test`
 - Perfect for "parallel vibe coding" with multiple AI agents
@@ -43,8 +43,8 @@ Modern development workflows often require working on multiple features simultan
 # Install Phantom
 npm install -g @aku11i/phantom
 
-# Create a new development space (garden)
-phantom garden create feature-awesome
+# Create a new phantom (worktree)
+phantom create feature-awesome
 
 # Jump into the new space
 phantom shell feature-awesome
@@ -53,11 +53,11 @@ phantom shell feature-awesome
 phantom exec feature-awesome npm install
 phantom exec feature-awesome npm test
 
-# List all your gardens
-phantom garden list
+# List all your phantoms
+phantom list
 
 # Clean up when done
-phantom garden delete feature-awesome
+phantom delete feature-awesome
 ```
 
 ## 📦 Installation
@@ -90,60 +90,58 @@ npm link
 
 ### Core Concepts
 
-**Gardens** 🌳 - Git worktrees managed by Phantom. Each garden is an isolated workspace for a specific branch or feature.
-
-**Phantoms** 👻 - Processes or agents that work within gardens.
+**Phantoms** 👻 - Git worktrees managed by this tool. Each phantom is an isolated workspace for a specific branch or feature, allowing parallel development without conflicts.
 
 ### Commands Overview
 
-#### Gardens Management
+#### Phantom Management
 
 ```bash
-# Create a new garden with a matching branch
-phantom garden create <name>
+# Create a new phantom with a matching branch
+phantom create <name>
 
-# List all gardens with their current status
-phantom garden list
+# List all phantoms with their current status
+phantom list
 
-# Get the absolute path to a garden
-phantom garden where <name>
+# Get the absolute path to a phantom
+phantom where <name>
 
-# Delete a garden and its branch
-phantom garden delete <name>
-phantom garden delete <name> --force  # Force delete with uncommitted changes
+# Delete a phantom and its branch
+phantom delete <name>
+phantom delete <name> --force  # Force delete with uncommitted changes
 ```
 
-#### Working with Gardens
+#### Working with Phantoms
 
 ```bash
-# Execute any command in a garden's context
-phantom exec <garden> <command> [args...]
+# Execute any command in a phantom's context
+phantom exec <phantom> <command> [args...]
 
 # Examples:
 phantom exec feature-auth npm install
 phantom exec feature-auth npm run test
 phantom exec feature-auth git status
 
-# Open an interactive shell session in a garden
-phantom shell <garden>
+# Open an interactive shell session in a phantom
+phantom shell <phantom>
 ```
 
 ### Environment Variables
 
 When working within a Phantom context, these environment variables are available:
 
-- `PHANTOM_GARDEN` - Name of the current garden
-- `PHANTOM_GARDEN_PATH` - Absolute path to the garden directory
+- `PHANTOM_NAME` - Name of the current phantom
+- `PHANTOM_PATH` - Absolute path to the phantom directory
 
 ## 🔄 Phantom vs Git Worktree
 
 | Feature | Git Worktree | Phantom |
 |---------|--------------|---------|
-| Create worktree + branch | `git worktree add -b feature ../project-feature` | `phantom garden create feature` |
-| List worktrees | `git worktree list` | `phantom garden list` |
+| Create worktree + branch | `git worktree add -b feature ../project-feature` | `phantom create feature` |
+| List worktrees | `git worktree list` | `phantom list` |
 | Navigate to worktree | `cd ../project-feature` | `phantom shell feature` |
 | Run command in worktree | `cd ../project-feature && npm test` | `phantom exec feature npm test` |
-| Remove worktree | `git worktree remove ../project-feature` | `phantom garden delete feature` |
+| Remove worktree | `git worktree remove ../project-feature` | `phantom delete feature` |
 
 ## 🛠️ Development
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@aku11i/phantom",
   "packageManager": "pnpm@10.8.1",
   "version": "0.2.0",
-  "description": "A powerful CLI tool for managing Git worktrees as phantoms for parallel development",
+  "description": "A powerful CLI tool for managing Git worktrees for parallel development",
   "keywords": [
     "git",
     "worktree",

--- a/package.json
+++ b/package.json
@@ -2,15 +2,15 @@
   "name": "@aku11i/phantom",
   "packageManager": "pnpm@10.8.1",
   "version": "0.2.0",
-  "description": "A CLI tool for managing Git worktrees (gardens) with enhanced functionality",
+  "description": "A powerful CLI tool for managing Git worktrees as phantoms for parallel development",
   "keywords": [
     "git",
     "worktree",
     "cli",
     "phantom",
-    "gardens",
     "workspace",
-    "development"
+    "development",
+    "parallel"
   ],
   "homepage": "https://github.com/aku11i/phantom#readme",
   "bugs": {

--- a/src/bin/phantom.ts
+++ b/src/bin/phantom.ts
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 
 import { argv, exit } from "node:process";
-import { gardensCreateHandler } from "../gardens/commands/create.ts";
-import { gardensDeleteHandler } from "../gardens/commands/delete.ts";
-import { gardensListHandler } from "../gardens/commands/list.ts";
-import { gardensWhereHandler } from "../gardens/commands/where.ts";
 import { execHandler } from "../phantom/command/exec.ts";
 import { shellHandler } from "../phantom/command/shell.ts";
+import { phantomsCreateHandler } from "../phantoms/commands/create.ts";
+import { phantomsDeleteHandler } from "../phantoms/commands/delete.ts";
+import { phantomsListHandler } from "../phantoms/commands/list.ts";
+import { phantomsWhereHandler } from "../phantoms/commands/where.ts";
 
 interface Command {
   name: string;
@@ -17,53 +17,42 @@ interface Command {
 
 const commands: Command[] = [
   {
-    name: "garden",
-    description: "Manage git worktrees (gardens)",
-    subcommands: [
-      {
-        name: "create",
-        description: "Create a new worktree (garden) [--shell to open shell]",
-        handler: gardensCreateHandler,
-      },
-      {
-        name: "list",
-        description: "List all gardens",
-        handler: gardensListHandler,
-      },
-      {
-        name: "where",
-        description: "Output the path of a specific garden",
-        handler: gardensWhereHandler,
-      },
-      {
-        name: "delete",
-        description: "Delete a garden (use --force for dirty gardens)",
-        handler: gardensDeleteHandler,
-      },
-    ],
+    name: "create",
+    description: "Create a new worktree (phantom) [--shell to open shell]",
+    handler: phantomsCreateHandler,
+  },
+  {
+    name: "list",
+    description: "List all phantoms",
+    handler: phantomsListHandler,
+  },
+  {
+    name: "where",
+    description: "Output the path of a specific phantom",
+    handler: phantomsWhereHandler,
+  },
+  {
+    name: "delete",
+    description: "Delete a phantom (use --force for dirty phantoms)",
+    handler: phantomsDeleteHandler,
   },
   {
     name: "exec",
-    description: "Execute a command in a garden directory",
+    description: "Execute a command in a phantom directory",
     handler: execHandler,
   },
   {
     name: "shell",
-    description: "Open interactive shell in a garden directory",
+    description: "Open interactive shell in a phantom directory",
     handler: shellHandler,
   },
 ];
 
-function printHelp(commands: Command[], prefix = "") {
+function printHelp(commands: Command[]) {
   console.log("Usage: phantom <command> [options]\n");
   console.log("Commands:");
   for (const cmd of commands) {
-    console.log(`  ${prefix}${cmd.name.padEnd(20)} ${cmd.description}`);
-    if (cmd.subcommands) {
-      for (const subcmd of cmd.subcommands) {
-        console.log(`    ${subcmd.name.padEnd(18)} ${subcmd.description}`);
-      }
-    }
+    console.log(`  ${cmd.name.padEnd(12)} ${cmd.description}`);
   }
 }
 

--- a/src/bin/phantom.ts
+++ b/src/bin/phantom.ts
@@ -18,32 +18,32 @@ interface Command {
 const commands: Command[] = [
   {
     name: "create",
-    description: "Create a new worktree (phantom) [--shell to open shell]",
+    description: "Create a new worktree [--shell to open shell]",
     handler: phantomsCreateHandler,
   },
   {
     name: "list",
-    description: "List all phantoms",
+    description: "List all worktrees",
     handler: phantomsListHandler,
   },
   {
     name: "where",
-    description: "Output the path of a specific phantom",
+    description: "Output the path of a specific worktree",
     handler: phantomsWhereHandler,
   },
   {
     name: "delete",
-    description: "Delete a phantom (use --force for dirty phantoms)",
+    description: "Delete a worktree (use --force for uncommitted changes)",
     handler: phantomsDeleteHandler,
   },
   {
     name: "exec",
-    description: "Execute a command in a phantom directory",
+    description: "Execute a command in a worktree directory",
     handler: execHandler,
   },
   {
     name: "shell",
-    description: "Open interactive shell in a phantom directory",
+    description: "Open interactive shell in a worktree directory",
     handler: shellHandler,
   },
 ];

--- a/src/phantom/command/exec.test.ts
+++ b/src/phantom/command/exec.test.ts
@@ -1,14 +1,14 @@
 import { strictEqual } from "node:assert";
 import { before, describe, it, mock } from "node:test";
 
-describe("execInGarden", () => {
+describe("execInPhantom", () => {
   let spawnMock: ReturnType<typeof mock.fn>;
-  let whereGardenMock: ReturnType<typeof mock.fn>;
-  let execInGarden: typeof import("./exec.ts").execInGarden;
+  let wherePhantomMock: ReturnType<typeof mock.fn>;
+  let execInPhantom: typeof import("./exec.ts").execInPhantom;
 
   before(async () => {
     spawnMock = mock.fn();
-    whereGardenMock = mock.fn();
+    wherePhantomMock = mock.fn();
 
     mock.module("node:child_process", {
       namedExports: {
@@ -16,53 +16,53 @@ describe("execInGarden", () => {
       },
     });
 
-    mock.module("../../gardens/commands/where.ts", {
+    mock.module("../../phantoms/commands/where.ts", {
       namedExports: {
-        whereGarden: whereGardenMock,
+        wherePhantom: wherePhantomMock,
       },
     });
 
-    ({ execInGarden } = await import("./exec.ts"));
+    ({ execInPhantom } = await import("./exec.ts"));
   });
 
-  it("should return error when garden name is not provided", async () => {
-    const result = await execInGarden("", ["echo", "test"]);
+  it("should return error when phantom name is not provided", async () => {
+    const result = await execInPhantom("", ["echo", "test"]);
     strictEqual(result.success, false);
-    strictEqual(result.message, "Error: garden name required");
+    strictEqual(result.message, "Error: phantom name required");
   });
 
   it("should return error when command is not provided", async () => {
-    const result = await execInGarden("test-garden", []);
+    const result = await execInPhantom("test-phantom", []);
     strictEqual(result.success, false);
     strictEqual(result.message, "Error: command required");
   });
 
-  it("should return error when garden does not exist", async () => {
-    whereGardenMock.mock.resetCalls();
+  it("should return error when phantom does not exist", async () => {
+    wherePhantomMock.mock.resetCalls();
     spawnMock.mock.resetCalls();
 
-    whereGardenMock.mock.mockImplementation(() =>
+    wherePhantomMock.mock.mockImplementation(() =>
       Promise.resolve({
         success: false,
-        message: "Error: Garden 'nonexistent' does not exist",
+        message: "Error: Phantom 'nonexistent' does not exist",
       }),
     );
 
-    const result = await execInGarden("nonexistent", ["echo", "test"]);
+    const result = await execInPhantom("nonexistent", ["echo", "test"]);
 
     strictEqual(result.success, false);
-    strictEqual(result.message, "Error: Garden 'nonexistent' does not exist");
+    strictEqual(result.message, "Error: Phantom 'nonexistent' does not exist");
   });
 
   it("should execute command successfully with exit code 0", async () => {
-    whereGardenMock.mock.resetCalls();
+    wherePhantomMock.mock.resetCalls();
     spawnMock.mock.resetCalls();
 
-    // Mock successful garden location
-    whereGardenMock.mock.mockImplementation(() =>
+    // Mock successful phantom location
+    wherePhantomMock.mock.mockImplementation(() =>
       Promise.resolve({
         success: true,
-        path: "/test/repo/.git/phantom/gardens/test-garden",
+        path: "/test/repo/.git/phantom/phantoms/test-phantom",
       }),
     );
 
@@ -83,7 +83,7 @@ describe("execInGarden", () => {
 
     spawnMock.mock.mockImplementation(() => mockChildProcess);
 
-    const result = await execInGarden("test-garden", ["echo", "hello"]);
+    const result = await execInPhantom("test-phantom", ["echo", "hello"]);
 
     strictEqual(result.success, true);
     strictEqual(result.exitCode, 0);
@@ -97,19 +97,19 @@ describe("execInGarden", () => {
     ];
     strictEqual(cmd, "echo");
     strictEqual(args[0], "hello");
-    strictEqual(options.cwd, "/test/repo/.git/phantom/gardens/test-garden");
+    strictEqual(options.cwd, "/test/repo/.git/phantom/phantoms/test-phantom");
     strictEqual(options.stdio, "inherit");
   });
 
   it("should handle command execution failure with non-zero exit code", async () => {
-    whereGardenMock.mock.resetCalls();
+    wherePhantomMock.mock.resetCalls();
     spawnMock.mock.resetCalls();
 
-    // Mock successful garden location
-    whereGardenMock.mock.mockImplementation(() =>
+    // Mock successful phantom location
+    wherePhantomMock.mock.mockImplementation(() =>
       Promise.resolve({
         success: true,
-        path: "/test/repo/.git/phantom/gardens/test-garden",
+        path: "/test/repo/.git/phantom/phantoms/test-phantom",
       }),
     );
 
@@ -130,21 +130,21 @@ describe("execInGarden", () => {
 
     spawnMock.mock.mockImplementation(() => mockChildProcess);
 
-    const result = await execInGarden("test-garden", ["false"]);
+    const result = await execInPhantom("test-phantom", ["false"]);
 
     strictEqual(result.success, false);
     strictEqual(result.exitCode, 1);
   });
 
   it("should handle command execution error", async () => {
-    whereGardenMock.mock.resetCalls();
+    wherePhantomMock.mock.resetCalls();
     spawnMock.mock.resetCalls();
 
-    // Mock successful garden location
-    whereGardenMock.mock.mockImplementation(() =>
+    // Mock successful phantom location
+    wherePhantomMock.mock.mockImplementation(() =>
       Promise.resolve({
         success: true,
-        path: "/test/repo/.git/phantom/gardens/test-garden",
+        path: "/test/repo/.git/phantom/phantoms/test-phantom",
       }),
     );
 
@@ -159,21 +159,21 @@ describe("execInGarden", () => {
 
     spawnMock.mock.mockImplementation(() => mockChildProcess);
 
-    const result = await execInGarden("test-garden", ["nonexistent-command"]);
+    const result = await execInPhantom("test-phantom", ["nonexistent-command"]);
 
     strictEqual(result.success, false);
     strictEqual(result.message, "Error executing command: Command not found");
   });
 
   it("should handle signal termination", async () => {
-    whereGardenMock.mock.resetCalls();
+    wherePhantomMock.mock.resetCalls();
     spawnMock.mock.resetCalls();
 
-    // Mock successful garden location
-    whereGardenMock.mock.mockImplementation(() =>
+    // Mock successful phantom location
+    wherePhantomMock.mock.mockImplementation(() =>
       Promise.resolve({
         success: true,
-        path: "/test/repo/.git/phantom/gardens/test-garden",
+        path: "/test/repo/.git/phantom/phantoms/test-phantom",
       }),
     );
 
@@ -194,7 +194,9 @@ describe("execInGarden", () => {
 
     spawnMock.mock.mockImplementation(() => mockChildProcess);
 
-    const result = await execInGarden("test-garden", ["long-running-command"]);
+    const result = await execInPhantom("test-phantom", [
+      "long-running-command",
+    ]);
 
     strictEqual(result.success, false);
     strictEqual(result.message, "Command terminated by signal: SIGTERM");
@@ -202,14 +204,14 @@ describe("execInGarden", () => {
   });
 
   it("should parse complex commands with multiple arguments", async () => {
-    whereGardenMock.mock.resetCalls();
+    wherePhantomMock.mock.resetCalls();
     spawnMock.mock.resetCalls();
 
-    // Mock successful garden location
-    whereGardenMock.mock.mockImplementation(() =>
+    // Mock successful phantom location
+    wherePhantomMock.mock.mockImplementation(() =>
       Promise.resolve({
         success: true,
-        path: "/test/repo/.git/phantom/gardens/test-garden",
+        path: "/test/repo/.git/phantom/phantoms/test-phantom",
       }),
     );
 
@@ -229,7 +231,7 @@ describe("execInGarden", () => {
 
     spawnMock.mock.mockImplementation(() => mockChildProcess);
 
-    const result = await execInGarden("test-garden", [
+    const result = await execInPhantom("test-phantom", [
       "npm",
       "run",
       "test",

--- a/src/phantom/command/exec.test.ts
+++ b/src/phantom/command/exec.test.ts
@@ -62,7 +62,7 @@ describe("execInPhantom", () => {
     wherePhantomMock.mock.mockImplementation(() =>
       Promise.resolve({
         success: true,
-        path: "/test/repo/.git/phantom/phantoms/test-phantom",
+        path: "/test/repo/.git/phantom/worktrees/test-phantom",
       }),
     );
 
@@ -97,7 +97,7 @@ describe("execInPhantom", () => {
     ];
     strictEqual(cmd, "echo");
     strictEqual(args[0], "hello");
-    strictEqual(options.cwd, "/test/repo/.git/phantom/phantoms/test-phantom");
+    strictEqual(options.cwd, "/test/repo/.git/phantom/worktrees/test-phantom");
     strictEqual(options.stdio, "inherit");
   });
 
@@ -109,7 +109,7 @@ describe("execInPhantom", () => {
     wherePhantomMock.mock.mockImplementation(() =>
       Promise.resolve({
         success: true,
-        path: "/test/repo/.git/phantom/phantoms/test-phantom",
+        path: "/test/repo/.git/phantom/worktrees/test-phantom",
       }),
     );
 
@@ -144,7 +144,7 @@ describe("execInPhantom", () => {
     wherePhantomMock.mock.mockImplementation(() =>
       Promise.resolve({
         success: true,
-        path: "/test/repo/.git/phantom/phantoms/test-phantom",
+        path: "/test/repo/.git/phantom/worktrees/test-phantom",
       }),
     );
 
@@ -173,7 +173,7 @@ describe("execInPhantom", () => {
     wherePhantomMock.mock.mockImplementation(() =>
       Promise.resolve({
         success: true,
-        path: "/test/repo/.git/phantom/phantoms/test-phantom",
+        path: "/test/repo/.git/phantom/worktrees/test-phantom",
       }),
     );
 
@@ -211,7 +211,7 @@ describe("execInPhantom", () => {
     wherePhantomMock.mock.mockImplementation(() =>
       Promise.resolve({
         success: true,
-        path: "/test/repo/.git/phantom/phantoms/test-phantom",
+        path: "/test/repo/.git/phantom/worktrees/test-phantom",
       }),
     );
 

--- a/src/phantom/command/exec.ts
+++ b/src/phantom/command/exec.ts
@@ -1,35 +1,35 @@
 import { spawn } from "node:child_process";
 import { exit } from "node:process";
-import { whereGarden } from "../../gardens/commands/where.ts";
+import { wherePhantom } from "../../phantoms/commands/where.ts";
 
-export async function execInGarden(
-  gardenName: string,
+export async function execInPhantom(
+  phantomName: string,
   command: string[],
 ): Promise<{
   success: boolean;
   message?: string;
   exitCode?: number;
 }> {
-  if (!gardenName) {
-    return { success: false, message: "Error: garden name required" };
+  if (!phantomName) {
+    return { success: false, message: "Error: phantom name required" };
   }
 
   if (!command || command.length === 0) {
     return { success: false, message: "Error: command required" };
   }
 
-  // Validate garden exists and get its path
-  const gardenResult = await whereGarden(gardenName);
-  if (!gardenResult.success) {
-    return { success: false, message: gardenResult.message };
+  // Validate phantom exists and get its path
+  const phantomResult = await wherePhantom(phantomName);
+  if (!phantomResult.success) {
+    return { success: false, message: phantomResult.message };
   }
 
-  const gardenPath = gardenResult.path as string;
+  const phantomPath = phantomResult.path as string;
   const [cmd, ...args] = command;
 
   return new Promise((resolve) => {
     const childProcess = spawn(cmd, args, {
-      cwd: gardenPath,
+      cwd: phantomPath,
       stdio: "inherit",
     });
 
@@ -60,14 +60,14 @@ export async function execInGarden(
 
 export async function execHandler(args: string[]): Promise<void> {
   if (args.length < 2) {
-    console.error("Usage: phantom exec <garden-name> <command> [args...]");
+    console.error("Usage: phantom exec <phantom-name> <command> [args...]");
     exit(1);
   }
 
-  const gardenName = args[0];
+  const phantomName = args[0];
   const command = args.slice(1);
 
-  const result = await execInGarden(gardenName, command);
+  const result = await execInPhantom(phantomName, command);
 
   if (!result.success) {
     if (result.message) {

--- a/src/phantom/command/shell.test.ts
+++ b/src/phantom/command/shell.test.ts
@@ -1,15 +1,15 @@
 import { strictEqual } from "node:assert";
 import { before, describe, it, mock } from "node:test";
 
-describe("shellInGarden", () => {
+describe("shellInPhantom", () => {
   let spawnMock: ReturnType<typeof mock.fn>;
-  let whereGardenMock: ReturnType<typeof mock.fn>;
-  let shellInGarden: typeof import("./shell.ts").shellInGarden;
+  let wherePhantomMock: ReturnType<typeof mock.fn>;
+  let shellInPhantom: typeof import("./shell.ts").shellInPhantom;
   const originalEnv = process.env;
 
   before(async () => {
     spawnMock = mock.fn();
-    whereGardenMock = mock.fn();
+    wherePhantomMock = mock.fn();
 
     mock.module("node:child_process", {
       namedExports: {
@@ -17,47 +17,47 @@ describe("shellInGarden", () => {
       },
     });
 
-    mock.module("../../gardens/commands/where.ts", {
+    mock.module("../../phantoms/commands/where.ts", {
       namedExports: {
-        whereGarden: whereGardenMock,
+        wherePhantom: wherePhantomMock,
       },
     });
 
-    ({ shellInGarden } = await import("./shell.ts"));
+    ({ shellInPhantom } = await import("./shell.ts"));
   });
 
-  it("should return error when garden name is not provided", async () => {
-    const result = await shellInGarden("");
+  it("should return error when phantom name is not provided", async () => {
+    const result = await shellInPhantom("");
     strictEqual(result.success, false);
-    strictEqual(result.message, "Error: garden name required");
+    strictEqual(result.message, "Error: phantom name required");
   });
 
-  it("should return error when garden does not exist", async () => {
-    whereGardenMock.mock.resetCalls();
+  it("should return error when phantom does not exist", async () => {
+    wherePhantomMock.mock.resetCalls();
     spawnMock.mock.resetCalls();
 
-    whereGardenMock.mock.mockImplementation(() =>
+    wherePhantomMock.mock.mockImplementation(() =>
       Promise.resolve({
         success: false,
-        message: "Error: Garden 'nonexistent' does not exist",
+        message: "Error: Phantom 'nonexistent' does not exist",
       }),
     );
 
-    const result = await shellInGarden("nonexistent");
+    const result = await shellInPhantom("nonexistent");
 
     strictEqual(result.success, false);
-    strictEqual(result.message, "Error: Garden 'nonexistent' does not exist");
+    strictEqual(result.message, "Error: Phantom 'nonexistent' does not exist");
   });
 
   it("should start shell successfully with exit code 0", async () => {
-    whereGardenMock.mock.resetCalls();
+    wherePhantomMock.mock.resetCalls();
     spawnMock.mock.resetCalls();
 
-    // Mock successful garden location
-    whereGardenMock.mock.mockImplementation(() =>
+    // Mock successful phantom location
+    wherePhantomMock.mock.mockImplementation(() =>
       Promise.resolve({
         success: true,
-        path: "/test/repo/.git/phantom/gardens/test-garden",
+        path: "/test/repo/.git/phantom/phantoms/test-phantom",
       }),
     );
 
@@ -78,7 +78,7 @@ describe("shellInGarden", () => {
 
     spawnMock.mock.mockImplementation(() => mockChildProcess);
 
-    const result = await shellInGarden("test-garden");
+    const result = await shellInPhantom("test-phantom");
 
     strictEqual(result.success, true);
     strictEqual(result.exitCode, 0);
@@ -92,17 +92,17 @@ describe("shellInGarden", () => {
     ];
     strictEqual(shell, process.env.SHELL || "/bin/sh");
     strictEqual(args.length, 0);
-    strictEqual(options.cwd, "/test/repo/.git/phantom/gardens/test-garden");
+    strictEqual(options.cwd, "/test/repo/.git/phantom/phantoms/test-phantom");
     strictEqual(options.stdio, "inherit");
-    strictEqual(options.env.PHANTOM_GARDEN, "test-garden");
+    strictEqual(options.env.PHANTOM_NAME, "test-phantom");
     strictEqual(
-      options.env.PHANTOM_GARDEN_PATH,
-      "/test/repo/.git/phantom/gardens/test-garden",
+      options.env.PHANTOM_PATH,
+      "/test/repo/.git/phantom/phantoms/test-phantom",
     );
   });
 
   it("should use /bin/sh when SHELL is not set", async () => {
-    whereGardenMock.mock.resetCalls();
+    wherePhantomMock.mock.resetCalls();
     spawnMock.mock.resetCalls();
 
     // Temporarily remove SHELL env var
@@ -110,11 +110,11 @@ describe("shellInGarden", () => {
     // biome-ignore lint/performance/noDelete: Need to actually delete for test
     delete process.env.SHELL;
 
-    // Mock successful garden location
-    whereGardenMock.mock.mockImplementation(() =>
+    // Mock successful phantom location
+    wherePhantomMock.mock.mockImplementation(() =>
       Promise.resolve({
         success: true,
-        path: "/test/repo/.git/phantom/gardens/test-garden",
+        path: "/test/repo/.git/phantom/phantoms/test-phantom",
       }),
     );
 
@@ -134,7 +134,7 @@ describe("shellInGarden", () => {
 
     spawnMock.mock.mockImplementation(() => mockChildProcess);
 
-    await shellInGarden("test-garden");
+    await shellInPhantom("test-phantom");
 
     // Verify /bin/sh was used
     const [shell] = spawnMock.mock.calls[0].arguments as [string, unknown];
@@ -147,14 +147,14 @@ describe("shellInGarden", () => {
   });
 
   it("should handle shell execution failure with non-zero exit code", async () => {
-    whereGardenMock.mock.resetCalls();
+    wherePhantomMock.mock.resetCalls();
     spawnMock.mock.resetCalls();
 
-    // Mock successful garden location
-    whereGardenMock.mock.mockImplementation(() =>
+    // Mock successful phantom location
+    wherePhantomMock.mock.mockImplementation(() =>
       Promise.resolve({
         success: true,
-        path: "/test/repo/.git/phantom/gardens/test-garden",
+        path: "/test/repo/.git/phantom/phantoms/test-phantom",
       }),
     );
 
@@ -175,21 +175,21 @@ describe("shellInGarden", () => {
 
     spawnMock.mock.mockImplementation(() => mockChildProcess);
 
-    const result = await shellInGarden("test-garden");
+    const result = await shellInPhantom("test-phantom");
 
     strictEqual(result.success, false);
     strictEqual(result.exitCode, 1);
   });
 
   it("should handle shell startup error", async () => {
-    whereGardenMock.mock.resetCalls();
+    wherePhantomMock.mock.resetCalls();
     spawnMock.mock.resetCalls();
 
-    // Mock successful garden location
-    whereGardenMock.mock.mockImplementation(() =>
+    // Mock successful phantom location
+    wherePhantomMock.mock.mockImplementation(() =>
       Promise.resolve({
         success: true,
-        path: "/test/repo/.git/phantom/gardens/test-garden",
+        path: "/test/repo/.git/phantom/phantoms/test-phantom",
       }),
     );
 
@@ -204,21 +204,21 @@ describe("shellInGarden", () => {
 
     spawnMock.mock.mockImplementation(() => mockChildProcess);
 
-    const result = await shellInGarden("test-garden");
+    const result = await shellInPhantom("test-phantom");
 
     strictEqual(result.success, false);
     strictEqual(result.message, "Error starting shell: Shell not found");
   });
 
   it("should handle signal termination", async () => {
-    whereGardenMock.mock.resetCalls();
+    wherePhantomMock.mock.resetCalls();
     spawnMock.mock.resetCalls();
 
-    // Mock successful garden location
-    whereGardenMock.mock.mockImplementation(() =>
+    // Mock successful phantom location
+    wherePhantomMock.mock.mockImplementation(() =>
       Promise.resolve({
         success: true,
-        path: "/test/repo/.git/phantom/gardens/test-garden",
+        path: "/test/repo/.git/phantom/phantoms/test-phantom",
       }),
     );
 
@@ -239,7 +239,7 @@ describe("shellInGarden", () => {
 
     spawnMock.mock.mockImplementation(() => mockChildProcess);
 
-    const result = await shellInGarden("test-garden");
+    const result = await shellInPhantom("test-phantom");
 
     strictEqual(result.success, false);
     strictEqual(result.message, "Shell terminated by signal: SIGTERM");

--- a/src/phantom/command/shell.test.ts
+++ b/src/phantom/command/shell.test.ts
@@ -57,7 +57,7 @@ describe("shellInPhantom", () => {
     wherePhantomMock.mock.mockImplementation(() =>
       Promise.resolve({
         success: true,
-        path: "/test/repo/.git/phantom/phantoms/test-phantom",
+        path: "/test/repo/.git/phantom/worktrees/test-phantom",
       }),
     );
 
@@ -92,12 +92,12 @@ describe("shellInPhantom", () => {
     ];
     strictEqual(shell, process.env.SHELL || "/bin/sh");
     strictEqual(args.length, 0);
-    strictEqual(options.cwd, "/test/repo/.git/phantom/phantoms/test-phantom");
+    strictEqual(options.cwd, "/test/repo/.git/phantom/worktrees/test-phantom");
     strictEqual(options.stdio, "inherit");
     strictEqual(options.env.PHANTOM_NAME, "test-phantom");
     strictEqual(
       options.env.PHANTOM_PATH,
-      "/test/repo/.git/phantom/phantoms/test-phantom",
+      "/test/repo/.git/phantom/worktrees/test-phantom",
     );
   });
 
@@ -114,7 +114,7 @@ describe("shellInPhantom", () => {
     wherePhantomMock.mock.mockImplementation(() =>
       Promise.resolve({
         success: true,
-        path: "/test/repo/.git/phantom/phantoms/test-phantom",
+        path: "/test/repo/.git/phantom/worktrees/test-phantom",
       }),
     );
 
@@ -154,7 +154,7 @@ describe("shellInPhantom", () => {
     wherePhantomMock.mock.mockImplementation(() =>
       Promise.resolve({
         success: true,
-        path: "/test/repo/.git/phantom/phantoms/test-phantom",
+        path: "/test/repo/.git/phantom/worktrees/test-phantom",
       }),
     );
 
@@ -189,7 +189,7 @@ describe("shellInPhantom", () => {
     wherePhantomMock.mock.mockImplementation(() =>
       Promise.resolve({
         success: true,
-        path: "/test/repo/.git/phantom/phantoms/test-phantom",
+        path: "/test/repo/.git/phantom/worktrees/test-phantom",
       }),
     );
 
@@ -218,7 +218,7 @@ describe("shellInPhantom", () => {
     wherePhantomMock.mock.mockImplementation(() =>
       Promise.resolve({
         success: true,
-        path: "/test/repo/.git/phantom/phantoms/test-phantom",
+        path: "/test/repo/.git/phantom/worktrees/test-phantom",
       }),
     );
 

--- a/src/phantom/command/shell.ts
+++ b/src/phantom/command/shell.ts
@@ -1,35 +1,35 @@
 import { spawn } from "node:child_process";
 import { exit } from "node:process";
-import { whereGarden } from "../../gardens/commands/where.ts";
+import { wherePhantom } from "../../phantoms/commands/where.ts";
 
-export async function shellInGarden(gardenName: string): Promise<{
+export async function shellInPhantom(phantomName: string): Promise<{
   success: boolean;
   message?: string;
   exitCode?: number;
 }> {
-  if (!gardenName) {
-    return { success: false, message: "Error: garden name required" };
+  if (!phantomName) {
+    return { success: false, message: "Error: phantom name required" };
   }
 
-  // Validate garden exists and get its path
-  const gardenResult = await whereGarden(gardenName);
-  if (!gardenResult.success) {
-    return { success: false, message: gardenResult.message };
+  // Validate phantom exists and get its path
+  const phantomResult = await wherePhantom(phantomName);
+  if (!phantomResult.success) {
+    return { success: false, message: phantomResult.message };
   }
 
-  const gardenPath = gardenResult.path as string;
+  const phantomPath = phantomResult.path as string;
   // Use user's preferred shell or fallback to /bin/sh
   const shell = process.env.SHELL || "/bin/sh";
 
   return new Promise((resolve) => {
     const childProcess = spawn(shell, [], {
-      cwd: gardenPath,
+      cwd: phantomPath,
       stdio: "inherit",
       env: {
         ...process.env,
-        // Add environment variable to indicate we're in a phantom garden
-        PHANTOM_GARDEN: gardenName,
-        PHANTOM_GARDEN_PATH: gardenPath,
+        // Add environment variable to indicate we're in a phantom
+        PHANTOM_NAME: phantomName,
+        PHANTOM_PATH: phantomPath,
       },
     });
 
@@ -60,24 +60,24 @@ export async function shellInGarden(gardenName: string): Promise<{
 
 export async function shellHandler(args: string[]): Promise<void> {
   if (args.length < 1) {
-    console.error("Usage: phantom shell <garden-name>");
+    console.error("Usage: phantom shell <phantom-name>");
     exit(1);
   }
 
-  const gardenName = args[0];
+  const phantomName = args[0];
 
-  // Get garden path for display
-  const gardenResult = await whereGarden(gardenName);
-  if (!gardenResult.success) {
-    console.error(gardenResult.message);
+  // Get phantom path for display
+  const phantomResult = await wherePhantom(phantomName);
+  if (!phantomResult.success) {
+    console.error(phantomResult.message);
     exit(1);
   }
 
   // Display entering message
-  console.log(`Entering garden '${gardenName}' at ${gardenResult.path}`);
+  console.log(`Entering phantom '${phantomName}' at ${phantomResult.path}`);
   console.log("Type 'exit' to return to your original directory\n");
 
-  const result = await shellInGarden(gardenName);
+  const result = await shellInPhantom(phantomName);
 
   if (!result.success) {
     if (result.message) {

--- a/src/phantoms/commands/create.test.ts
+++ b/src/phantoms/commands/create.test.ts
@@ -61,10 +61,10 @@ describe("createPhantom", () => {
     execMock.mock.resetCalls();
 
     accessMock.mock.mockImplementation((path: string) => {
-      if (path === "/test/repo/.git/phantom/phantoms") {
+      if (path === "/test/repo/.git/phantom/worktrees") {
         return Promise.reject(new Error("ENOENT"));
       }
-      if (path === "/test/repo/.git/phantom/phantoms/test-phantom") {
+      if (path === "/test/repo/.git/phantom/worktrees/test-phantom") {
         return Promise.reject(new Error("ENOENT"));
       }
       return Promise.resolve();
@@ -85,13 +85,13 @@ describe("createPhantom", () => {
     strictEqual(result.success, true);
     strictEqual(
       result.message,
-      "Created phantom 'test-phantom' at /test/repo/.git/phantom/phantoms/test-phantom",
+      "Created phantom 'test-phantom' at /test/repo/.git/phantom/worktrees/test-phantom",
     );
-    strictEqual(result.path, "/test/repo/.git/phantom/phantoms/test-phantom");
+    strictEqual(result.path, "/test/repo/.git/phantom/worktrees/test-phantom");
 
     strictEqual(mkdirMock.mock.calls.length, 1);
     deepStrictEqual(mkdirMock.mock.calls[0].arguments, [
-      "/test/repo/.git/phantom/phantoms",
+      "/test/repo/.git/phantom/worktrees",
       { recursive: true },
     ]);
 
@@ -102,7 +102,7 @@ describe("createPhantom", () => {
     );
     strictEqual(
       execMock.mock.calls[1].arguments[0],
-      'git worktree add "/test/repo/.git/phantom/phantoms/test-phantom" -b "test-phantom" HEAD',
+      'git worktree add "/test/repo/.git/phantom/worktrees/test-phantom" -b "test-phantom" HEAD',
     );
   });
 
@@ -112,10 +112,10 @@ describe("createPhantom", () => {
     execMock.mock.resetCalls();
 
     accessMock.mock.mockImplementation((path: string) => {
-      if (path === "/test/repo/.git/phantom/phantoms") {
+      if (path === "/test/repo/.git/phantom/worktrees") {
         return Promise.resolve();
       }
-      if (path === "/test/repo/.git/phantom/phantoms/existing-phantom") {
+      if (path === "/test/repo/.git/phantom/worktrees/existing-phantom") {
         return Promise.resolve();
       }
       return Promise.reject(new Error("ENOENT"));
@@ -157,10 +157,10 @@ describe("createPhantom", () => {
     execMock.mock.resetCalls();
 
     accessMock.mock.mockImplementation((path: string) => {
-      if (path === "/test/repo/.git/phantom/phantoms") {
+      if (path === "/test/repo/.git/phantom/worktrees") {
         return Promise.resolve();
       }
-      if (path === "/test/repo/.git/phantom/phantoms/test-phantom") {
+      if (path === "/test/repo/.git/phantom/worktrees/test-phantom") {
         return Promise.reject(new Error("ENOENT"));
       }
       return Promise.reject(new Error("ENOENT"));

--- a/src/phantoms/commands/create.test.ts
+++ b/src/phantoms/commands/create.test.ts
@@ -1,11 +1,11 @@
 import { deepStrictEqual, strictEqual } from "node:assert";
 import { before, describe, it, mock } from "node:test";
 
-describe("createGarden", () => {
+describe("createPhantom", () => {
   let accessMock: ReturnType<typeof mock.fn>;
   let mkdirMock: ReturnType<typeof mock.fn>;
   let execMock: ReturnType<typeof mock.fn>;
-  let createGarden: typeof import("./create.ts").createGarden;
+  let createPhantom: typeof import("./create.ts").createPhantom;
 
   before(async () => {
     accessMock = mock.fn();
@@ -40,31 +40,31 @@ describe("createGarden", () => {
       },
     });
 
-    mock.module("../../gardens/commands/where.ts", {
+    mock.module("../../phantoms/commands/where.ts", {
       namedExports: {
-        whereGarden: mock.fn(),
+        wherePhantom: mock.fn(),
       },
     });
 
-    ({ createGarden } = await import("./create.ts"));
+    ({ createPhantom } = await import("./create.ts"));
   });
 
   it("should return error when name is not provided", async () => {
-    const result = await createGarden("");
+    const result = await createPhantom("");
     strictEqual(result.success, false);
-    strictEqual(result.message, "Error: garden name required");
+    strictEqual(result.message, "Error: phantom name required");
   });
 
-  it("should create garden directory when it does not exist", async () => {
+  it("should create phantom directory when it does not exist", async () => {
     accessMock.mock.resetCalls();
     mkdirMock.mock.resetCalls();
     execMock.mock.resetCalls();
 
     accessMock.mock.mockImplementation((path: string) => {
-      if (path === "/test/repo/.git/phantom/gardens") {
+      if (path === "/test/repo/.git/phantom/phantoms") {
         return Promise.reject(new Error("ENOENT"));
       }
-      if (path === "/test/repo/.git/phantom/gardens/test-garden") {
+      if (path === "/test/repo/.git/phantom/phantoms/test-phantom") {
         return Promise.reject(new Error("ENOENT"));
       }
       return Promise.resolve();
@@ -80,18 +80,18 @@ describe("createGarden", () => {
       return Promise.resolve({ stdout: "", stderr: "" });
     });
 
-    const result = await createGarden("test-garden");
+    const result = await createPhantom("test-phantom");
 
     strictEqual(result.success, true);
     strictEqual(
       result.message,
-      "Created garden 'test-garden' at /test/repo/.git/phantom/gardens/test-garden",
+      "Created phantom 'test-phantom' at /test/repo/.git/phantom/phantoms/test-phantom",
     );
-    strictEqual(result.path, "/test/repo/.git/phantom/gardens/test-garden");
+    strictEqual(result.path, "/test/repo/.git/phantom/phantoms/test-phantom");
 
     strictEqual(mkdirMock.mock.calls.length, 1);
     deepStrictEqual(mkdirMock.mock.calls[0].arguments, [
-      "/test/repo/.git/phantom/gardens",
+      "/test/repo/.git/phantom/phantoms",
       { recursive: true },
     ]);
 
@@ -102,20 +102,20 @@ describe("createGarden", () => {
     );
     strictEqual(
       execMock.mock.calls[1].arguments[0],
-      'git worktree add "/test/repo/.git/phantom/gardens/test-garden" -b "test-garden" HEAD',
+      'git worktree add "/test/repo/.git/phantom/phantoms/test-phantom" -b "test-phantom" HEAD',
     );
   });
 
-  it("should return error when garden already exists", async () => {
+  it("should return error when phantom already exists", async () => {
     accessMock.mock.resetCalls();
     mkdirMock.mock.resetCalls();
     execMock.mock.resetCalls();
 
     accessMock.mock.mockImplementation((path: string) => {
-      if (path === "/test/repo/.git/phantom/gardens") {
+      if (path === "/test/repo/.git/phantom/phantoms") {
         return Promise.resolve();
       }
-      if (path === "/test/repo/.git/phantom/gardens/existing-garden") {
+      if (path === "/test/repo/.git/phantom/phantoms/existing-phantom") {
         return Promise.resolve();
       }
       return Promise.reject(new Error("ENOENT"));
@@ -127,12 +127,12 @@ describe("createGarden", () => {
       return Promise.resolve({ stdout: "", stderr: "" });
     });
 
-    const result = await createGarden("existing-garden");
+    const result = await createPhantom("existing-phantom");
 
     strictEqual(result.success, false);
     strictEqual(
       result.message,
-      "Error: garden 'existing-garden' already exists",
+      "Error: phantom 'existing-phantom' already exists",
     );
   });
 
@@ -145,22 +145,22 @@ describe("createGarden", () => {
       return Promise.reject(new Error("Not a git repository"));
     });
 
-    const result = await createGarden("test-garden");
+    const result = await createPhantom("test-phantom");
 
     strictEqual(result.success, false);
-    strictEqual(result.message, "Error creating garden: Not a git repository");
+    strictEqual(result.message, "Error creating phantom: Not a git repository");
   });
 
-  it("should not create gardens directory if it already exists", async () => {
+  it("should not create phantoms directory if it already exists", async () => {
     accessMock.mock.resetCalls();
     mkdirMock.mock.resetCalls();
     execMock.mock.resetCalls();
 
     accessMock.mock.mockImplementation((path: string) => {
-      if (path === "/test/repo/.git/phantom/gardens") {
+      if (path === "/test/repo/.git/phantom/phantoms") {
         return Promise.resolve();
       }
-      if (path === "/test/repo/.git/phantom/gardens/test-garden") {
+      if (path === "/test/repo/.git/phantom/phantoms/test-phantom") {
         return Promise.reject(new Error("ENOENT"));
       }
       return Promise.reject(new Error("ENOENT"));
@@ -175,7 +175,7 @@ describe("createGarden", () => {
       return Promise.resolve({ stdout: "", stderr: "" });
     });
 
-    const result = await createGarden("test-garden");
+    const result = await createPhantom("test-phantom");
 
     strictEqual(result.success, true);
     strictEqual(mkdirMock.mock.calls.length, 0);

--- a/src/phantoms/commands/create.ts
+++ b/src/phantoms/commands/create.ts
@@ -16,7 +16,7 @@ export async function createPhantom(name: string): Promise<{
 
   try {
     const gitRoot = await getGitRoot();
-    const phantomsPath = join(gitRoot, ".git", "phantom", "phantoms");
+    const phantomsPath = join(gitRoot, ".git", "phantom", "worktrees");
     const worktreePath = join(phantomsPath, name);
 
     try {

--- a/src/phantoms/commands/create.ts
+++ b/src/phantoms/commands/create.ts
@@ -3,33 +3,33 @@ import { join } from "node:path";
 import { exit } from "node:process";
 import { addWorktree } from "../../git/libs/add-worktree.ts";
 import { getGitRoot } from "../../git/libs/get-git-root.ts";
-import { shellInGarden } from "../../phantom/command/shell.ts";
+import { shellInPhantom } from "../../phantom/command/shell.ts";
 
-export async function createGarden(name: string): Promise<{
+export async function createPhantom(name: string): Promise<{
   success: boolean;
   message: string;
   path?: string;
 }> {
   if (!name) {
-    return { success: false, message: "Error: garden name required" };
+    return { success: false, message: "Error: phantom name required" };
   }
 
   try {
     const gitRoot = await getGitRoot();
-    const gardensPath = join(gitRoot, ".git", "phantom", "gardens");
-    const worktreePath = join(gardensPath, name);
+    const phantomsPath = join(gitRoot, ".git", "phantom", "phantoms");
+    const worktreePath = join(phantomsPath, name);
 
     try {
-      await access(gardensPath);
+      await access(phantomsPath);
     } catch {
-      await mkdir(gardensPath, { recursive: true });
+      await mkdir(phantomsPath, { recursive: true });
     }
 
     try {
       await access(worktreePath);
       return {
         success: false,
-        message: `Error: garden '${name}' already exists`,
+        message: `Error: phantom '${name}' already exists`,
       };
     } catch {
       // Path doesn't exist, which is what we want
@@ -43,23 +43,23 @@ export async function createGarden(name: string): Promise<{
 
     return {
       success: true,
-      message: `Created garden '${name}' at ${worktreePath}`,
+      message: `Created phantom '${name}' at ${worktreePath}`,
       path: worktreePath,
     };
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     return {
       success: false,
-      message: `Error creating garden: ${errorMessage}`,
+      message: `Error creating phantom: ${errorMessage}`,
     };
   }
 }
 
-export async function gardensCreateHandler(args: string[]): Promise<void> {
+export async function phantomsCreateHandler(args: string[]): Promise<void> {
   const name = args[0];
   const openShell = args.includes("--shell");
 
-  const result = await createGarden(name);
+  const result = await createPhantom(name);
 
   if (!result.success) {
     console.error(result.message);
@@ -69,10 +69,10 @@ export async function gardensCreateHandler(args: string[]): Promise<void> {
   console.log(result.message);
 
   if (openShell && result.path) {
-    console.log(`\nEntering garden '${name}' at ${result.path}`);
+    console.log(`\nEntering phantom '${name}' at ${result.path}`);
     console.log("Type 'exit' to return to your original directory\n");
 
-    const shellResult = await shellInGarden(name);
+    const shellResult = await shellInPhantom(name);
 
     if (!shellResult.success) {
       if (shellResult.message) {

--- a/src/phantoms/commands/delete.test.ts
+++ b/src/phantoms/commands/delete.test.ts
@@ -1,10 +1,10 @@
 import { strictEqual } from "node:assert";
 import { before, describe, it, mock } from "node:test";
 
-describe("deleteGarden", () => {
+describe("deletePhantom", () => {
   let accessMock: ReturnType<typeof mock.fn>;
   let execMock: ReturnType<typeof mock.fn>;
-  let deleteGarden: typeof import("./delete.ts").deleteGarden;
+  let deletePhantom: typeof import("./delete.ts").deletePhantom;
 
   before(async () => {
     accessMock = mock.fn();
@@ -28,16 +28,16 @@ describe("deleteGarden", () => {
       },
     });
 
-    ({ deleteGarden } = await import("./delete.ts"));
+    ({ deletePhantom } = await import("./delete.ts"));
   });
 
   it("should return error when name is not provided", async () => {
-    const result = await deleteGarden("");
+    const result = await deletePhantom("");
     strictEqual(result.success, false);
-    strictEqual(result.message, "Error: garden name required");
+    strictEqual(result.message, "Error: phantom name required");
   });
 
-  it("should return error when garden does not exist", async () => {
+  it("should return error when phantom does not exist", async () => {
     accessMock.mock.resetCalls();
     execMock.mock.resetCalls();
 
@@ -49,21 +49,21 @@ describe("deleteGarden", () => {
       return Promise.resolve({ stdout: "", stderr: "" });
     });
 
-    // Mock garden doesn't exist
+    // Mock phantom doesn't exist
     accessMock.mock.mockImplementation(() => {
       return Promise.reject(new Error("ENOENT"));
     });
 
-    const result = await deleteGarden("nonexistent-garden");
+    const result = await deletePhantom("nonexistent-phantom");
 
     strictEqual(result.success, false);
     strictEqual(
       result.message,
-      "Error: Garden 'nonexistent-garden' does not exist",
+      "Error: Phantom 'nonexistent-phantom' does not exist",
     );
   });
 
-  it("should delete clean garden successfully", async () => {
+  it("should delete clean phantom successfully", async () => {
     accessMock.mock.resetCalls();
     execMock.mock.resetCalls();
 
@@ -86,20 +86,20 @@ describe("deleteGarden", () => {
       },
     );
 
-    // Mock garden exists
+    // Mock phantom exists
     accessMock.mock.mockImplementation(() => Promise.resolve());
 
-    const result = await deleteGarden("clean-garden");
+    const result = await deletePhantom("clean-phantom");
 
     strictEqual(result.success, true);
     strictEqual(
       result.message,
-      "Deleted garden 'clean-garden' and its branch 'phantom/gardens/clean-garden'",
+      "Deleted phantom 'clean-phantom' and its branch 'phantom/phantoms/clean-phantom'",
     );
     strictEqual(result.hasUncommittedChanges, false);
   });
 
-  it("should refuse to delete dirty garden without --force", async () => {
+  it("should refuse to delete dirty phantom without --force", async () => {
     accessMock.mock.resetCalls();
     execMock.mock.resetCalls();
 
@@ -119,21 +119,21 @@ describe("deleteGarden", () => {
       },
     );
 
-    // Mock garden exists
+    // Mock phantom exists
     accessMock.mock.mockImplementation(() => Promise.resolve());
 
-    const result = await deleteGarden("dirty-garden");
+    const result = await deletePhantom("dirty-phantom");
 
     strictEqual(result.success, false);
     strictEqual(
       result.message,
-      "Error: Garden 'dirty-garden' has uncommitted changes (2 files). Use --force to delete anyway.",
+      "Error: Phantom 'dirty-phantom' has uncommitted changes (2 files). Use --force to delete anyway.",
     );
     strictEqual(result.hasUncommittedChanges, true);
     strictEqual(result.changedFiles, 2);
   });
 
-  it("should delete dirty garden with --force", async () => {
+  it("should delete dirty phantom with --force", async () => {
     accessMock.mock.resetCalls();
     execMock.mock.resetCalls();
 
@@ -159,15 +159,15 @@ describe("deleteGarden", () => {
       },
     );
 
-    // Mock garden exists
+    // Mock phantom exists
     accessMock.mock.mockImplementation(() => Promise.resolve());
 
-    const result = await deleteGarden("dirty-garden", { force: true });
+    const result = await deletePhantom("dirty-phantom", { force: true });
 
     strictEqual(result.success, true);
     strictEqual(
       result.message,
-      "Warning: Garden 'dirty-garden' had uncommitted changes (2 files)\nDeleted garden 'dirty-garden' and its branch 'phantom/gardens/dirty-garden'",
+      "Warning: Phantom 'dirty-phantom' had uncommitted changes (2 files)\nDeleted phantom 'dirty-phantom' and its branch 'phantom/phantoms/dirty-phantom'",
     );
     strictEqual(result.hasUncommittedChanges, true);
     strictEqual(result.changedFiles, 2);
@@ -199,15 +199,15 @@ describe("deleteGarden", () => {
       },
     );
 
-    // Mock garden exists
+    // Mock phantom exists
     accessMock.mock.mockImplementation(() => Promise.resolve());
 
-    const result = await deleteGarden("stubborn-garden");
+    const result = await deletePhantom("stubborn-phantom");
 
     strictEqual(result.success, true);
     strictEqual(
       result.message,
-      "Deleted garden 'stubborn-garden' and its branch 'phantom/gardens/stubborn-garden'",
+      "Deleted phantom 'stubborn-phantom' and its branch 'phantom/phantoms/stubborn-phantom'",
     );
   });
 
@@ -234,15 +234,15 @@ describe("deleteGarden", () => {
       },
     );
 
-    // Mock garden exists
+    // Mock phantom exists
     accessMock.mock.mockImplementation(() => Promise.resolve());
 
-    const result = await deleteGarden("branch-missing-garden");
+    const result = await deletePhantom("branch-missing-phantom");
 
     strictEqual(result.success, true);
     strictEqual(
       result.message,
-      "Deleted garden 'branch-missing-garden' and its branch 'phantom/gardens/branch-missing-garden'",
+      "Deleted phantom 'branch-missing-phantom' and its branch 'phantom/phantoms/branch-missing-phantom'",
     );
   });
 
@@ -266,15 +266,15 @@ describe("deleteGarden", () => {
       },
     );
 
-    // Mock garden exists
+    // Mock phantom exists
     accessMock.mock.mockImplementation(() => Promise.resolve());
 
-    const result = await deleteGarden("impossible-garden");
+    const result = await deletePhantom("impossible-phantom");
 
     strictEqual(result.success, false);
     strictEqual(
       result.message,
-      "Error: Failed to remove worktree for garden 'impossible-garden'",
+      "Error: Failed to remove worktree for phantom 'impossible-phantom'",
     );
   });
 
@@ -301,15 +301,15 @@ describe("deleteGarden", () => {
       },
     );
 
-    // Mock garden exists
+    // Mock phantom exists
     accessMock.mock.mockImplementation(() => Promise.resolve());
 
-    const result = await deleteGarden("status-error-garden");
+    const result = await deletePhantom("status-error-phantom");
 
     strictEqual(result.success, true);
     strictEqual(
       result.message,
-      "Deleted garden 'status-error-garden' and its branch 'phantom/gardens/status-error-garden'",
+      "Deleted phantom 'status-error-phantom' and its branch 'phantom/phantoms/status-error-phantom'",
     );
     strictEqual(result.hasUncommittedChanges, false);
   });

--- a/src/phantoms/commands/delete.test.ts
+++ b/src/phantoms/commands/delete.test.ts
@@ -94,7 +94,7 @@ describe("deletePhantom", () => {
     strictEqual(result.success, true);
     strictEqual(
       result.message,
-      "Deleted phantom 'clean-phantom' and its branch 'phantom/phantoms/clean-phantom'",
+      "Deleted phantom 'clean-phantom' and its branch 'phantom/worktrees/clean-phantom'",
     );
     strictEqual(result.hasUncommittedChanges, false);
   });
@@ -167,7 +167,7 @@ describe("deletePhantom", () => {
     strictEqual(result.success, true);
     strictEqual(
       result.message,
-      "Warning: Phantom 'dirty-phantom' had uncommitted changes (2 files)\nDeleted phantom 'dirty-phantom' and its branch 'phantom/phantoms/dirty-phantom'",
+      "Warning: Phantom 'dirty-phantom' had uncommitted changes (2 files)\nDeleted phantom 'dirty-phantom' and its branch 'phantom/worktrees/dirty-phantom'",
     );
     strictEqual(result.hasUncommittedChanges, true);
     strictEqual(result.changedFiles, 2);
@@ -207,7 +207,7 @@ describe("deletePhantom", () => {
     strictEqual(result.success, true);
     strictEqual(
       result.message,
-      "Deleted phantom 'stubborn-phantom' and its branch 'phantom/phantoms/stubborn-phantom'",
+      "Deleted phantom 'stubborn-phantom' and its branch 'phantom/worktrees/stubborn-phantom'",
     );
   });
 
@@ -242,7 +242,7 @@ describe("deletePhantom", () => {
     strictEqual(result.success, true);
     strictEqual(
       result.message,
-      "Deleted phantom 'branch-missing-phantom' and its branch 'phantom/phantoms/branch-missing-phantom'",
+      "Deleted phantom 'branch-missing-phantom' and its branch 'phantom/worktrees/branch-missing-phantom'",
     );
   });
 
@@ -309,7 +309,7 @@ describe("deletePhantom", () => {
     strictEqual(result.success, true);
     strictEqual(
       result.message,
-      "Deleted phantom 'status-error-phantom' and its branch 'phantom/phantoms/status-error-phantom'",
+      "Deleted phantom 'status-error-phantom' and its branch 'phantom/worktrees/status-error-phantom'",
     );
     strictEqual(result.hasUncommittedChanges, false);
   });

--- a/src/phantoms/commands/delete.ts
+++ b/src/phantoms/commands/delete.ts
@@ -24,7 +24,7 @@ export async function deletePhantom(
 
   try {
     const gitRoot = await getGitRoot();
-    const phantomsPath = join(gitRoot, ".git", "phantom", "phantoms");
+    const phantomsPath = join(gitRoot, ".git", "phantom", "worktrees");
     const phantomPath = join(phantomsPath, name);
 
     // Check if phantom exists
@@ -84,7 +84,7 @@ export async function deletePhantom(
     }
 
     // Delete associated branch
-    const branchName = `phantom/phantoms/${name}`;
+    const branchName = `phantom/worktrees/${name}`;
     try {
       await execAsync(`git branch -D "${branchName}"`, {
         cwd: gitRoot,

--- a/src/phantoms/commands/delete.ts
+++ b/src/phantoms/commands/delete.ts
@@ -7,7 +7,7 @@ import { getGitRoot } from "../../git/libs/get-git-root.ts";
 
 const execAsync = promisify(exec);
 
-export async function deleteGarden(
+export async function deletePhantom(
   name: string,
   options: { force?: boolean } = {},
 ): Promise<{
@@ -17,23 +17,23 @@ export async function deleteGarden(
   changedFiles?: number;
 }> {
   if (!name) {
-    return { success: false, message: "Error: garden name required" };
+    return { success: false, message: "Error: phantom name required" };
   }
 
   const { force = false } = options;
 
   try {
     const gitRoot = await getGitRoot();
-    const gardensPath = join(gitRoot, ".git", "phantom", "gardens");
-    const gardenPath = join(gardensPath, name);
+    const phantomsPath = join(gitRoot, ".git", "phantom", "phantoms");
+    const phantomPath = join(phantomsPath, name);
 
-    // Check if garden exists
+    // Check if phantom exists
     try {
-      await access(gardenPath);
+      await access(phantomPath);
     } catch {
       return {
         success: false,
-        message: `Error: Garden '${name}' does not exist`,
+        message: `Error: Phantom '${name}' does not exist`,
       };
     }
 
@@ -42,7 +42,7 @@ export async function deleteGarden(
     let changedFiles = 0;
     try {
       const { stdout } = await execAsync("git status --porcelain", {
-        cwd: gardenPath,
+        cwd: phantomPath,
       });
       const changes = stdout.trim();
       if (changes) {
@@ -54,11 +54,11 @@ export async function deleteGarden(
       hasUncommittedChanges = false;
     }
 
-    // If garden has uncommitted changes and --force is not specified, refuse deletion
+    // If phantom has uncommitted changes and --force is not specified, refuse deletion
     if (hasUncommittedChanges && !force) {
       return {
         success: false,
-        message: `Error: Garden '${name}' has uncommitted changes (${changedFiles} files). Use --force to delete anyway.`,
+        message: `Error: Phantom '${name}' has uncommitted changes (${changedFiles} files). Use --force to delete anyway.`,
         hasUncommittedChanges: true,
         changedFiles,
       };
@@ -66,25 +66,25 @@ export async function deleteGarden(
 
     // Remove git worktree
     try {
-      await execAsync(`git worktree remove "${gardenPath}"`, {
+      await execAsync(`git worktree remove "${phantomPath}"`, {
         cwd: gitRoot,
       });
     } catch (error) {
       // If worktree remove fails, try force removal
       try {
-        await execAsync(`git worktree remove --force "${gardenPath}"`, {
+        await execAsync(`git worktree remove --force "${phantomPath}"`, {
           cwd: gitRoot,
         });
       } catch {
         return {
           success: false,
-          message: `Error: Failed to remove worktree for garden '${name}'`,
+          message: `Error: Failed to remove worktree for phantom '${name}'`,
         };
       }
     }
 
     // Delete associated branch
-    const branchName = `phantom/gardens/${name}`;
+    const branchName = `phantom/phantoms/${name}`;
     try {
       await execAsync(`git branch -D "${branchName}"`, {
         cwd: gitRoot,
@@ -94,9 +94,9 @@ export async function deleteGarden(
       // We'll still report success for the worktree removal
     }
 
-    let message = `Deleted garden '${name}' and its branch '${branchName}'`;
+    let message = `Deleted phantom '${name}' and its branch '${branchName}'`;
     if (hasUncommittedChanges) {
-      message = `Warning: Garden '${name}' had uncommitted changes (${changedFiles} files)\n${message}`;
+      message = `Warning: Phantom '${name}' had uncommitted changes (${changedFiles} files)\n${message}`;
     }
 
     return {
@@ -109,21 +109,21 @@ export async function deleteGarden(
     const errorMessage = error instanceof Error ? error.message : String(error);
     return {
       success: false,
-      message: `Error deleting garden: ${errorMessage}`,
+      message: `Error deleting phantom: ${errorMessage}`,
     };
   }
 }
 
-export async function gardensDeleteHandler(args: string[]): Promise<void> {
+export async function phantomsDeleteHandler(args: string[]): Promise<void> {
   // Parse arguments for --force flag
   const forceIndex = args.indexOf("--force");
   const force = forceIndex !== -1;
 
-  // Remove --force from args to get the garden name
+  // Remove --force from args to get the phantom name
   const filteredArgs = args.filter((arg) => arg !== "--force");
   const name = filteredArgs[0];
 
-  const result = await deleteGarden(name, { force });
+  const result = await deletePhantom(name, { force });
 
   if (!result.success) {
     console.error(result.message);

--- a/src/phantoms/commands/list.test.ts
+++ b/src/phantoms/commands/list.test.ts
@@ -1,11 +1,11 @@
 import { deepStrictEqual, strictEqual } from "node:assert";
 import { before, describe, it, mock } from "node:test";
 
-describe("listGardens", () => {
+describe("listPhantoms", () => {
   let accessMock: ReturnType<typeof mock.fn>;
   let readdirMock: ReturnType<typeof mock.fn>;
   let execMock: ReturnType<typeof mock.fn>;
-  let listGardens: typeof import("./list.ts").listGardens;
+  let listPhantoms: typeof import("./list.ts").listPhantoms;
 
   before(async () => {
     accessMock = mock.fn();
@@ -31,10 +31,10 @@ describe("listGardens", () => {
       },
     });
 
-    ({ listGardens } = await import("./list.ts"));
+    ({ listPhantoms } = await import("./list.ts"));
   });
 
-  it("should return empty array when gardens directory doesn't exist", async () => {
+  it("should return empty array when phantoms directory doesn't exist", async () => {
     accessMock.mock.resetCalls();
     readdirMock.mock.resetCalls();
     execMock.mock.resetCalls();
@@ -47,25 +47,25 @@ describe("listGardens", () => {
       return Promise.resolve({ stdout: "", stderr: "" });
     });
 
-    // Mock gardens directory doesn't exist
+    // Mock phantoms directory doesn't exist
     accessMock.mock.mockImplementation((path: string) => {
-      if (path === "/test/repo/.git/phantom/gardens") {
+      if (path === "/test/repo/.git/phantom/phantoms") {
         return Promise.reject(new Error("ENOENT"));
       }
       return Promise.resolve();
     });
 
-    const result = await listGardens();
+    const result = await listPhantoms();
 
     strictEqual(result.success, true);
-    deepStrictEqual(result.gardens, []);
+    deepStrictEqual(result.phantoms, []);
     strictEqual(
       result.message,
-      "No gardens found (gardens directory doesn't exist)",
+      "No phantoms found (phantoms directory doesn't exist)",
     );
   });
 
-  it("should return empty array when gardens directory is empty", async () => {
+  it("should return empty array when phantoms directory is empty", async () => {
     accessMock.mock.resetCalls();
     readdirMock.mock.resetCalls();
     execMock.mock.resetCalls();
@@ -78,18 +78,18 @@ describe("listGardens", () => {
       return Promise.resolve({ stdout: "", stderr: "" });
     });
 
-    // Mock gardens directory exists but is empty
+    // Mock phantoms directory exists but is empty
     accessMock.mock.mockImplementation(() => Promise.resolve());
     readdirMock.mock.mockImplementation(() => Promise.resolve([]));
 
-    const result = await listGardens();
+    const result = await listPhantoms();
 
     strictEqual(result.success, true);
-    deepStrictEqual(result.gardens, []);
-    strictEqual(result.message, "No gardens found");
+    deepStrictEqual(result.phantoms, []);
+    strictEqual(result.message, "No phantoms found");
   });
 
-  it("should list gardens with clean status", async () => {
+  it("should list phantoms with clean status", async () => {
     accessMock.mock.resetCalls();
     readdirMock.mock.resetCalls();
     execMock.mock.resetCalls();
@@ -101,10 +101,10 @@ describe("listGardens", () => {
           return Promise.resolve({ stdout: "/test/repo\n", stderr: "" });
         }
         if (cmd === "git branch --show-current") {
-          if (options?.cwd?.includes("test-garden-1")) {
+          if (options?.cwd?.includes("test-phantom-1")) {
             return Promise.resolve({ stdout: "feature/test\n", stderr: "" });
           }
-          if (options?.cwd?.includes("test-garden-2")) {
+          if (options?.cwd?.includes("test-phantom-2")) {
             return Promise.resolve({ stdout: "main\n", stderr: "" });
           }
         }
@@ -115,25 +115,25 @@ describe("listGardens", () => {
       },
     );
 
-    // Mock gardens directory and contents
+    // Mock phantoms directory and contents
     accessMock.mock.mockImplementation(() => Promise.resolve());
     readdirMock.mock.mockImplementation(() =>
-      Promise.resolve(["test-garden-1", "test-garden-2"]),
+      Promise.resolve(["test-phantom-1", "test-phantom-2"]),
     );
 
-    const result = await listGardens();
+    const result = await listPhantoms();
 
     strictEqual(result.success, true);
-    strictEqual(result.gardens?.length, 2);
-    strictEqual(result.gardens?.[0].name, "test-garden-1");
-    strictEqual(result.gardens?.[0].branch, "feature/test");
-    strictEqual(result.gardens?.[0].status, "clean");
-    strictEqual(result.gardens?.[1].name, "test-garden-2");
-    strictEqual(result.gardens?.[1].branch, "main");
-    strictEqual(result.gardens?.[1].status, "clean");
+    strictEqual(result.phantoms?.length, 2);
+    strictEqual(result.phantoms?.[0].name, "test-phantom-1");
+    strictEqual(result.phantoms?.[0].branch, "feature/test");
+    strictEqual(result.phantoms?.[0].status, "clean");
+    strictEqual(result.phantoms?.[1].name, "test-phantom-2");
+    strictEqual(result.phantoms?.[1].branch, "main");
+    strictEqual(result.phantoms?.[1].status, "clean");
   });
 
-  it("should list gardens with dirty status", async () => {
+  it("should list phantoms with dirty status", async () => {
     accessMock.mock.resetCalls();
     readdirMock.mock.resetCalls();
     execMock.mock.resetCalls();
@@ -157,20 +157,20 @@ describe("listGardens", () => {
       },
     );
 
-    // Mock gardens directory and contents
+    // Mock phantoms directory and contents
     accessMock.mock.mockImplementation(() => Promise.resolve());
     readdirMock.mock.mockImplementation(() =>
-      Promise.resolve(["dirty-garden"]),
+      Promise.resolve(["dirty-phantom"]),
     );
 
-    const result = await listGardens();
+    const result = await listPhantoms();
 
     strictEqual(result.success, true);
-    strictEqual(result.gardens?.length, 1);
-    strictEqual(result.gardens?.[0].name, "dirty-garden");
-    strictEqual(result.gardens?.[0].branch, "feature/dirty");
-    strictEqual(result.gardens?.[0].status, "dirty");
-    strictEqual(result.gardens?.[0].changedFiles, 2);
+    strictEqual(result.phantoms?.length, 1);
+    strictEqual(result.phantoms?.[0].name, "dirty-phantom");
+    strictEqual(result.phantoms?.[0].branch, "feature/dirty");
+    strictEqual(result.phantoms?.[0].status, "dirty");
+    strictEqual(result.phantoms?.[0].changedFiles, 2);
   });
 
   it("should handle git command errors gracefully", async () => {
@@ -192,19 +192,19 @@ describe("listGardens", () => {
       return Promise.resolve({ stdout: "", stderr: "" });
     });
 
-    // Mock gardens directory and contents
+    // Mock phantoms directory and contents
     accessMock.mock.mockImplementation(() => Promise.resolve());
     readdirMock.mock.mockImplementation(() =>
-      Promise.resolve(["error-garden"]),
+      Promise.resolve(["error-phantom"]),
     );
 
-    const result = await listGardens();
+    const result = await listPhantoms();
 
     strictEqual(result.success, true);
-    strictEqual(result.gardens?.length, 1);
-    strictEqual(result.gardens?.[0].name, "error-garden");
-    strictEqual(result.gardens?.[0].branch, "unknown");
-    strictEqual(result.gardens?.[0].status, "clean");
+    strictEqual(result.phantoms?.length, 1);
+    strictEqual(result.phantoms?.[0].name, "error-phantom");
+    strictEqual(result.phantoms?.[0].branch, "unknown");
+    strictEqual(result.phantoms?.[0].status, "clean");
   });
 
   it("should handle detached HEAD state", async () => {
@@ -226,18 +226,18 @@ describe("listGardens", () => {
       return Promise.resolve({ stdout: "", stderr: "" });
     });
 
-    // Mock gardens directory and contents
+    // Mock phantoms directory and contents
     accessMock.mock.mockImplementation(() => Promise.resolve());
     readdirMock.mock.mockImplementation(() =>
-      Promise.resolve(["detached-garden"]),
+      Promise.resolve(["detached-phantom"]),
     );
 
-    const result = await listGardens();
+    const result = await listPhantoms();
 
     strictEqual(result.success, true);
-    strictEqual(result.gardens?.length, 1);
-    strictEqual(result.gardens?.[0].name, "detached-garden");
-    strictEqual(result.gardens?.[0].branch, "detached HEAD");
-    strictEqual(result.gardens?.[0].status, "clean");
+    strictEqual(result.phantoms?.length, 1);
+    strictEqual(result.phantoms?.[0].name, "detached-phantom");
+    strictEqual(result.phantoms?.[0].branch, "detached HEAD");
+    strictEqual(result.phantoms?.[0].status, "clean");
   });
 });

--- a/src/phantoms/commands/list.test.ts
+++ b/src/phantoms/commands/list.test.ts
@@ -49,7 +49,7 @@ describe("listPhantoms", () => {
 
     // Mock phantoms directory doesn't exist
     accessMock.mock.mockImplementation((path: string) => {
-      if (path === "/test/repo/.git/phantom/phantoms") {
+      if (path === "/test/repo/.git/phantom/worktrees") {
         return Promise.reject(new Error("ENOENT"));
       }
       return Promise.resolve();

--- a/src/phantoms/commands/list.ts
+++ b/src/phantoms/commands/list.ts
@@ -6,42 +6,42 @@ import { getGitRoot } from "../../git/libs/get-git-root.ts";
 
 const execAsync = promisify(exec);
 
-export interface GardenInfo {
+export interface PhantomInfo {
   name: string;
   branch: string;
   status: "clean" | "dirty";
   changedFiles?: number;
 }
 
-export async function listGardens(): Promise<{
+export async function listPhantoms(): Promise<{
   success: boolean;
   message?: string;
-  gardens?: GardenInfo[];
+  phantoms?: PhantomInfo[];
 }> {
   try {
     const gitRoot = await getGitRoot();
-    const gardensPath = join(gitRoot, ".git", "phantom", "gardens");
+    const phantomsPath = join(gitRoot, ".git", "phantom", "phantoms");
 
-    // Check if gardens directory exists
+    // Check if phantoms directory exists
     try {
-      await access(gardensPath);
+      await access(phantomsPath);
     } catch {
       return {
         success: true,
-        gardens: [],
-        message: "No gardens found (gardens directory doesn't exist)",
+        phantoms: [],
+        message: "No phantoms found (phantoms directory doesn't exist)",
       };
     }
 
-    // Read gardens directory
-    let gardenNames: string[];
+    // Read phantoms directory
+    let phantomNames: string[];
     try {
-      const entries = await readdir(gardensPath);
+      const entries = await readdir(phantomsPath);
       // Filter entries to only include directories
       const validEntries = await Promise.all(
         entries.map(async (entry) => {
           try {
-            const entryPath = join(gardensPath, entry);
+            const entryPath = join(phantomsPath, entry);
             await access(entryPath);
             return entry;
           } catch {
@@ -49,35 +49,35 @@ export async function listGardens(): Promise<{
           }
         }),
       );
-      gardenNames = validEntries.filter(
+      phantomNames = validEntries.filter(
         (entry): entry is string => entry !== null,
       );
     } catch {
       return {
         success: true,
-        gardens: [],
-        message: "No gardens found (unable to read gardens directory)",
+        phantoms: [],
+        message: "No phantoms found (unable to read phantoms directory)",
       };
     }
 
-    if (gardenNames.length === 0) {
+    if (phantomNames.length === 0) {
       return {
         success: true,
-        gardens: [],
-        message: "No gardens found",
+        phantoms: [],
+        message: "No phantoms found",
       };
     }
 
-    // Get detailed information for each garden
-    const gardens: GardenInfo[] = await Promise.all(
-      gardenNames.map(async (name) => {
-        const gardenPath = join(gardensPath, name);
+    // Get detailed information for each phantom
+    const phantoms: PhantomInfo[] = await Promise.all(
+      phantomNames.map(async (name) => {
+        const phantomPath = join(phantomsPath, name);
 
         // Get current branch
         let branch = "unknown";
         try {
           const { stdout } = await execAsync("git branch --show-current", {
-            cwd: gardenPath,
+            cwd: phantomPath,
           });
           branch = stdout.trim() || "detached HEAD";
         } catch {
@@ -89,7 +89,7 @@ export async function listGardens(): Promise<{
         let changedFiles: number | undefined;
         try {
           const { stdout } = await execAsync("git status --porcelain", {
-            cwd: gardenPath,
+            cwd: phantomPath,
           });
           const changes = stdout.trim();
           if (changes) {
@@ -112,41 +112,41 @@ export async function listGardens(): Promise<{
 
     return {
       success: true,
-      gardens,
+      phantoms,
     };
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     return {
       success: false,
-      message: `Error listing gardens: ${errorMessage}`,
+      message: `Error listing phantoms: ${errorMessage}`,
     };
   }
 }
 
-export async function gardensListHandler(): Promise<void> {
-  const result = await listGardens();
+export async function phantomsListHandler(): Promise<void> {
+  const result = await listPhantoms();
 
   if (!result.success) {
     console.error(result.message);
     return;
   }
 
-  if (!result.gardens || result.gardens.length === 0) {
-    console.log(result.message || "No gardens found");
+  if (!result.phantoms || result.phantoms.length === 0) {
+    console.log(result.message || "No phantoms found");
     return;
   }
 
-  console.log("Gardens:");
-  for (const garden of result.gardens) {
+  console.log("Phantoms:");
+  for (const phantom of result.phantoms) {
     const statusText =
-      garden.status === "clean"
+      phantom.status === "clean"
         ? "[clean]"
-        : `[dirty: ${garden.changedFiles} files]`;
+        : `[dirty: ${phantom.changedFiles} files]`;
 
     console.log(
-      `  ${garden.name.padEnd(20)} (branch: ${garden.branch.padEnd(20)}) ${statusText}`,
+      `  ${phantom.name.padEnd(20)} (branch: ${phantom.branch.padEnd(20)}) ${statusText}`,
     );
   }
 
-  console.log(`\nTotal: ${result.gardens.length} gardens`);
+  console.log(`\nTotal: ${result.phantoms.length} phantoms`);
 }

--- a/src/phantoms/commands/list.ts
+++ b/src/phantoms/commands/list.ts
@@ -20,7 +20,7 @@ export async function listPhantoms(): Promise<{
 }> {
   try {
     const gitRoot = await getGitRoot();
-    const phantomsPath = join(gitRoot, ".git", "phantom", "phantoms");
+    const phantomsPath = join(gitRoot, ".git", "phantom", "worktrees");
 
     // Check if phantoms directory exists
     try {

--- a/src/phantoms/commands/where.test.ts
+++ b/src/phantoms/commands/where.test.ts
@@ -83,7 +83,7 @@ describe("wherePhantom", () => {
     strictEqual(result.success, true);
     strictEqual(
       result.path,
-      "/test/repo/.git/phantom/phantoms/existing-phantom",
+      "/test/repo/.git/phantom/worktrees/existing-phantom",
     );
   });
 
@@ -122,7 +122,7 @@ describe("wherePhantom", () => {
     strictEqual(result.success, true);
     strictEqual(
       result.path,
-      "/different/repo/.git/phantom/phantoms/feature-branch-123",
+      "/different/repo/.git/phantom/worktrees/feature-branch-123",
     );
   });
 
@@ -146,7 +146,7 @@ describe("wherePhantom", () => {
     strictEqual(result.success, true);
     strictEqual(
       result.path,
-      "/test/repo/.git/phantom/phantoms/feature-with-dashes_and_underscores",
+      "/test/repo/.git/phantom/worktrees/feature-with-dashes_and_underscores",
     );
   });
 });

--- a/src/phantoms/commands/where.test.ts
+++ b/src/phantoms/commands/where.test.ts
@@ -1,10 +1,10 @@
 import { strictEqual } from "node:assert";
 import { before, describe, it, mock } from "node:test";
 
-describe("whereGarden", () => {
+describe("wherePhantom", () => {
   let accessMock: ReturnType<typeof mock.fn>;
   let execMock: ReturnType<typeof mock.fn>;
-  let whereGarden: typeof import("./where.ts").whereGarden;
+  let wherePhantom: typeof import("./where.ts").wherePhantom;
 
   before(async () => {
     accessMock = mock.fn();
@@ -28,16 +28,16 @@ describe("whereGarden", () => {
       },
     });
 
-    ({ whereGarden } = await import("./where.ts"));
+    ({ wherePhantom } = await import("./where.ts"));
   });
 
   it("should return error when name is not provided", async () => {
-    const result = await whereGarden("");
+    const result = await wherePhantom("");
     strictEqual(result.success, false);
-    strictEqual(result.message, "Error: garden name required");
+    strictEqual(result.message, "Error: phantom name required");
   });
 
-  it("should return error when garden does not exist", async () => {
+  it("should return error when phantom does not exist", async () => {
     accessMock.mock.resetCalls();
     execMock.mock.resetCalls();
 
@@ -49,21 +49,21 @@ describe("whereGarden", () => {
       return Promise.resolve({ stdout: "", stderr: "" });
     });
 
-    // Mock garden doesn't exist
+    // Mock phantom doesn't exist
     accessMock.mock.mockImplementation(() => {
       return Promise.reject(new Error("ENOENT"));
     });
 
-    const result = await whereGarden("nonexistent-garden");
+    const result = await wherePhantom("nonexistent-phantom");
 
     strictEqual(result.success, false);
     strictEqual(
       result.message,
-      "Error: Garden 'nonexistent-garden' does not exist",
+      "Error: Phantom 'nonexistent-phantom' does not exist",
     );
   });
 
-  it("should return path when garden exists", async () => {
+  it("should return path when phantom exists", async () => {
     accessMock.mock.resetCalls();
     execMock.mock.resetCalls();
 
@@ -75,13 +75,16 @@ describe("whereGarden", () => {
       return Promise.resolve({ stdout: "", stderr: "" });
     });
 
-    // Mock garden exists
+    // Mock phantom exists
     accessMock.mock.mockImplementation(() => Promise.resolve());
 
-    const result = await whereGarden("existing-garden");
+    const result = await wherePhantom("existing-phantom");
 
     strictEqual(result.success, true);
-    strictEqual(result.path, "/test/repo/.git/phantom/gardens/existing-garden");
+    strictEqual(
+      result.path,
+      "/test/repo/.git/phantom/phantoms/existing-phantom",
+    );
   });
 
   it("should handle git root detection failures", async () => {
@@ -93,13 +96,13 @@ describe("whereGarden", () => {
       return Promise.reject(new Error("Not a git repository"));
     });
 
-    const result = await whereGarden("some-garden");
+    const result = await wherePhantom("some-phantom");
 
     strictEqual(result.success, false);
-    strictEqual(result.message, "Error locating garden: Not a git repository");
+    strictEqual(result.message, "Error locating phantom: Not a git repository");
   });
 
-  it("should handle different garden names correctly", async () => {
+  it("should handle different phantom names correctly", async () => {
     accessMock.mock.resetCalls();
     execMock.mock.resetCalls();
 
@@ -111,19 +114,19 @@ describe("whereGarden", () => {
       return Promise.resolve({ stdout: "", stderr: "" });
     });
 
-    // Mock garden exists
+    // Mock phantom exists
     accessMock.mock.mockImplementation(() => Promise.resolve());
 
-    const result = await whereGarden("feature-branch-123");
+    const result = await wherePhantom("feature-branch-123");
 
     strictEqual(result.success, true);
     strictEqual(
       result.path,
-      "/different/repo/.git/phantom/gardens/feature-branch-123",
+      "/different/repo/.git/phantom/phantoms/feature-branch-123",
     );
   });
 
-  it("should handle special characters in garden names", async () => {
+  it("should handle special characters in phantom names", async () => {
     accessMock.mock.resetCalls();
     execMock.mock.resetCalls();
 
@@ -135,15 +138,15 @@ describe("whereGarden", () => {
       return Promise.resolve({ stdout: "", stderr: "" });
     });
 
-    // Mock garden exists
+    // Mock phantom exists
     accessMock.mock.mockImplementation(() => Promise.resolve());
 
-    const result = await whereGarden("feature-with-dashes_and_underscores");
+    const result = await wherePhantom("feature-with-dashes_and_underscores");
 
     strictEqual(result.success, true);
     strictEqual(
       result.path,
-      "/test/repo/.git/phantom/gardens/feature-with-dashes_and_underscores",
+      "/test/repo/.git/phantom/phantoms/feature-with-dashes_and_underscores",
     );
   });
 });

--- a/src/phantoms/commands/where.ts
+++ b/src/phantoms/commands/where.ts
@@ -3,46 +3,46 @@ import { join } from "node:path";
 import { exit } from "node:process";
 import { getGitRoot } from "../../git/libs/get-git-root.ts";
 
-export async function whereGarden(name: string): Promise<{
+export async function wherePhantom(name: string): Promise<{
   success: boolean;
   message?: string;
   path?: string;
 }> {
   if (!name) {
-    return { success: false, message: "Error: garden name required" };
+    return { success: false, message: "Error: phantom name required" };
   }
 
   try {
     const gitRoot = await getGitRoot();
-    const gardensPath = join(gitRoot, ".git", "phantom", "gardens");
-    const gardenPath = join(gardensPath, name);
+    const phantomsPath = join(gitRoot, ".git", "phantom", "phantoms");
+    const phantomPath = join(phantomsPath, name);
 
-    // Check if garden exists
+    // Check if phantom exists
     try {
-      await access(gardenPath);
+      await access(phantomPath);
     } catch {
       return {
         success: false,
-        message: `Error: Garden '${name}' does not exist`,
+        message: `Error: Phantom '${name}' does not exist`,
       };
     }
 
     return {
       success: true,
-      path: gardenPath,
+      path: phantomPath,
     };
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     return {
       success: false,
-      message: `Error locating garden: ${errorMessage}`,
+      message: `Error locating phantom: ${errorMessage}`,
     };
   }
 }
 
-export async function gardensWhereHandler(args: string[]): Promise<void> {
+export async function phantomsWhereHandler(args: string[]): Promise<void> {
   const name = args[0];
-  const result = await whereGarden(name);
+  const result = await wherePhantom(name);
 
   if (!result.success) {
     console.error(result.message);

--- a/src/phantoms/commands/where.ts
+++ b/src/phantoms/commands/where.ts
@@ -14,7 +14,7 @@ export async function wherePhantom(name: string): Promise<{
 
   try {
     const gitRoot = await getGitRoot();
-    const phantomsPath = join(gitRoot, ".git", "phantom", "phantoms");
+    const phantomsPath = join(gitRoot, ".git", "phantom", "worktrees");
     const phantomPath = join(phantomsPath, name);
 
     // Check if phantom exists


### PR DESCRIPTION
## Summary
This PR addresses #42 by completely removing the "garden" terminology from the project and flattening the command structure.

## Breaking Changes
- **Removed nested "garden" command structure** - Commands are now directly under `phantom`
- **Renamed all "garden" references to "phantom"** throughout the codebase
- **Directory restructure** - `src/gardens/` renamed to `src/phantoms/`

### Before:
```bash
phantom garden create feature-branch
phantom garden list
phantom garden delete feature-branch
phantom garden where feature-branch
```

### After:
```bash
phantom create feature-branch
phantom list
phantom delete feature-branch
phantom where feature-branch
```

## Changes Made
- Updated command structure in `src/bin/phantom.ts` to register commands directly
- Renamed `src/gardens/` directory to `src/phantoms/`
- Updated all imports and references from "garden" to "phantom"
- Updated README.md and README.ja.md documentation
- Updated package.json description
- Updated CLAUDE.md project documentation
- Updated all test files to reflect the new terminology

## Impact
This is a breaking change that will require users to update their workflows. The command structure is now simpler and more intuitive, with "phantom" representing the worktrees themselves rather than being just a tool that manages "gardens".

Closes #42

🤖 Generated with [Claude Code](https://claude.ai/code)