### PR TITLE
refactor: use git worktree list command instead of readdir

### DIFF
--- a/src/core/git/libs/list-worktrees.ts
+++ b/src/core/git/libs/list-worktrees.ts
@@ -1,0 +1,54 @@
+import { executeGitCommand } from "../executor.ts";
+
+export interface GitWorktree {
+  path: string;
+  branch: string;
+  head: string;
+  isLocked: boolean;
+  isPrunable: boolean;
+}
+
+export async function listWorktrees(gitRoot: string): Promise<GitWorktree[]> {
+  const { stdout } = await executeGitCommand([
+    "worktree",
+    "list",
+    "--porcelain",
+  ]);
+
+  const worktrees: GitWorktree[] = [];
+  let currentWorktree: Partial<GitWorktree> = {};
+
+  const lines = stdout.split("\n").filter((line) => line.length > 0);
+
+  for (const line of lines) {
+    if (line.startsWith("worktree ")) {
+      if (currentWorktree.path) {
+        worktrees.push(currentWorktree as GitWorktree);
+      }
+      currentWorktree = {
+        path: line.substring("worktree ".length),
+        isLocked: false,
+        isPrunable: false,
+      };
+    } else if (line.startsWith("HEAD ")) {
+      currentWorktree.head = line.substring("HEAD ".length);
+    } else if (line.startsWith("branch ")) {
+      const fullBranch = line.substring("branch ".length);
+      currentWorktree.branch = fullBranch.startsWith("refs/heads/")
+        ? fullBranch.substring("refs/heads/".length)
+        : fullBranch;
+    } else if (line === "detached") {
+      currentWorktree.branch = "(detached HEAD)";
+    } else if (line === "locked") {
+      currentWorktree.isLocked = true;
+    } else if (line === "prunable") {
+      currentWorktree.isPrunable = true;
+    }
+  }
+
+  if (currentWorktree.path) {
+    worktrees.push(currentWorktree as GitWorktree);
+  }
+
+  return worktrees;
+}

--- a/src/core/worktree/list.test.ts
+++ b/src/core/worktree/list.test.ts
@@ -1,18 +1,47 @@
-import { deepStrictEqual } from "node:assert";
+import { ok as assertOk, deepStrictEqual } from "node:assert";
 import { describe, it, mock } from "node:test";
 
 describe("listWorktrees", () => {
-  let readdirMock: ReturnType<typeof mock.fn>;
-  let statMock: ReturnType<typeof mock.fn>;
-  let execMock: ReturnType<typeof mock.fn>;
+  it("should return empty array when no phantom worktrees exist", async () => {
+    const execFileMock = mock.fn(
+      (_cmd: string, _args: string[], _options: Record<string, unknown>) => {
+        if (_args.includes("worktree") && _args.includes("list")) {
+          return Promise.resolve({
+            stdout:
+              "worktree /test/repo\nHEAD abc123\nbranch refs/heads/main\n\n",
+            stderr: "",
+          });
+        }
+        return Promise.resolve({ stdout: "", stderr: "" });
+      },
+    );
 
-  it("should return empty array when worktrees directory doesn't exist", async () => {
-    readdirMock = mock.fn(() => Promise.reject(new Error("ENOENT")));
-
-    mock.module("node:fs/promises", {
+    mock.module("node:child_process", {
       namedExports: {
-        readdir: readdirMock,
-        stat: statMock,
+        execFile: (
+          cmd: string,
+          args: string[],
+          options: Record<string, unknown>,
+          callback: (
+            error: Error | null,
+            result?: { stdout: string; stderr: string },
+          ) => void,
+        ) => {
+          const result = execFileMock(cmd, args, options);
+          if (callback) {
+            result.then(
+              (res: { stdout: string; stderr: string }) => callback(null, res),
+              (err: Error) => callback(err),
+            );
+          }
+          return {};
+        },
+      },
+    });
+
+    mock.module("node:util", {
+      namedExports: {
+        promisify: () => execFileMock,
       },
     });
 
@@ -31,69 +60,66 @@ describe("listWorktrees", () => {
     const { listWorktrees } = await import("./list.ts");
     const result = await listWorktrees("/test/repo");
 
-    deepStrictEqual(result, []);
-  });
-
-  it("should return empty array when worktrees directory is empty", async () => {
-    readdirMock = mock.fn(() => Promise.resolve([]));
-
-    mock.module("node:fs/promises", {
-      namedExports: {
-        readdir: readdirMock,
-        stat: statMock,
-      },
-    });
-
-    mock.module("../paths.ts", {
-      namedExports: {
-        getPhantomDirectory: mock.fn(
-          (gitRoot: string) => `${gitRoot}/.git/phantom/worktrees`,
-        ),
-        getWorktreePath: mock.fn(
-          (gitRoot: string, name: string) =>
-            `${gitRoot}/.git/phantom/worktrees/${name}`,
-        ),
-      },
-    });
-
-    const { listWorktrees } = await import("./list.ts");
-    const result = await listWorktrees("/test/repo");
-
-    deepStrictEqual(result, []);
+    assertOk(result.ok);
+    if (result.ok) {
+      deepStrictEqual(result.value.worktrees, []);
+      deepStrictEqual(result.value.message, "No worktrees found");
+    }
   });
 
   it("should list worktrees with clean status", async () => {
-    readdirMock = mock.fn(() => Promise.resolve(["feature-1", "feature-2"]));
-    statMock = mock.fn(() => Promise.resolve({ isDirectory: () => true }));
-    execMock = mock.fn((cmd: string) => {
-      if (cmd.includes("git -C") && cmd.includes("status --porcelain")) {
-        return Promise.resolve({ stdout: "", stderr: "" });
-      }
-      if (cmd.includes("git -C") && cmd.includes("branch --show-current")) {
-        if (cmd.includes("feature-1")) {
-          return Promise.resolve({ stdout: "feature-1\n", stderr: "" });
-        }
-        return Promise.resolve({ stdout: "feature-2\n", stderr: "" });
-      }
-      return Promise.resolve({ stdout: "", stderr: "" });
-    });
+    const execFileMock = mock.fn(
+      (_cmd: string, _args: string[], _options: Record<string, unknown>) => {
+        if (_args.includes("worktree") && _args.includes("list")) {
+          return Promise.resolve({
+            stdout: `worktree /test/repo
+HEAD abc123
+branch refs/heads/main
 
-    mock.module("node:fs/promises", {
-      namedExports: {
-        readdir: readdirMock,
-        stat: statMock,
+worktree /test/repo/.git/phantom/worktrees/feature-1
+HEAD def456
+branch refs/heads/feature-1
+
+worktree /test/repo/.git/phantom/worktrees/feature-2
+HEAD ghi789
+branch refs/heads/feature-2
+`,
+            stderr: "",
+          });
+        }
+        if (_args.includes("status") && _args.includes("--porcelain")) {
+          return Promise.resolve({ stdout: "", stderr: "" });
+        }
+        return Promise.resolve({ stdout: "", stderr: "" });
       },
-    });
+    );
 
     mock.module("node:child_process", {
       namedExports: {
-        exec: execMock,
+        execFile: (
+          cmd: string,
+          args: string[],
+          options: Record<string, unknown>,
+          callback: (
+            error: Error | null,
+            result?: { stdout: string; stderr: string },
+          ) => void,
+        ) => {
+          const result = execFileMock(cmd, args, options);
+          if (callback) {
+            result.then(
+              (res: { stdout: string; stderr: string }) => callback(null, res),
+              (err: Error) => callback(err),
+            );
+          }
+          return {};
+        },
       },
     });
 
     mock.module("node:util", {
       namedExports: {
-        promisify: (fn: unknown) => fn,
+        promisify: () => execFileMock,
       },
     });
 
@@ -112,115 +138,74 @@ describe("listWorktrees", () => {
     const { listWorktrees } = await import("./list.ts");
     const result = await listWorktrees("/test/repo");
 
-    deepStrictEqual(result, [
-      {
-        name: "feature-1",
-        path: "/test/repo/.git/phantom/worktrees/feature-1",
-        branch: "feature-1",
-        isClean: true,
-      },
-      {
-        name: "feature-2",
-        path: "/test/repo/.git/phantom/worktrees/feature-2",
-        branch: "feature-2",
-        isClean: true,
-      },
-    ]);
+    assertOk(result.ok);
+    if (result.ok) {
+      deepStrictEqual(result.value.worktrees, [
+        {
+          name: "feature-1",
+          path: "/test/repo/.git/phantom/worktrees/feature-1",
+          branch: "feature-1",
+          isClean: true,
+        },
+        {
+          name: "feature-2",
+          path: "/test/repo/.git/phantom/worktrees/feature-2",
+          branch: "feature-2",
+          isClean: true,
+        },
+      ]);
+    }
   });
 
   it("should handle worktrees with dirty status", async () => {
-    readdirMock = mock.fn(() => Promise.resolve(["dirty-feature"]));
-    statMock = mock.fn(() => Promise.resolve({ isDirectory: () => true }));
-    execMock = mock.fn((cmd: string) => {
-      if (cmd.includes("git -C") && cmd.includes("status --porcelain")) {
-        return Promise.resolve({ stdout: "M file.txt\n", stderr: "" });
-      }
-      if (cmd.includes("git -C") && cmd.includes("branch --show-current")) {
-        return Promise.resolve({ stdout: "dirty-feature\n", stderr: "" });
-      }
-      return Promise.resolve({ stdout: "", stderr: "" });
-    });
+    const execFileMock = mock.fn(
+      (_cmd: string, _args: string[], _options: Record<string, unknown>) => {
+        if (_args.includes("worktree") && _args.includes("list")) {
+          return Promise.resolve({
+            stdout: `worktree /test/repo
+HEAD abc123
+branch refs/heads/main
 
-    mock.module("node:fs/promises", {
-      namedExports: {
-        readdir: readdirMock,
-        stat: statMock,
-      },
-    });
-
-    mock.module("node:child_process", {
-      namedExports: {
-        exec: execMock,
-      },
-    });
-
-    mock.module("node:util", {
-      namedExports: {
-        promisify: (fn: unknown) => fn,
-      },
-    });
-
-    mock.module("../paths.ts", {
-      namedExports: {
-        getPhantomDirectory: mock.fn(
-          (gitRoot: string) => `${gitRoot}/.git/phantom/worktrees`,
-        ),
-        getWorktreePath: mock.fn(
-          (gitRoot: string, name: string) =>
-            `${gitRoot}/.git/phantom/worktrees/${name}`,
-        ),
-      },
-    });
-
-    const { listWorktrees } = await import("./list.ts");
-    const result = await listWorktrees("/test/repo");
-
-    deepStrictEqual(result, [
-      {
-        name: "dirty-feature",
-        path: "/test/repo/.git/phantom/worktrees/dirty-feature",
-        branch: "dirty-feature",
-        isClean: false,
-      },
-    ]);
-  });
-
-  it("should skip non-directory entries", async () => {
-    readdirMock = mock.fn(() =>
-      Promise.resolve(["file.txt", "valid-worktree"]),
-    );
-    statMock = mock.fn((path: string) => {
-      if (path.includes("file.txt")) {
-        return Promise.resolve({ isDirectory: () => false });
-      }
-      return Promise.resolve({ isDirectory: () => true });
-    });
-    execMock = mock.fn((cmd: string) => {
-      if (cmd.includes("status --porcelain")) {
+worktree /test/repo/.git/phantom/worktrees/dirty-feature
+HEAD def456
+branch refs/heads/dirty-feature
+`,
+            stderr: "",
+          });
+        }
+        if (_args.includes("status") && _args.includes("--porcelain")) {
+          return Promise.resolve({ stdout: "M file.txt\n", stderr: "" });
+        }
         return Promise.resolve({ stdout: "", stderr: "" });
-      }
-      if (cmd.includes("branch --show-current")) {
-        return Promise.resolve({ stdout: "valid-worktree\n", stderr: "" });
-      }
-      return Promise.resolve({ stdout: "", stderr: "" });
-    });
-
-    mock.module("node:fs/promises", {
-      namedExports: {
-        readdir: readdirMock,
-        stat: statMock,
       },
-    });
+    );
 
     mock.module("node:child_process", {
       namedExports: {
-        exec: execMock,
+        execFile: (
+          cmd: string,
+          args: string[],
+          options: Record<string, unknown>,
+          callback: (
+            error: Error | null,
+            result?: { stdout: string; stderr: string },
+          ) => void,
+        ) => {
+          const result = execFileMock(cmd, args, options);
+          if (callback) {
+            result.then(
+              (res: { stdout: string; stderr: string }) => callback(null, res),
+              (err: Error) => callback(err),
+            );
+          }
+          return {};
+        },
       },
     });
 
     mock.module("node:util", {
       namedExports: {
-        promisify: (fn: unknown) => fn,
+        promisify: () => execFileMock,
       },
     });
 
@@ -239,45 +224,68 @@ describe("listWorktrees", () => {
     const { listWorktrees } = await import("./list.ts");
     const result = await listWorktrees("/test/repo");
 
-    deepStrictEqual(result, [
-      {
-        name: "valid-worktree",
-        path: "/test/repo/.git/phantom/worktrees/valid-worktree",
-        branch: "valid-worktree",
-        isClean: true,
-      },
-    ]);
+    assertOk(result.ok);
+    if (result.ok) {
+      deepStrictEqual(result.value.worktrees, [
+        {
+          name: "dirty-feature",
+          path: "/test/repo/.git/phantom/worktrees/dirty-feature",
+          branch: "dirty-feature",
+          isClean: false,
+        },
+      ]);
+    }
   });
 
   it("should handle detached HEAD state", async () => {
-    readdirMock = mock.fn(() => Promise.resolve(["detached"]));
-    statMock = mock.fn(() => Promise.resolve({ isDirectory: () => true }));
-    execMock = mock.fn((cmd: string) => {
-      if (cmd.includes("status --porcelain")) {
-        return Promise.resolve({ stdout: "", stderr: "" });
-      }
-      if (cmd.includes("branch --show-current")) {
-        return Promise.resolve({ stdout: "", stderr: "" });
-      }
-      return Promise.resolve({ stdout: "", stderr: "" });
-    });
+    const execFileMock = mock.fn(
+      (_cmd: string, _args: string[], _options: Record<string, unknown>) => {
+        if (_args.includes("worktree") && _args.includes("list")) {
+          return Promise.resolve({
+            stdout: `worktree /test/repo
+HEAD abc123
+branch refs/heads/main
 
-    mock.module("node:fs/promises", {
-      namedExports: {
-        readdir: readdirMock,
-        stat: statMock,
+worktree /test/repo/.git/phantom/worktrees/detached
+HEAD def456
+detached
+`,
+            stderr: "",
+          });
+        }
+        if (_args.includes("status") && _args.includes("--porcelain")) {
+          return Promise.resolve({ stdout: "", stderr: "" });
+        }
+        return Promise.resolve({ stdout: "", stderr: "" });
       },
-    });
+    );
 
     mock.module("node:child_process", {
       namedExports: {
-        exec: execMock,
+        execFile: (
+          cmd: string,
+          args: string[],
+          options: Record<string, unknown>,
+          callback: (
+            error: Error | null,
+            result?: { stdout: string; stderr: string },
+          ) => void,
+        ) => {
+          const result = execFileMock(cmd, args, options);
+          if (callback) {
+            result.then(
+              (res: { stdout: string; stderr: string }) => callback(null, res),
+              (err: Error) => callback(err),
+            );
+          }
+          return {};
+        },
       },
     });
 
     mock.module("node:util", {
       namedExports: {
-        promisify: (fn: unknown) => fn,
+        promisify: () => execFileMock,
       },
     });
 
@@ -296,13 +304,100 @@ describe("listWorktrees", () => {
     const { listWorktrees } = await import("./list.ts");
     const result = await listWorktrees("/test/repo");
 
-    deepStrictEqual(result, [
-      {
-        name: "detached",
-        path: "/test/repo/.git/phantom/worktrees/detached",
-        branch: "(detached HEAD)",
-        isClean: true,
+    assertOk(result.ok);
+    if (result.ok) {
+      deepStrictEqual(result.value.worktrees, [
+        {
+          name: "detached",
+          path: "/test/repo/.git/phantom/worktrees/detached",
+          branch: "(detached HEAD)",
+          isClean: true,
+        },
+      ]);
+    }
+  });
+
+  it("should filter out non-phantom worktrees", async () => {
+    const execFileMock = mock.fn(
+      (_cmd: string, _args: string[], _options: Record<string, unknown>) => {
+        if (_args.includes("worktree") && _args.includes("list")) {
+          return Promise.resolve({
+            stdout: `worktree /test/repo
+HEAD abc123
+branch refs/heads/main
+
+worktree /test/repo/.git/phantom/worktrees/phantom-feature
+HEAD def456
+branch refs/heads/phantom-feature
+
+worktree /test/repo/other-worktree
+HEAD ghi789
+branch refs/heads/other-feature
+`,
+            stderr: "",
+          });
+        }
+        if (_args.includes("status") && _args.includes("--porcelain")) {
+          return Promise.resolve({ stdout: "", stderr: "" });
+        }
+        return Promise.resolve({ stdout: "", stderr: "" });
       },
-    ]);
+    );
+
+    mock.module("node:child_process", {
+      namedExports: {
+        execFile: (
+          cmd: string,
+          args: string[],
+          options: Record<string, unknown>,
+          callback: (
+            error: Error | null,
+            result?: { stdout: string; stderr: string },
+          ) => void,
+        ) => {
+          const result = execFileMock(cmd, args, options);
+          if (callback) {
+            result.then(
+              (res: { stdout: string; stderr: string }) => callback(null, res),
+              (err: Error) => callback(err),
+            );
+          }
+          return {};
+        },
+      },
+    });
+
+    mock.module("node:util", {
+      namedExports: {
+        promisify: () => execFileMock,
+      },
+    });
+
+    mock.module("../paths.ts", {
+      namedExports: {
+        getPhantomDirectory: mock.fn(
+          (gitRoot: string) => `${gitRoot}/.git/phantom/worktrees`,
+        ),
+        getWorktreePath: mock.fn(
+          (gitRoot: string, name: string) =>
+            `${gitRoot}/.git/phantom/worktrees/${name}`,
+        ),
+      },
+    });
+
+    const { listWorktrees } = await import("./list.ts");
+    const result = await listWorktrees("/test/repo");
+
+    assertOk(result.ok);
+    if (result.ok) {
+      deepStrictEqual(result.value.worktrees, [
+        {
+          name: "phantom-feature",
+          path: "/test/repo/.git/phantom/worktrees/phantom-feature",
+          branch: "phantom-feature",
+          isClean: true,
+        },
+      ]);
+    }
   });
 });

--- a/src/core/worktree/validate.ts
+++ b/src/core/worktree/validate.ts
@@ -59,27 +59,3 @@ export async function validatePhantomDirectoryExists(
     return false;
   }
 }
-
-export async function listValidWorktrees(gitRoot: string): Promise<string[]> {
-  const phantomDir = getPhantomDirectory(gitRoot);
-
-  if (!(await validatePhantomDirectoryExists(gitRoot))) {
-    return [];
-  }
-
-  try {
-    const entries = await fs.readdir(phantomDir);
-    const validWorktrees: string[] = [];
-
-    for (const entry of entries) {
-      const result = await validateWorktreeExists(gitRoot, entry);
-      if (result.exists) {
-        validWorktrees.push(entry);
-      }
-    }
-
-    return validWorktrees;
-  } catch {
-    return [];
-  }
-}


### PR DESCRIPTION
## Summary
- Replace filesystem-based worktree discovery with `git worktree list` command
- Add robust parsing for git's porcelain output format
- Improve reliability by using git's native worktree tracking

## Changes
- Created new git helper library `list-worktrees.ts` that executes and parses `git worktree list --porcelain`
- Updated `list.ts` to filter worktrees from git command output instead of reading directories
- Removed obsolete `listValidWorktrees` function from `validate.ts`
- Updated tests to mock git command execution instead of filesystem operations

## Benefits
- More reliable worktree detection using git's internal state
- Handles edge cases better (e.g., corrupted worktrees, locked worktrees)
- Simplifies code by removing manual directory traversal
- Future-proof as it uses git's official API

## Test plan
- [x] All existing tests pass
- [x] Manual testing shows correct filtering of phantom worktrees
- [x] Handles detached HEAD states correctly
- [x] Filters out non-phantom worktrees properly