### PR TITLE
fix: enable phantom execution from within git worktree directories

### DIFF
--- a/src/core/git/libs/get-git-root.ts
+++ b/src/core/git/libs/get-git-root.ts
@@ -1,6 +1,16 @@
+import { dirname, resolve } from "node:path";
 import { executeGitCommand } from "../executor.ts";
 
 export async function getGitRoot(): Promise<string> {
-  const { stdout } = await executeGitCommand(["rev-parse", "--show-toplevel"]);
-  return stdout;
+  const { stdout } = await executeGitCommand(["rev-parse", "--git-common-dir"]);
+
+  if (stdout.endsWith("/.git") || stdout === ".git") {
+    return resolve(process.cwd(), dirname(stdout));
+  }
+
+  const { stdout: toplevel } = await executeGitCommand([
+    "rev-parse",
+    "--show-toplevel",
+  ]);
+  return toplevel;
 }


### PR DESCRIPTION
## Summary
- Fixed phantom commands to work correctly when executed from within a git worktree directory
- Implemented automatic detection of the main repository using `git rev-parse --git-common-dir`

## Problem
Previously, phantom commands failed when executed from within a git worktree because git worktree operations need to be executed from the main repository, not from within another worktree.

## Solution
Updated `getGitRoot()` function to:
1. Use `git rev-parse --git-common-dir` to get the main repository's .git directory
2. Handle relative paths (like `../.git` or `.git`) by resolving them to absolute paths
3. Fall back to the existing behavior for non-worktree environments

## Test plan
- [x] Manually tested phantom commands from within a worktree
- [x] Verified that `pnpm phantom list` works from worktree directories
- [x] All existing tests pass
- [x] Backward compatibility maintained for non-worktree usage

Fixes #64

🤖 Generated with [Claude Code](https://claude.ai/code)