### PR TITLE
Fix environment variable names and add PHANTOM indicator

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -133,8 +133,9 @@ phantom shell <name>
 
 ### 環境変数
 
-Phantomで管理されたworktree内で作業する際、以下の環境変数が利用可能です：
+`phantom shell`でインタラクティブシェルを開いた際、以下の環境変数が設定されます：
 
+- `PHANTOM` - phantom shellから起動されたすべてのプロセスに"1"がセットされる
 - `PHANTOM_NAME` - 現在のworktreeの名前
 - `PHANTOM_PATH` - worktreeディレクトリへの絶対パス
 

--- a/README.md
+++ b/README.md
@@ -133,8 +133,9 @@ phantom shell <name>
 
 ### Environment Variables
 
-When working within a worktree managed by Phantom, these environment variables are available:
+When opening an interactive shell with `phantom shell`, these environment variables are set:
 
+- `PHANTOM` - Set to "1" for all processes spawned from phantom shell
 - `PHANTOM_NAME` - Name of the current worktree
 - `PHANTOM_PATH` - Absolute path to the worktree directory
 

--- a/src/commands/shell.test.ts
+++ b/src/commands/shell.test.ts
@@ -96,9 +96,10 @@ describe("shellInWorktree", () => {
       spawnCall.options?.cwd,
       "/test/repo/.git/phantom/worktrees/test-worktree",
     );
-    strictEqual(spawnCall.options?.env?.WORKTREE_NAME, "test-worktree");
+    strictEqual(spawnCall.options?.env?.PHANTOM, "1");
+    strictEqual(spawnCall.options?.env?.PHANTOM_NAME, "test-worktree");
     strictEqual(
-      spawnCall.options?.env?.WORKTREE_PATH,
+      spawnCall.options?.env?.PHANTOM_PATH,
       "/test/repo/.git/phantom/worktrees/test-worktree",
     );
   });

--- a/src/commands/shell.ts
+++ b/src/commands/shell.ts
@@ -39,8 +39,9 @@ export async function shellInWorktree(
       env: {
         ...process.env,
         // Add environment variable to indicate we're in a worktree
-        WORKTREE_NAME: worktreeName,
-        WORKTREE_PATH: worktreePath,
+        PHANTOM: "1",
+        PHANTOM_NAME: worktreeName,
+        PHANTOM_PATH: worktreePath,
       },
     },
   });


### PR DESCRIPTION
## Summary
- Fixed incorrect environment variable names from `WORKTREE_NAME`/`WORKTREE_PATH` to `PHANTOM_NAME`/`PHANTOM_PATH` to match documentation
- Added `PHANTOM=1` environment variable to indicate processes are running in a phantom shell
- Updated documentation to clarify that these environment variables are only set when using `phantom shell` command

## Test plan
- [x] All existing tests pass
- [x] Updated test cases to check for new environment variable names
- [x] Manually tested `phantom shell` command to verify environment variables are set correctly

🤖 Generated with [Claude Code](https://claude.ai/code)