### PR TITLE
feat: Apply validateWorktreeName to create command

### DIFF
--- a/src/core/worktree/create.test.ts
+++ b/src/core/worktree/create.test.ts
@@ -1,7 +1,7 @@
 import { deepStrictEqual, strictEqual } from "node:assert";
 import { describe, it, mock } from "node:test";
 import type { AddWorktreeOptions } from "../git/libs/add-worktree.ts";
-import { isErr, isOk } from "../types/result.ts";
+import { err, isErr, isOk, ok } from "../types/result.ts";
 import { GitOperationError, WorktreeAlreadyExistsError } from "./errors.ts";
 
 describe("createWorktree", () => {
@@ -26,6 +26,7 @@ describe("createWorktree", () => {
     mock.module("./validate.ts", {
       namedExports: {
         validateWorktreeDoesNotExist: validateMock,
+        validateWorktreeName: mock.fn(() => ok(undefined)),
       },
     });
 
@@ -85,6 +86,7 @@ describe("createWorktree", () => {
     mock.module("./validate.ts", {
       namedExports: {
         validateWorktreeDoesNotExist: validateMock,
+        validateWorktreeName: mock.fn(() => ok(undefined)),
       },
     });
 
@@ -135,6 +137,7 @@ describe("createWorktree", () => {
     mock.module("./validate.ts", {
       namedExports: {
         validateWorktreeDoesNotExist: validateMock,
+        validateWorktreeName: mock.fn(() => ok(undefined)),
       },
     });
 
@@ -175,6 +178,7 @@ describe("createWorktree", () => {
     mock.module("./validate.ts", {
       namedExports: {
         validateWorktreeDoesNotExist: validateMock,
+        validateWorktreeName: mock.fn(() => ok(undefined)),
       },
     });
 
@@ -225,6 +229,7 @@ describe("createWorktree", () => {
     mock.module("./validate.ts", {
       namedExports: {
         validateWorktreeDoesNotExist: validateMock,
+        validateWorktreeName: mock.fn(() => ok(undefined)),
       },
     });
 

--- a/src/core/worktree/create.ts
+++ b/src/core/worktree/create.ts
@@ -1,9 +1,12 @@
 import fs from "node:fs/promises";
 import { addWorktree } from "../git/libs/add-worktree.ts";
 import { getPhantomDirectory, getWorktreePath } from "../paths.ts";
-import { type Result, err, ok } from "../types/result.ts";
+import { type Result, err, isErr, ok } from "../types/result.ts";
 import { GitOperationError, WorktreeAlreadyExistsError } from "./errors.ts";
-import { validateWorktreeDoesNotExist } from "./validate.ts";
+import {
+  validateWorktreeDoesNotExist,
+  validateWorktreeName,
+} from "./validate.ts";
 
 export interface CreateWorktreeOptions {
   branch?: string;
@@ -22,6 +25,11 @@ export async function createWorktree(
 ): Promise<
   Result<CreateWorktreeSuccess, WorktreeAlreadyExistsError | GitOperationError>
 > {
+  const nameValidation = validateWorktreeName(name);
+  if (isErr(nameValidation)) {
+    return nameValidation;
+  }
+
   const { branch = name, commitish = "HEAD" } = options;
 
   const worktreesPath = getPhantomDirectory(gitRoot);


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Apply `validateWorktreeName` function to the `create` command for consistent validation
- Prevent creation of worktrees with invalid names (empty, containing slashes, or starting with dots)
- Ensure both `create` and `attach` commands follow the same validation rules

## Changes
- Import and apply `validateWorktreeName` in `src/core/worktree/create.ts`
- Add validation check before creating the worktree
- Return appropriate error if validation fails
- Update tests to handle the validation mock

## Test plan
- [x] Run `pnpm ready` - all checks pass
- [x] Manual testing confirms validation works for all three scenarios:
  - Empty names are rejected
  - Names with slashes are rejected
  - Names starting with dots are rejected
- [x] Existing functionality remains intact

Closes #83

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)