### PR TITLE
feat: implement Result type for better type safety

### DIFF
--- a/src/cli/handlers/exec.ts
+++ b/src/cli/handlers/exec.ts
@@ -1,5 +1,7 @@
 import { getGitRoot } from "../../core/git/libs/get-git-root.ts";
 import { execInWorktree as execInWorktreeCore } from "../../core/process/exec.ts";
+import { isErr } from "../../core/types/result.ts";
+import { WorktreeNotFoundError } from "../../core/worktree/errors.ts";
 import { exitCodes, exitWithError } from "../errors.ts";
 
 export async function execHandler(args: string[]): Promise<void> {
@@ -16,11 +18,15 @@ export async function execHandler(args: string[]): Promise<void> {
     const gitRoot = await getGitRoot();
     const result = await execInWorktreeCore(gitRoot, worktreeName, commandArgs);
 
-    if (!result.success && result.message) {
-      exitWithError(result.message, result.exitCode || exitCodes.generalError);
+    if (isErr(result)) {
+      const exitCode =
+        result.error instanceof WorktreeNotFoundError
+          ? exitCodes.notFound
+          : result.error.exitCode || exitCodes.generalError;
+      exitWithError(result.error.message, exitCode);
     }
 
-    process.exit(result.exitCode || 0);
+    process.exit(result.value.exitCode);
   } catch (error) {
     exitWithError(
       error instanceof Error ? error.message : String(error),

--- a/src/cli/handlers/where.ts
+++ b/src/cli/handlers/where.ts
@@ -1,4 +1,5 @@
 import { getGitRoot } from "../../core/git/libs/get-git-root.ts";
+import { isErr } from "../../core/types/result.ts";
 import { whereWorktree as whereWorktreeCore } from "../../core/worktree/where.ts";
 import { exitCodes, exitWithError, exitWithSuccess } from "../errors.ts";
 import { output } from "../output.ts";
@@ -14,11 +15,11 @@ export async function whereHandler(args: string[]): Promise<void> {
     const gitRoot = await getGitRoot();
     const result = await whereWorktreeCore(gitRoot, worktreeName);
 
-    if (!result.success || !result.path) {
-      exitWithError(result.message || "Worktree not found", exitCodes.notFound);
+    if (isErr(result)) {
+      exitWithError(result.error.message, exitCodes.notFound);
     }
 
-    output.log(result.path);
+    output.log(result.value.path);
     exitWithSuccess();
   } catch (error) {
     exitWithError(

--- a/src/core/process/errors.ts
+++ b/src/core/process/errors.ts
@@ -1,0 +1,31 @@
+export class ProcessError extends Error {
+  public readonly exitCode?: number;
+
+  constructor(message: string, exitCode?: number) {
+    super(message);
+    this.name = "ProcessError";
+    this.exitCode = exitCode;
+  }
+}
+
+export class ProcessExecutionError extends ProcessError {
+  constructor(command: string, exitCode: number) {
+    super(`Command '${command}' failed with exit code ${exitCode}`, exitCode);
+    this.name = "ProcessExecutionError";
+  }
+}
+
+export class ProcessSignalError extends ProcessError {
+  constructor(signal: string) {
+    const exitCode = 128 + (signal === "SIGTERM" ? 15 : 1);
+    super(`Command terminated by signal: ${signal}`, exitCode);
+    this.name = "ProcessSignalError";
+  }
+}
+
+export class ProcessSpawnError extends ProcessError {
+  constructor(command: string, details: string) {
+    super(`Error executing command '${command}': ${details}`);
+    this.name = "ProcessSpawnError";
+  }
+}

--- a/src/core/process/exec.ts
+++ b/src/core/process/exec.ts
@@ -1,19 +1,21 @@
+import { type Result, err } from "../types/result.ts";
+import { WorktreeNotFoundError } from "../worktree/errors.ts";
 import { validateWorktreeExists } from "../worktree/validate.ts";
-import { type SpawnResult, spawnProcess } from "./spawn.ts";
+import type { ProcessError } from "./errors.ts";
+import { type SpawnSuccess, spawnProcess } from "./spawn.ts";
 
-export interface ExecInWorktreeResult extends SpawnResult {}
+export type ExecInWorktreeSuccess = SpawnSuccess;
 
 export async function execInWorktree(
   gitRoot: string,
   worktreeName: string,
   command: string[],
-): Promise<ExecInWorktreeResult> {
+): Promise<
+  Result<ExecInWorktreeSuccess, WorktreeNotFoundError | ProcessError>
+> {
   const validation = await validateWorktreeExists(gitRoot, worktreeName);
   if (!validation.exists) {
-    return {
-      success: false,
-      message: validation.message || `Worktree '${worktreeName}' not found`,
-    };
+    return err(new WorktreeNotFoundError(worktreeName));
   }
 
   const worktreePath = validation.path as string;

--- a/src/core/process/shell.ts
+++ b/src/core/process/shell.ts
@@ -1,18 +1,20 @@
+import { type Result, err } from "../types/result.ts";
+import { WorktreeNotFoundError } from "../worktree/errors.ts";
 import { validateWorktreeExists } from "../worktree/validate.ts";
-import { type SpawnResult, spawnProcess } from "./spawn.ts";
+import type { ProcessError } from "./errors.ts";
+import { type SpawnSuccess, spawnProcess } from "./spawn.ts";
 
-export interface ShellInWorktreeResult extends SpawnResult {}
+export type ShellInWorktreeSuccess = SpawnSuccess;
 
 export async function shellInWorktree(
   gitRoot: string,
   worktreeName: string,
-): Promise<ShellInWorktreeResult> {
+): Promise<
+  Result<ShellInWorktreeSuccess, WorktreeNotFoundError | ProcessError>
+> {
   const validation = await validateWorktreeExists(gitRoot, worktreeName);
   if (!validation.exists) {
-    return {
-      success: false,
-      message: validation.message || `Worktree '${worktreeName}' not found`,
-    };
+    return err(new WorktreeNotFoundError(worktreeName));
   }
 
   const worktreePath = validation.path as string;

--- a/src/core/types/result.test.ts
+++ b/src/core/types/result.test.ts
@@ -1,0 +1,44 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { err, isErr, isOk, ok } from "./result.ts";
+
+describe("Result type", () => {
+  describe("ok", () => {
+    it("should create an Ok result", () => {
+      const result = ok(42);
+      deepStrictEqual(result, { ok: true, value: 42 });
+    });
+  });
+
+  describe("err", () => {
+    it("should create an Err result", () => {
+      const error = new Error("Something went wrong");
+      const result = err(error);
+      deepStrictEqual(result, { ok: false, error });
+    });
+  });
+
+  describe("isOk", () => {
+    it("should return true for Ok result", () => {
+      const result = ok(42);
+      strictEqual(isOk(result), true);
+    });
+
+    it("should return false for Err result", () => {
+      const result = err(new Error("Error"));
+      strictEqual(isOk(result), false);
+    });
+  });
+
+  describe("isErr", () => {
+    it("should return true for Err result", () => {
+      const result = err(new Error("Error"));
+      strictEqual(isErr(result), true);
+    });
+
+    it("should return false for Ok result", () => {
+      const result = ok(42);
+      strictEqual(isErr(result), false);
+    });
+  });
+});

--- a/src/core/types/result.ts
+++ b/src/core/types/result.ts
@@ -1,0 +1,76 @@
+/**
+ * Represents a value that is either successful (Ok) or contains an error (Err).
+ * This type is inspired by Rust's Result type and provides type-safe error handling.
+ *
+ * @template T - The type of the success value
+ * @template E - The type of the error value (defaults to Error)
+ */
+export type Result<T, E = Error> =
+  | { ok: true; value: T }
+  | { ok: false; error: E };
+
+/**
+ * Creates a successful Result containing the given value.
+ *
+ * @template T - The type of the success value
+ * @param value - The success value to wrap
+ * @returns A Result in the Ok state containing the value
+ *
+ * @example
+ * const result = ok(42);
+ * // result: Result<number, never> = { ok: true, value: 42 }
+ */
+export const ok = <T>(value: T): Result<T, never> => ({
+  ok: true,
+  value,
+});
+
+/**
+ * Creates a failed Result containing the given error.
+ *
+ * @template E - The type of the error value
+ * @param error - The error value to wrap
+ * @returns A Result in the Err state containing the error
+ *
+ * @example
+ * const result = err(new Error("Something went wrong"));
+ * // result: Result<never, Error> = { ok: false, error: Error(...) }
+ */
+export const err = <E>(error: E): Result<never, E> => ({
+  ok: false,
+  error,
+});
+
+/**
+ * Type guard that checks if a Result is in the Ok state.
+ *
+ * @template T - The type of the success value
+ * @template E - The type of the error value
+ * @param result - The Result to check
+ * @returns True if the Result is Ok, false otherwise
+ *
+ * @example
+ * if (isOk(result)) {
+ *   console.log(result.value); // TypeScript knows result.value exists
+ * }
+ */
+export const isOk = <T, E>(
+  result: Result<T, E>,
+): result is { ok: true; value: T } => result.ok;
+
+/**
+ * Type guard that checks if a Result is in the Err state.
+ *
+ * @template T - The type of the success value
+ * @template E - The type of the error value
+ * @param result - The Result to check
+ * @returns True if the Result is Err, false otherwise
+ *
+ * @example
+ * if (isErr(result)) {
+ *   console.error(result.error); // TypeScript knows result.error exists
+ * }
+ */
+export const isErr = <T, E>(
+  result: Result<T, E>,
+): result is { ok: false; error: E } => !result.ok;

--- a/src/core/worktree/errors.ts
+++ b/src/core/worktree/errors.ts
@@ -1,0 +1,34 @@
+export class WorktreeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "WorktreeError";
+  }
+}
+
+export class WorktreeNotFoundError extends WorktreeError {
+  constructor(name: string) {
+    super(`Worktree '${name}' not found`);
+    this.name = "WorktreeNotFoundError";
+  }
+}
+
+export class WorktreeAlreadyExistsError extends WorktreeError {
+  constructor(name: string) {
+    super(`Worktree '${name}' already exists`);
+    this.name = "WorktreeAlreadyExistsError";
+  }
+}
+
+export class InvalidWorktreeNameError extends WorktreeError {
+  constructor(name: string) {
+    super(`Invalid worktree name: '${name}'`);
+    this.name = "InvalidWorktreeNameError";
+  }
+}
+
+export class GitOperationError extends WorktreeError {
+  constructor(operation: string, details: string) {
+    super(`Git ${operation} failed: ${details}`);
+    this.name = "GitOperationError";
+  }
+}

--- a/src/core/worktree/list.ts
+++ b/src/core/worktree/list.ts
@@ -1,5 +1,6 @@
 import { executeGitCommandInDirectory } from "../git/executor.ts";
 import { getWorktreePath } from "../paths.ts";
+import { type Result, ok } from "../types/result.ts";
 import {
   listValidWorktrees,
   validatePhantomDirectoryExists,
@@ -12,8 +13,7 @@ export interface WorktreeInfo {
   isClean: boolean;
 }
 
-export interface ListWorktreesResult {
-  success: boolean;
+export interface ListWorktreesSuccess {
   worktrees: WorktreeInfo[];
   message?: string;
 }
@@ -66,23 +66,21 @@ export async function getWorktreeInfo(
 
 export async function listWorktrees(
   gitRoot: string,
-): Promise<ListWorktreesResult> {
+): Promise<Result<ListWorktreesSuccess, never>> {
   if (!(await validatePhantomDirectoryExists(gitRoot))) {
-    return {
-      success: true,
+    return ok({
       worktrees: [],
       message: "No worktrees found (worktrees directory doesn't exist)",
-    };
+    });
   }
 
   const worktreeNames = await listValidWorktrees(gitRoot);
 
   if (worktreeNames.length === 0) {
-    return {
-      success: true,
+    return ok({
       worktrees: [],
       message: "No worktrees found",
-    };
+    });
   }
 
   try {
@@ -90,10 +88,9 @@ export async function listWorktrees(
       worktreeNames.map((name) => getWorktreeInfo(gitRoot, name)),
     );
 
-    return {
-      success: true,
+    return ok({
       worktrees,
-    };
+    });
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     throw new Error(`Failed to list worktrees: ${errorMessage}`);

--- a/src/core/worktree/where.ts
+++ b/src/core/worktree/where.ts
@@ -1,26 +1,22 @@
+import { type Result, err, ok } from "../types/result.ts";
+import { WorktreeNotFoundError } from "./errors.ts";
 import { validateWorktreeExists } from "./validate.ts";
 
-export interface WhereWorktreeResult {
-  success: boolean;
-  message?: string;
-  path?: string;
+export interface WhereWorktreeSuccess {
+  path: string;
 }
 
 export async function whereWorktree(
   gitRoot: string,
   name: string,
-): Promise<WhereWorktreeResult> {
+): Promise<Result<WhereWorktreeSuccess, WorktreeNotFoundError>> {
   const validation = await validateWorktreeExists(gitRoot, name);
 
   if (!validation.exists) {
-    return {
-      success: false,
-      message: validation.message || `Worktree '${name}' not found`,
-    };
+    return err(new WorktreeNotFoundError(name));
   }
 
-  return {
-    success: true,
-    path: validation.path,
-  };
+  return ok({
+    path: validation.path as string,
+  });
 }


### PR DESCRIPTION
## Summary
- Implements a proper Result<T, E> type pattern to replace the current `{ success: boolean }` approach
- Provides type-safe error handling with compile-time guarantees
- Closes #66 

## Changes
### Core Implementation
- Added `Result<T, E>` type definition with discriminated union
- Created helper functions: `ok()`, `err()`, `isOk()`, `isErr()`
- Added comprehensive JSDoc documentation for all functions
- Created unit tests for Result type functionality

### Error Types
- **Worktree errors**: `WorktreeError`, `WorktreeNotFoundError`, `WorktreeAlreadyExistsError`, `GitOperationError`
- **Process errors**: `ProcessError`, `ProcessExecutionError`, `ProcessSignalError`, `ProcessSpawnError`

### Refactored Modules
All core modules now return Result types:
- `createWorktree`: `Result<CreateWorktreeSuccess, WorktreeAlreadyExistsError | GitOperationError>`
- `deleteWorktree`: `Result<DeleteWorktreeSuccess, WorktreeNotFoundError | WorktreeError | GitOperationError>`
- `listWorktrees`: `Result<ListWorktreesSuccess, never>`
- `whereWorktree`: `Result<WhereWorktreeSuccess, WorktreeNotFoundError>`
- `spawnProcess`: `Result<SpawnSuccess, ProcessError>`
- `execInWorktree`: `Result<ExecInWorktreeSuccess, WorktreeNotFoundError | ProcessError>`
- `shellInWorktree`: `Result<ShellInWorktreeSuccess, WorktreeNotFoundError | ProcessError>`

### CLI Updates
- Updated all CLI handlers to use pattern matching with `isOk()` and `isErr()`
- Proper error code mapping based on error types
- Maintained backward compatibility with existing CLI behavior

## Benefits
- **Type Safety**: Errors are now part of the function signature
- **Explicit Error Handling**: Can't ignore errors without explicitly handling them
- **Better DX**: IDE provides autocomplete and type hints for error cases
- **Clear Intent**: Function signatures clearly show what errors can occur

## Test Plan
- [x] All existing tests pass
- [x] New Result type tests pass
- [x] Type checking passes (`pnpm type-check`)
- [x] Linting passes (`pnpm lint`)
- [x] Manual testing of CLI commands

🤖 Generated with [Claude Code](https://claude.ai/code)