### PR TITLE
docs: add comprehensive wiki documentation with Japanese translation

### DIFF
--- a/docs/wiki-manual.md
+++ b/docs/wiki-manual.md
@@ -6,63 +6,93 @@ This manual provides a standardized approach for building comprehensive document
 ## Wiki Structure Template
 
 ### 1. Home Page (`Home.md`)
+- Language switcher for multilingual support
 - Project technical overview and purpose
 - Quick navigation to all sections
 - Quick navigation to technical documentation
 - Links to key developer resources (repository, CI/CD, package registry)
 
-### 2. Getting Started (`Getting-Started/`)
-- `Development-Setup.md` - Setting up the development environment
-- `Quick-Start.md` - Get the code running in 5 minutes
-- `Architecture-Overview.md` - High-level system design
+### 2. Getting Started
+- `Getting-Started-Development-Setup.md` - Setting up the development environment
+- `Getting-Started-Quick-Start.md` - Get the code running in 5 minutes
+- `Getting-Started-Architecture-Overview.md` - High-level system design
   <!-- Use Mermaid syntax for visual representation -->
-- `Core-Concepts.md` - Essential technical concepts and terminology
+- `Getting-Started-Core-Concepts.md` - Essential technical concepts and terminology
 
-### 3. Architecture (`Architecture/`)
-- `Technology-Stack.md` - Languages, frameworks, and tools used
-- `System-Design.md` - Overall architecture and design patterns
-- `Module-Structure.md` - Code organization and dependencies
+### 3. Architecture
+- `Architecture-Technology-Stack.md` - Languages, frameworks, and tools used
+- `Architecture-System-Design.md` - Overall architecture and design patterns
+- `Architecture-Module-Structure.md` - Code organization and dependencies
   <!-- Use Mermaid syntax for visual representation -->
-- `Data-Flow.md` - How data moves through the system
+- `Architecture-Data-Flow.md` - How data moves through the system
   <!-- Use Mermaid syntax for visual representation -->
 
-### 4. Testing (`Testing/`)
+### 4. Testing
 <!-- Skip items that don't exist -->
-- `Testing-Strategy.md` - Overall testing approach
-- `Unit-Testing.md` - Writing and running unit tests
-- `Integration-Testing.md` - Integration test guidelines
-- `E2E-Testing.md` - End-to-end testing approach
-- `Performance-Testing.md` - Load and performance testing
+- `Testing-Testing-Strategy.md` - Overall testing approach
+- `Testing-Unit-Testing.md` - Writing and running unit tests
+- `Testing-Integration-Testing.md` - Integration test guidelines
+- `Testing-E2E-Testing.md` - End-to-end testing approach
+- `Testing-Performance-Testing.md` - Load and performance testing
 
-### 5. Development Guides (`Development-Guides/`)
+### 5. Development Guides
 <!-- Skip items that don't exist -->
-- `Local-Development.md` - Running locally
-- `Debugging.md` - Debugging techniques and tools
-- `Profiling.md` - Performance profiling
-- `Logging.md` - Logging standards and practices
-- `Monitoring.md` - Observability and monitoring
-- `Code-Styles.md` - Coding conventions and style guide
+- `Development-Guides-Local-Development.md` - Running locally
+- `Development-Guides-Debugging.md` - Debugging techniques and tools
+- `Development-Guides-Profiling.md` - Performance profiling
+- `Development-Guides-Logging.md` - Logging standards and practices
+- `Development-Guides-Monitoring.md` - Observability and monitoring
+- `Development-Guides-Code-Styles.md` - Coding conventions and style guide
 
-### 6. Deployment (`Deployment/`)
+### 6. Deployment
 <!-- Skip items that don't exist -->
-- `Build-Process.md` - How to build the project
-- `Configuration.md` - Environment configuration
-- `Deployment-Guide.md` - Deployment procedures
-- `Infrastructure.md` - Infrastructure requirements
-- `CI-CD.md` - Continuous integration and deployment
+- `Deployment-Build-Process.md` - How to build the project
+- `Deployment-Configuration.md` - Environment configuration
+- `Deployment-Deployment-Guide.md` - Deployment procedures
+- `Deployment-Infrastructure.md` - Infrastructure requirements
+- `Deployment-CI-CD.md` - Continuous integration and deployment
 
-### 7. Security (`Security/`)
+### 7. Security
 <!-- Skip items that don't exist -->
-- `Security-Overview.md` - Security architecture
-- `Authentication.md` - Auth implementation
-- `Authorization.md` - Access control
-- `Security-Best-Practices.md` - Secure coding guidelines
+- `Security-Security-Overview.md` - Security architecture
+- `Security-Authentication.md` - Auth implementation
+- `Security-Authorization.md` - Access control
+- `Security-Security-Best-Practices.md` - Secure coding guidelines
+
+## File Naming Convention
+
+Since GitHub Wiki uses a flat file structure, use the following naming pattern:
+
+### For English Documentation
+`Category-SubCategory-PageName.md`
+
+Examples:
+- `Getting-Started-Development-Setup.md`
+- `Architecture-Technology-Stack.md`
+- `Testing-Unit-Testing.md`
+
+### For Multilingual Support
+Prefix with language code:
+- English: Use standard pattern (no prefix)
+- Japanese: `JA-Category-SubCategory-PageName.md`
+- Other languages: `[LANG]-Category-SubCategory-PageName.md`
+
+Examples:
+- `JA-Getting-Started-Development-Setup.md`
+- `JA-Architecture-Technology-Stack.md`
 
 ## Rules
 
 - **Formatting**: Use GitHub Flavored Markdown.
   - **Mermaid Syntax**: Use Mermaid syntax for architecture and data flow diagrams.
   - **Links**: Use Markdown link syntax for links to related documents and resources within sections.
-    - Example: `[Link Text](full-URL-of-wiki-page)`
+    - Example: `[Link Text](https://github.com/owner/repo/wiki/Category-PageName)`
+- **Language Support**: 
+  - Add language switcher at the top of Home pages
+  - Maintain consistent structure across languages
+  - Update all internal links when using the naming convention
 - **Consistency**: Each section should use the same format and style.
 - **Source Attribution**: Clearly indicate which files in the repository the information was derived from using GitHub Permalinks.
+  - Always use permalinks to the `main` branch, not commit hashes
+  - Format: `https://github.com/owner/repo/blob/main/path/to/file.ext#L123`
+  - Example: `Source: [package.json#L36](https://github.com/owner/repo/blob/main/package.json#L36)`

--- a/docs/wiki-manual.md
+++ b/docs/wiki-manual.md
@@ -1,0 +1,68 @@
+# GitHub Wiki Construction Manual
+
+## Purpose
+This manual provides a standardized approach for building comprehensive documentation wikis for software projects.
+
+## Wiki Structure Template
+
+### 1. Home Page (`Home.md`)
+- Project technical overview and purpose
+- Quick navigation to all sections
+- Quick navigation to technical documentation
+- Links to key developer resources (repository, CI/CD, package registry)
+
+### 2. Getting Started (`Getting-Started/`)
+- `Development-Setup.md` - Setting up the development environment
+- `Quick-Start.md` - Get the code running in 5 minutes
+- `Architecture-Overview.md` - High-level system design
+  <!-- Use Mermaid syntax for visual representation -->
+- `Core-Concepts.md` - Essential technical concepts and terminology
+
+### 3. Architecture (`Architecture/`)
+- `Technology-Stack.md` - Languages, frameworks, and tools used
+- `System-Design.md` - Overall architecture and design patterns
+- `Module-Structure.md` - Code organization and dependencies
+  <!-- Use Mermaid syntax for visual representation -->
+- `Data-Flow.md` - How data moves through the system
+  <!-- Use Mermaid syntax for visual representation -->
+
+### 4. Testing (`Testing/`)
+<!-- Skip items that don't exist -->
+- `Testing-Strategy.md` - Overall testing approach
+- `Unit-Testing.md` - Writing and running unit tests
+- `Integration-Testing.md` - Integration test guidelines
+- `E2E-Testing.md` - End-to-end testing approach
+- `Performance-Testing.md` - Load and performance testing
+
+### 5. Development Guides (`Development-Guides/`)
+<!-- Skip items that don't exist -->
+- `Local-Development.md` - Running locally
+- `Debugging.md` - Debugging techniques and tools
+- `Profiling.md` - Performance profiling
+- `Logging.md` - Logging standards and practices
+- `Monitoring.md` - Observability and monitoring
+- `Code-Styles.md` - Coding conventions and style guide
+
+### 6. Deployment (`Deployment/`)
+<!-- Skip items that don't exist -->
+- `Build-Process.md` - How to build the project
+- `Configuration.md` - Environment configuration
+- `Deployment-Guide.md` - Deployment procedures
+- `Infrastructure.md` - Infrastructure requirements
+- `CI-CD.md` - Continuous integration and deployment
+
+### 7. Security (`Security/`)
+<!-- Skip items that don't exist -->
+- `Security-Overview.md` - Security architecture
+- `Authentication.md` - Auth implementation
+- `Authorization.md` - Access control
+- `Security-Best-Practices.md` - Secure coding guidelines
+
+## Rules
+
+- **Formatting**: Use GitHub Flavored Markdown.
+  - **Mermaid Syntax**: Use Mermaid syntax for architecture and data flow diagrams.
+  - **Links**: Use Markdown link syntax for links to related documents and resources within sections.
+    - Example: `[Link Text](full-URL-of-wiki-page)`
+- **Consistency**: Each section should use the same format and style.
+- **Source Attribution**: Clearly indicate which files in the repository the information was derived from using GitHub Permalinks.


### PR DESCRIPTION
## Summary
- Add comprehensive wiki documentation covering all aspects of the Phantom project
- Include complete Japanese translation of all documentation
- Reorganize files for GitHub Wiki's flat structure requirements

## Changes

### Documentation Added (32 pages total)
- **16 English pages** covering:
  - Getting Started (Development Setup, Quick Start, Architecture Overview, Core Concepts)
  - Architecture (Technology Stack, System Design, Module Structure, Data Flow)
  - Testing (Testing Strategy, Unit Testing)
  - Development Guides (Local Development, Code Styles, Debugging)
  - Deployment (Build Process, CI/CD)
  
- **16 Japanese pages** - Complete translations of all English documentation

### File Organization
- Implemented flat file structure for GitHub Wiki compatibility
- Naming pattern: `Category-SubCategory-PageName.md` (English)
- Naming pattern: `JA-Category-SubCategory-PageName.md` (Japanese)
- Added language switchers to both Home pages

### Additional Updates
- Updated wiki manual with new file naming conventions
- Fixed all GitHub permalinks to use `main` branch instead of commit hashes
- Added Mermaid diagrams for architecture visualization

## Test Plan
- [ ] Verify all wiki links work correctly in GitHub Wiki
- [ ] Check language switcher functionality
- [ ] Ensure Mermaid diagrams render properly
- [ ] Confirm Japanese translations are accurate

🤖 Generated with [Claude Code](https://claude.ai/code)