### PR TITLE
feat: add --current option to delete command

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ phantom where <name>
 # Delete a worktree and its branch
 phantom delete <name>
 phantom delete <name> --force  # Force delete with uncommitted changes
+phantom delete --current        # Delete the current worktree (when inside one)
+phantom delete --current --force # Force delete current worktree
 ```
 
 #### Working with Worktrees
@@ -200,6 +202,7 @@ phantom shell feature-awesome  # Continue feature development
 | Navigate to worktree | `cd ../project-feature` | `phantom shell feature` |
 | Run command in worktree | `cd ../project-feature && npm test` | `phantom exec feature npm test` |
 | Remove worktree | `git worktree remove ../project-feature` | `phantom delete feature` |
+| Remove current worktree | `cd .. && git worktree remove project-feature` | `phantom delete --current` |
 
 ## 🛠️ Development
 

--- a/src/cli/handlers/delete.test.ts
+++ b/src/cli/handlers/delete.test.ts
@@ -1,0 +1,425 @@
+import { strictEqual } from "node:assert";
+import { describe, it, mock } from "node:test";
+import { err, ok } from "../../core/types/result.ts";
+import { WorktreeNotFoundError } from "../../core/worktree/errors.ts";
+
+describe("deleteHandler", () => {
+  let exitMock: ReturnType<typeof mock.fn>;
+  let consoleLogMock: ReturnType<typeof mock.fn>;
+  let consoleErrorMock: ReturnType<typeof mock.fn>;
+  let getGitRootMock: ReturnType<typeof mock.fn>;
+  let deleteWorktreeMock: ReturnType<typeof mock.fn>;
+  let getCurrentWorktreeMock: ReturnType<typeof mock.fn>;
+
+  it("should delete worktree by name", async () => {
+    exitMock = mock.fn();
+    consoleLogMock = mock.fn();
+    consoleErrorMock = mock.fn();
+    getGitRootMock = mock.fn(() => Promise.resolve("/test/repo"));
+    deleteWorktreeMock = mock.fn(() =>
+      Promise.resolve(
+        ok({
+          message: "Deleted worktree 'feature' and its branch 'feature'",
+        }),
+      ),
+    );
+
+    mock.module("node:process", {
+      namedExports: {
+        exit: exitMock,
+      },
+    });
+
+    mock.module("../../core/git/libs/get-git-root.ts", {
+      namedExports: {
+        getGitRoot: getGitRootMock,
+      },
+    });
+
+    mock.module("../../core/worktree/delete.ts", {
+      namedExports: {
+        deleteWorktree: deleteWorktreeMock,
+      },
+    });
+
+    mock.module("../output.ts", {
+      namedExports: {
+        output: {
+          log: consoleLogMock,
+          error: consoleErrorMock,
+        },
+      },
+    });
+
+    mock.module("../errors.ts", {
+      namedExports: {
+        exitCodes: {
+          generalError: 1,
+          validationError: 2,
+        },
+        exitWithError: mock.fn((message: string, code: number) => {
+          consoleErrorMock(`Error: ${message}`);
+          exitMock(code);
+        }),
+        exitWithSuccess: mock.fn(() => exitMock(0)),
+      },
+    });
+
+    const { deleteHandler } = await import("./delete.ts");
+    await deleteHandler(["feature"]);
+
+    strictEqual(deleteWorktreeMock.mock.calls.length, 1);
+    strictEqual(deleteWorktreeMock.mock.calls[0].arguments[0], "/test/repo");
+    strictEqual(deleteWorktreeMock.mock.calls[0].arguments[1], "feature");
+    const deleteOptions = deleteWorktreeMock.mock.calls[0].arguments[2] as { force: boolean };
+    strictEqual(deleteOptions.force, false);
+
+    strictEqual(consoleLogMock.mock.calls.length, 1);
+    strictEqual(
+      consoleLogMock.mock.calls[0].arguments[0],
+      "Deleted worktree 'feature' and its branch 'feature'",
+    );
+
+    strictEqual(exitMock.mock.calls[0].arguments[0], 0);
+  });
+
+  it("should delete current worktree with --current option", async () => {
+    exitMock = mock.fn();
+    consoleLogMock = mock.fn();
+    consoleErrorMock = mock.fn();
+    getGitRootMock = mock.fn(() => Promise.resolve("/test/repo"));
+    getCurrentWorktreeMock = mock.fn(() => Promise.resolve("issue-93"));
+    deleteWorktreeMock = mock.fn(() =>
+      Promise.resolve(
+        ok({
+          message: "Deleted worktree 'issue-93' and its branch 'issue-93'",
+        }),
+      ),
+    );
+
+    mock.module("node:process", {
+      namedExports: {
+        exit: exitMock,
+      },
+    });
+
+    mock.module("../../core/git/libs/get-git-root.ts", {
+      namedExports: {
+        getGitRoot: getGitRootMock,
+      },
+    });
+
+    mock.module("../../core/git/libs/get-current-worktree.ts", {
+      namedExports: {
+        getCurrentWorktree: getCurrentWorktreeMock,
+      },
+    });
+
+    mock.module("../../core/worktree/delete.ts", {
+      namedExports: {
+        deleteWorktree: deleteWorktreeMock,
+      },
+    });
+
+    mock.module("../output.ts", {
+      namedExports: {
+        output: {
+          log: consoleLogMock,
+          error: consoleErrorMock,
+        },
+      },
+    });
+
+    mock.module("../errors.ts", {
+      namedExports: {
+        exitCodes: {
+          generalError: 1,
+          validationError: 2,
+        },
+        exitWithError: mock.fn((message: string, code: number) => {
+          consoleErrorMock(`Error: ${message}`);
+          exitMock(code);
+        }),
+        exitWithSuccess: mock.fn(() => exitMock(0)),
+      },
+    });
+
+    const { deleteHandler } = await import("./delete.ts");
+    await deleteHandler(["--current"]);
+
+    strictEqual(getCurrentWorktreeMock.mock.calls.length, 1);
+    strictEqual(
+      getCurrentWorktreeMock.mock.calls[0].arguments[0],
+      "/test/repo",
+    );
+
+    strictEqual(deleteWorktreeMock.mock.calls.length, 1);
+    strictEqual(deleteWorktreeMock.mock.calls[0].arguments[0], "/test/repo");
+    strictEqual(deleteWorktreeMock.mock.calls[0].arguments[1], "issue-93");
+    const deleteOptions = deleteWorktreeMock.mock.calls[0].arguments[2] as { force: boolean };
+    strictEqual(deleteOptions.force, false);
+
+    strictEqual(consoleLogMock.mock.calls.length, 1);
+    strictEqual(
+      consoleLogMock.mock.calls[0].arguments[0],
+      "Deleted worktree 'issue-93' and its branch 'issue-93'",
+    );
+
+    strictEqual(exitMock.mock.calls[0].arguments[0], 0);
+  });
+
+  it("should error when --current is used outside a worktree", async () => {
+    exitMock = mock.fn();
+    consoleErrorMock = mock.fn();
+    getGitRootMock = mock.fn(() => Promise.resolve("/test/repo"));
+    getCurrentWorktreeMock = mock.fn(() => Promise.resolve(null));
+
+    mock.module("node:process", {
+      namedExports: {
+        exit: exitMock,
+      },
+    });
+
+    mock.module("../../core/git/libs/get-git-root.ts", {
+      namedExports: {
+        getGitRoot: getGitRootMock,
+      },
+    });
+
+    mock.module("../../core/git/libs/get-current-worktree.ts", {
+      namedExports: {
+        getCurrentWorktree: getCurrentWorktreeMock,
+      },
+    });
+
+    mock.module("../errors.ts", {
+      namedExports: {
+        exitCodes: {
+          generalError: 1,
+          validationError: 2,
+        },
+        exitWithError: mock.fn((message: string, code: number) => {
+          consoleErrorMock(`Error: ${message}`);
+          exitMock(code);
+        }),
+        exitWithSuccess: mock.fn(() => exitMock(0)),
+      },
+    });
+
+    const { deleteHandler } = await import("./delete.ts");
+    await deleteHandler(["--current"]);
+
+    strictEqual(getCurrentWorktreeMock.mock.calls.length, 1);
+    strictEqual(consoleErrorMock.mock.calls.length, 1);
+    strictEqual(
+      consoleErrorMock.mock.calls[0].arguments[0],
+      "Error: Not in a worktree directory. The --current option can only be used from within a worktree.",
+    );
+    strictEqual(exitMock.mock.calls[0].arguments[0], 2);
+  });
+
+  it("should error when both name and --current are provided", async () => {
+    exitMock = mock.fn();
+    consoleErrorMock = mock.fn();
+
+    mock.module("node:process", {
+      namedExports: {
+        exit: exitMock,
+      },
+    });
+
+    mock.module("../errors.ts", {
+      namedExports: {
+        exitCodes: {
+          generalError: 1,
+          validationError: 2,
+        },
+        exitWithError: mock.fn((message: string, code: number) => {
+          consoleErrorMock(`Error: ${message}`);
+          exitMock(code);
+        }),
+        exitWithSuccess: mock.fn(() => exitMock(0)),
+      },
+    });
+
+    const { deleteHandler } = await import("./delete.ts");
+    await deleteHandler(["feature", "--current"]);
+
+    strictEqual(consoleErrorMock.mock.calls.length, 1);
+    strictEqual(
+      consoleErrorMock.mock.calls[0].arguments[0],
+      "Error: Cannot specify both a worktree name and --current option",
+    );
+    strictEqual(exitMock.mock.calls[0].arguments[0], 2);
+  });
+
+  it("should error when no arguments are provided", async () => {
+    exitMock = mock.fn();
+    consoleErrorMock = mock.fn();
+
+    mock.module("node:process", {
+      namedExports: {
+        exit: exitMock,
+      },
+    });
+
+    mock.module("../errors.ts", {
+      namedExports: {
+        exitCodes: {
+          generalError: 1,
+          validationError: 2,
+        },
+        exitWithError: mock.fn((message: string, code: number) => {
+          consoleErrorMock(`Error: ${message}`);
+          exitMock(code);
+        }),
+        exitWithSuccess: mock.fn(() => exitMock(0)),
+      },
+    });
+
+    const { deleteHandler } = await import("./delete.ts");
+    await deleteHandler([]);
+
+    strictEqual(consoleErrorMock.mock.calls.length, 1);
+    strictEqual(
+      consoleErrorMock.mock.calls[0].arguments[0],
+      "Error: Please provide a worktree name to delete or use --current to delete the current worktree",
+    );
+    strictEqual(exitMock.mock.calls[0].arguments[0], 2);
+  });
+
+  it("should handle force deletion with --current", async () => {
+    exitMock = mock.fn();
+    consoleLogMock = mock.fn();
+    consoleErrorMock = mock.fn();
+    getGitRootMock = mock.fn(() => Promise.resolve("/test/repo"));
+    getCurrentWorktreeMock = mock.fn(() => Promise.resolve("feature"));
+    deleteWorktreeMock = mock.fn(() =>
+      Promise.resolve(
+        ok({
+          message:
+            "Warning: Worktree 'feature' had uncommitted changes (2 files)\nDeleted worktree 'feature' and its branch 'feature'",
+          hasUncommittedChanges: true,
+          changedFiles: 2,
+        }),
+      ),
+    );
+
+    mock.module("node:process", {
+      namedExports: {
+        exit: exitMock,
+      },
+    });
+
+    mock.module("../../core/git/libs/get-git-root.ts", {
+      namedExports: {
+        getGitRoot: getGitRootMock,
+      },
+    });
+
+    mock.module("../../core/git/libs/get-current-worktree.ts", {
+      namedExports: {
+        getCurrentWorktree: getCurrentWorktreeMock,
+      },
+    });
+
+    mock.module("../../core/worktree/delete.ts", {
+      namedExports: {
+        deleteWorktree: deleteWorktreeMock,
+      },
+    });
+
+    mock.module("../output.ts", {
+      namedExports: {
+        output: {
+          log: consoleLogMock,
+          error: consoleErrorMock,
+        },
+      },
+    });
+
+    mock.module("../errors.ts", {
+      namedExports: {
+        exitCodes: {
+          generalError: 1,
+          validationError: 2,
+        },
+        exitWithError: mock.fn((message: string, code: number) => {
+          consoleErrorMock(`Error: ${message}`);
+          exitMock(code);
+        }),
+        exitWithSuccess: mock.fn(() => exitMock(0)),
+      },
+    });
+
+    const { deleteHandler } = await import("./delete.ts");
+    await deleteHandler(["--current", "--force"]);
+
+    strictEqual(deleteWorktreeMock.mock.calls.length, 1);
+    const deleteOptions = deleteWorktreeMock.mock.calls[0].arguments[2] as { force: boolean };
+    strictEqual(deleteOptions.force, true);
+
+    strictEqual(consoleLogMock.mock.calls.length, 1);
+    strictEqual(exitMock.mock.calls[0].arguments[0], 0);
+  });
+
+  it("should handle worktree not found error", async () => {
+    exitMock = mock.fn();
+    consoleErrorMock = mock.fn();
+    getGitRootMock = mock.fn(() => Promise.resolve("/test/repo"));
+    deleteWorktreeMock = mock.fn(() =>
+      Promise.resolve(err(new WorktreeNotFoundError("feature"))),
+    );
+
+    mock.module("node:process", {
+      namedExports: {
+        exit: exitMock,
+      },
+    });
+
+    mock.module("../../core/git/libs/get-git-root.ts", {
+      namedExports: {
+        getGitRoot: getGitRootMock,
+      },
+    });
+
+    mock.module("../../core/worktree/delete.ts", {
+      namedExports: {
+        deleteWorktree: deleteWorktreeMock,
+      },
+    });
+
+    mock.module("../output.ts", {
+      namedExports: {
+        output: {
+          log: consoleLogMock,
+          error: consoleErrorMock,
+        },
+      },
+    });
+
+    mock.module("../errors.ts", {
+      namedExports: {
+        exitCodes: {
+          generalError: 1,
+          validationError: 2,
+        },
+        exitWithError: mock.fn((message: string, code: number) => {
+          consoleErrorMock(`Error: ${message}`);
+          exitMock(code);
+        }),
+        exitWithSuccess: mock.fn(() => exitMock(0)),
+      },
+    });
+
+    const { deleteHandler } = await import("./delete.ts");
+    await deleteHandler(["feature"]);
+
+    strictEqual(consoleErrorMock.mock.calls.length, 1);
+    strictEqual(
+      consoleErrorMock.mock.calls[0].arguments[0],
+      "Error: Worktree 'feature' not found",
+    );
+    strictEqual(exitMock.mock.calls[0].arguments[0], 2);
+  });
+});

--- a/src/cli/handlers/delete.ts
+++ b/src/cli/handlers/delete.ts
@@ -1,4 +1,5 @@
 import { parseArgs } from "node:util";
+import { getCurrentWorktree } from "../../core/git/libs/get-current-worktree.ts";
 import { getGitRoot } from "../../core/git/libs/get-git-root.ts";
 import { isErr } from "../../core/types/result.ts";
 import { deleteWorktree as deleteWorktreeCore } from "../../core/worktree/delete.ts";
@@ -17,23 +18,49 @@ export async function deleteHandler(args: string[]): Promise<void> {
         type: "boolean",
         short: "f",
       },
+      current: {
+        type: "boolean",
+      },
     },
     strict: true,
     allowPositionals: true,
   });
 
-  if (positionals.length === 0) {
+  const deleteCurrent = values.current ?? false;
+
+  if (positionals.length === 0 && !deleteCurrent) {
     exitWithError(
-      "Please provide a worktree name to delete",
+      "Please provide a worktree name to delete or use --current to delete the current worktree",
       exitCodes.validationError,
     );
   }
 
-  const worktreeName = positionals[0];
+  if (positionals.length > 0 && deleteCurrent) {
+    exitWithError(
+      "Cannot specify both a worktree name and --current option",
+      exitCodes.validationError,
+    );
+  }
+
   const forceDelete = values.force ?? false;
 
   try {
     const gitRoot = await getGitRoot();
+
+    let worktreeName: string;
+    if (deleteCurrent) {
+      const currentWorktree = await getCurrentWorktree(gitRoot);
+      if (!currentWorktree) {
+        exitWithError(
+          "Not in a worktree directory. The --current option can only be used from within a worktree.",
+          exitCodes.validationError,
+        );
+      }
+      worktreeName = currentWorktree;
+    } else {
+      worktreeName = positionals[0];
+    }
+
     const result = await deleteWorktreeCore(gitRoot, worktreeName, {
       force: forceDelete,
     });

--- a/src/core/git/libs/get-current-worktree.test.ts
+++ b/src/core/git/libs/get-current-worktree.test.ts
@@ -1,0 +1,134 @@
+import { strictEqual } from "node:assert";
+import { describe, it, mock } from "node:test";
+
+describe("getCurrentWorktree", () => {
+  it("should return null when in the main repository", async () => {
+    const gitRoot = "/path/to/repo";
+
+    mock.module("../executor.ts", {
+      namedExports: {
+        executeGitCommand: mock.fn(() =>
+          Promise.resolve({
+            stdout: gitRoot,
+            stderr: "",
+          }),
+        ),
+      },
+    });
+
+    mock.module("./list-worktrees.ts", {
+      namedExports: {
+        listWorktrees: mock.fn(() =>
+          Promise.resolve([
+            {
+              path: gitRoot,
+              branch: "main",
+              head: "abc123",
+              isLocked: false,
+              isPrunable: false,
+            },
+          ]),
+        ),
+      },
+    });
+
+    const { getCurrentWorktree } = await import("./get-current-worktree.ts");
+    const result = await getCurrentWorktree(gitRoot);
+    strictEqual(result, null);
+  });
+
+  it("should return the branch name when in a worktree", async () => {
+    const gitRoot = "/path/to/repo";
+    const worktreePath = "/path/to/repo/.git/phantom/worktrees/feature-branch";
+
+    mock.module("../executor.ts", {
+      namedExports: {
+        executeGitCommand: mock.fn(() =>
+          Promise.resolve({
+            stdout: `${worktreePath}\n`,
+            stderr: "",
+          }),
+        ),
+      },
+    });
+
+    mock.module("./list-worktrees.ts", {
+      namedExports: {
+        listWorktrees: mock.fn(() =>
+          Promise.resolve([
+            {
+              path: gitRoot,
+              branch: "main",
+              head: "abc123",
+              isLocked: false,
+              isPrunable: false,
+            },
+            {
+              path: worktreePath,
+              branch: "feature-branch",
+              head: "def456",
+              isLocked: false,
+              isPrunable: false,
+            },
+          ]),
+        ),
+      },
+    });
+
+    const { getCurrentWorktree } = await import("./get-current-worktree.ts");
+    const result = await getCurrentWorktree(gitRoot);
+    strictEqual(result, "feature-branch");
+  });
+
+  it("should return null when git command fails", async () => {
+    const gitRoot = "/path/to/repo";
+
+    mock.module("../executor.ts", {
+      namedExports: {
+        executeGitCommand: mock.fn(() =>
+          Promise.reject(new Error("Git error")),
+        ),
+      },
+    });
+
+    const { getCurrentWorktree } = await import("./get-current-worktree.ts");
+    const result = await getCurrentWorktree(gitRoot);
+    strictEqual(result, null);
+  });
+
+  it("should return null when worktree is not found in list", async () => {
+    const gitRoot = "/path/to/repo";
+    const unknownPath = "/some/other/path";
+
+    mock.module("../executor.ts", {
+      namedExports: {
+        executeGitCommand: mock.fn(() =>
+          Promise.resolve({
+            stdout: unknownPath,
+            stderr: "",
+          }),
+        ),
+      },
+    });
+
+    mock.module("./list-worktrees.ts", {
+      namedExports: {
+        listWorktrees: mock.fn(() =>
+          Promise.resolve([
+            {
+              path: gitRoot,
+              branch: "main",
+              head: "abc123",
+              isLocked: false,
+              isPrunable: false,
+            },
+          ]),
+        ),
+      },
+    });
+
+    const { getCurrentWorktree } = await import("./get-current-worktree.ts");
+    const result = await getCurrentWorktree(gitRoot);
+    strictEqual(result, null);
+  });
+});

--- a/src/core/git/libs/get-current-worktree.ts
+++ b/src/core/git/libs/get-current-worktree.ts
@@ -1,0 +1,29 @@
+import { executeGitCommand } from "../executor.ts";
+import { listWorktrees } from "./list-worktrees.ts";
+
+export async function getCurrentWorktree(
+  gitRoot: string,
+): Promise<string | null> {
+  try {
+    const { stdout: currentPath } = await executeGitCommand([
+      "rev-parse",
+      "--show-toplevel",
+    ]);
+
+    const currentPathTrimmed = currentPath.trim();
+
+    const worktrees = await listWorktrees(gitRoot);
+
+    const currentWorktree = worktrees.find(
+      (wt) => wt.path === currentPathTrimmed,
+    );
+
+    if (!currentWorktree || currentWorktree.path === gitRoot) {
+      return null;
+    }
+
+    return currentWorktree.branch;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds a `--current` option to the `phantom delete` command, allowing users to delete the worktree they're currently in without needing to know its name.

Closes #93

## Changes

- Added `getCurrentWorktree()` function that detects if the current directory is inside a worktree
- Updated the delete handler to support `--current` option
- Added comprehensive unit tests for the new functionality
- Updated documentation with usage examples

## Usage

```bash
# Delete the current worktree (must be inside a worktree)
phantom delete --current

# Force delete with uncommitted changes
phantom delete --current --force
```

## Implementation Details

The current worktree detection works by:
1. Using `git rev-parse --show-toplevel` to get the current git directory
2. Comparing it against the list of worktrees from `git worktree list`
3. Returning the branch name if it's a worktree, or null if it's the main repository

## Safety

- The `--current` option can only be used from within a worktree
- Cannot specify both a worktree name and `--current` option
- Requires explicit `--force` flag to delete worktrees with uncommitted changes

## Testing

All tests are passing:
- Unit tests for `getCurrentWorktree()` function
- Integration tests for the delete handler with various scenarios
- TypeScript type checking passes
- Linting passes