### PR TITLE
feat: Enhanced tmux integration for phantom

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -109,9 +109,16 @@ npm link
 ```bash
 # 対応するブランチを持つ新しいworktreeを作成
 phantom create <name>
+phantom create <name> --shell  # 作成してインタラクティブシェルに入る
+phantom create <name> --exec <command>  # 作成してコマンドを実行
+phantom create <name> --tmux  # 作成して新しいtmuxウィンドウで開く
+phantom create <name> --tmux vertical  # 作成してtmuxペインを縦に分割
+phantom create <name> --tmux horizontal  # 作成してtmuxペインを横に分割
 
 # 既存のブランチにworktreeとしてアタッチ
 phantom attach <branch-name>
+phantom attach <branch-name> --shell  # アタッチしてインタラクティブシェルに入る
+phantom attach <branch-name> --exec <command>  # アタッチしてコマンドを実行
 
 # すべてのworktreeとその現在のステータスをリスト表示
 phantom list

--- a/README.ja.md
+++ b/README.ja.md
@@ -112,8 +112,10 @@ phantom create <name>
 phantom create <name> --shell  # 作成してインタラクティブシェルに入る
 phantom create <name> --exec <command>  # 作成してコマンドを実行
 phantom create <name> --tmux  # 作成して新しいtmuxウィンドウで開く
-phantom create <name> --tmux vertical  # 作成してtmuxペインを縦に分割
-phantom create <name> --tmux horizontal  # 作成してtmuxペインを横に分割
+phantom create <name> --tmux-vertical  # 作成してtmuxペインを縦に分割
+phantom create <name> --tmux-v  # --tmux-verticalの短縮形
+phantom create <name> --tmux-horizontal  # 作成してtmuxペインを横に分割
+phantom create <name> --tmux-h  # --tmux-horizontalの短縮形
 
 # 既存のブランチにworktreeとしてアタッチ
 phantom attach <branch-name>

--- a/README.md
+++ b/README.md
@@ -112,8 +112,10 @@ phantom create <name>
 phantom create <name> --shell  # Create and enter interactive shell
 phantom create <name> --exec <command>  # Create and execute command
 phantom create <name> --tmux  # Create and open in new tmux window
-phantom create <name> --tmux vertical  # Create and split tmux pane vertically
-phantom create <name> --tmux horizontal  # Create and split tmux pane horizontally
+phantom create <name> --tmux-vertical  # Create and split tmux pane vertically
+phantom create <name> --tmux-v  # Shorthand for --tmux-vertical
+phantom create <name> --tmux-horizontal  # Create and split tmux pane horizontally
+phantom create <name> --tmux-h  # Shorthand for --tmux-horizontal
 
 # Attach to an existing branch as a worktree
 phantom attach <branch-name>

--- a/README.md
+++ b/README.md
@@ -109,9 +109,16 @@ npm link
 ```bash
 # Create a new worktree with a matching branch
 phantom create <name>
+phantom create <name> --shell  # Create and enter interactive shell
+phantom create <name> --exec <command>  # Create and execute command
+phantom create <name> --tmux  # Create and open in new tmux window
+phantom create <name> --tmux vertical  # Create and split tmux pane vertically
+phantom create <name> --tmux horizontal  # Create and split tmux pane horizontally
 
 # Attach to an existing branch as a worktree
 phantom attach <branch-name>
+phantom attach <branch-name> --shell  # Attach and enter interactive shell
+phantom attach <branch-name> --exec <command>  # Attach and execute command
 
 # List all worktrees with their current status
 phantom list

--- a/src/bin/phantom.ts
+++ b/src/bin/phantom.ts
@@ -21,7 +21,7 @@ const commands: Command[] = [
   {
     name: "create",
     description:
-      "Create a new worktree [--shell | --exec <command> | --tmux [new|vertical|horizontal]]",
+      "Create a new worktree [--shell | --exec <command> | --tmux | --tmux-vertical | --tmux-horizontal]",
     handler: createHandler,
   },
   {

--- a/src/bin/phantom.ts
+++ b/src/bin/phantom.ts
@@ -20,7 +20,8 @@ interface Command {
 const commands: Command[] = [
   {
     name: "create",
-    description: "Create a new worktree [--shell | --exec <command>]",
+    description:
+      "Create a new worktree [--shell | --exec <command> | --tmux [new|vertical|horizontal]]",
     handler: createHandler,
   },
   {

--- a/src/cli/handlers/create.test.ts
+++ b/src/cli/handlers/create.test.ts
@@ -267,4 +267,261 @@ describe("createHandler", () => {
     const execArgs = execInWorktreeMock.mock.calls[0].arguments[2] as string[];
     strictEqual(execArgs[0], "/bin/sh");
   });
+
+  it("should error when --tmux is used outside tmux session", async () => {
+    exitMock = mock.fn();
+    consoleErrorMock = mock.fn();
+
+    mock.module("node:process", {
+      namedExports: {
+        exit: exitMock,
+        env: {},
+      },
+    });
+
+    mock.module("../../core/process/tmux.ts", {
+      namedExports: {
+        isInsideTmux: mock.fn(() => Promise.resolve(false)),
+        parseTmuxDirection: mock.fn(),
+        executeTmuxCommand: mock.fn(),
+      },
+    });
+
+    mock.module("../errors.ts", {
+      namedExports: {
+        exitCodes: {
+          generalError: 1,
+          validationError: 2,
+        },
+        exitWithError: mock.fn((message: string, code: number) => {
+          consoleErrorMock(`Error: ${message}`);
+          exitMock(code);
+        }),
+        exitWithSuccess: mock.fn(() => exitMock(0)),
+      },
+    });
+
+    const { createHandler } = await import("./create.ts");
+    await createHandler(["feature", "--tmux"]);
+
+    strictEqual(consoleErrorMock.mock.calls.length, 1);
+    strictEqual(
+      consoleErrorMock.mock.calls[0].arguments[0],
+      "Error: The --tmux option can only be used inside a tmux session",
+    );
+    strictEqual(exitMock.mock.calls[0].arguments[0], 2);
+  });
+
+  it("should create worktree and open in tmux window", async () => {
+    exitMock = mock.fn();
+    consoleLogMock = mock.fn();
+    getGitRootMock = mock.fn(() => Promise.resolve("/test/repo"));
+    createWorktreeMock = mock.fn(() =>
+      Promise.resolve(
+        ok({
+          message:
+            "Created worktree 'feature' at /test/repo/.git/phantom/worktrees/feature",
+          path: "/test/repo/.git/phantom/worktrees/feature",
+        }),
+      ),
+    );
+    const executeTmuxCommandMock = mock.fn(() =>
+      Promise.resolve(ok({ exitCode: 0 })),
+    );
+
+    mock.module("node:process", {
+      namedExports: {
+        exit: exitMock,
+        env: { SHELL: "/bin/bash", TMUX: "/tmp/tmux-1000/default,12345,0" },
+      },
+    });
+
+    mock.module("../../core/git/libs/get-git-root.ts", {
+      namedExports: {
+        getGitRoot: getGitRootMock,
+      },
+    });
+
+    mock.module("../../core/worktree/create.ts", {
+      namedExports: {
+        createWorktree: createWorktreeMock,
+      },
+    });
+
+    mock.module("../../core/process/tmux.ts", {
+      namedExports: {
+        isInsideTmux: mock.fn(() => Promise.resolve(true)),
+        parseTmuxDirection: mock.fn((value) =>
+          value === "" || value === true ? "new" : value,
+        ),
+        executeTmuxCommand: executeTmuxCommandMock,
+      },
+    });
+
+    mock.module("../output.ts", {
+      namedExports: {
+        output: {
+          log: consoleLogMock,
+          error: consoleErrorMock,
+        },
+      },
+    });
+
+    mock.module("../errors.ts", {
+      namedExports: {
+        exitCodes: {
+          generalError: 1,
+          validationError: 2,
+        },
+        exitWithError: mock.fn(),
+        exitWithSuccess: mock.fn(() => exitMock(0)),
+      },
+    });
+
+    const { createHandler } = await import("./create.ts");
+    await createHandler(["feature", "--tmux"]);
+
+    strictEqual(createWorktreeMock.mock.calls.length, 1);
+    strictEqual(executeTmuxCommandMock.mock.calls.length, 1);
+
+    // Verify tmux command was called with correct arguments
+    // biome-ignore lint/suspicious/noExplicitAny: Mock type inference issue
+    const tmuxArgs = (executeTmuxCommandMock.mock.calls[0] as any).arguments[0];
+    strictEqual(tmuxArgs.direction, "new");
+    strictEqual(tmuxArgs.cwd, "/test/repo/.git/phantom/worktrees/feature");
+
+    strictEqual(
+      consoleLogMock.mock.calls[0].arguments[0],
+      "Created worktree 'feature' at /test/repo/.git/phantom/worktrees/feature",
+    );
+    strictEqual(
+      consoleLogMock.mock.calls[1].arguments[0],
+      "\nOpening worktree 'feature' in tmux window...",
+    );
+
+    strictEqual(exitMock.mock.calls[0].arguments[0], 0);
+  });
+
+  it("should create worktree and open in tmux pane with vertical split", async () => {
+    exitMock = mock.fn();
+    consoleLogMock = mock.fn();
+    getGitRootMock = mock.fn(() => Promise.resolve("/test/repo"));
+    createWorktreeMock = mock.fn(() =>
+      Promise.resolve(
+        ok({
+          message:
+            "Created worktree 'feature' at /test/repo/.git/phantom/worktrees/feature",
+          path: "/test/repo/.git/phantom/worktrees/feature",
+        }),
+      ),
+    );
+    const executeTmuxCommandMock = mock.fn(() =>
+      Promise.resolve(ok({ exitCode: 0 })),
+    );
+
+    mock.module("node:process", {
+      namedExports: {
+        exit: exitMock,
+        env: { SHELL: "/bin/bash", TMUX: "/tmp/tmux-1000/default,12345,0" },
+      },
+    });
+
+    mock.module("../../core/git/libs/get-git-root.ts", {
+      namedExports: {
+        getGitRoot: getGitRootMock,
+      },
+    });
+
+    mock.module("../../core/worktree/create.ts", {
+      namedExports: {
+        createWorktree: createWorktreeMock,
+      },
+    });
+
+    mock.module("../../core/process/tmux.ts", {
+      namedExports: {
+        isInsideTmux: mock.fn(() => Promise.resolve(true)),
+        parseTmuxDirection: mock.fn((value) => value),
+        executeTmuxCommand: executeTmuxCommandMock,
+      },
+    });
+
+    mock.module("../output.ts", {
+      namedExports: {
+        output: {
+          log: consoleLogMock,
+          error: consoleErrorMock,
+        },
+      },
+    });
+
+    mock.module("../errors.ts", {
+      namedExports: {
+        exitCodes: {
+          generalError: 1,
+          validationError: 2,
+        },
+        exitWithError: mock.fn(),
+        exitWithSuccess: mock.fn(() => exitMock(0)),
+      },
+    });
+
+    const { createHandler } = await import("./create.ts");
+    await createHandler(["feature", "--tmux", "vertical"]);
+
+    strictEqual(createWorktreeMock.mock.calls.length, 1);
+    strictEqual(executeTmuxCommandMock.mock.calls.length, 1);
+
+    // Verify tmux command was called with correct arguments
+    // biome-ignore lint/suspicious/noExplicitAny: Mock type inference issue
+    const tmuxArgs = (executeTmuxCommandMock.mock.calls[0] as any).arguments[0];
+    strictEqual(tmuxArgs.direction, "vertical");
+    strictEqual(tmuxArgs.cwd, "/test/repo/.git/phantom/worktrees/feature");
+
+    strictEqual(
+      consoleLogMock.mock.calls[0].arguments[0],
+      "Created worktree 'feature' at /test/repo/.git/phantom/worktrees/feature",
+    );
+    strictEqual(
+      consoleLogMock.mock.calls[1].arguments[0],
+      "\nOpening worktree 'feature' in tmux pane...",
+    );
+
+    strictEqual(exitMock.mock.calls[0].arguments[0], 0);
+  });
+
+  it("should error when multiple action options are used together", async () => {
+    exitMock = mock.fn();
+    consoleErrorMock = mock.fn();
+
+    mock.module("node:process", {
+      namedExports: {
+        exit: exitMock,
+      },
+    });
+
+    mock.module("../errors.ts", {
+      namedExports: {
+        exitCodes: {
+          generalError: 1,
+          validationError: 2,
+        },
+        exitWithError: mock.fn((message: string, code: number) => {
+          consoleErrorMock(`Error: ${message}`);
+          exitMock(code);
+        }),
+        exitWithSuccess: mock.fn(() => exitMock(0)),
+      },
+    });
+
+    const { createHandler } = await import("./create.ts");
+    await createHandler(["feature", "--shell", "--tmux"]);
+
+    strictEqual(consoleErrorMock.mock.calls.length, 1);
+    strictEqual(
+      consoleErrorMock.mock.calls[0].arguments[0],
+      "Error: Cannot use --shell, --exec, and --tmux options together",
+    );
+    strictEqual(exitMock.mock.calls[0].arguments[0], 2);
+  });
 });

--- a/src/cli/handlers/create.test.ts
+++ b/src/cli/handlers/create.test.ts
@@ -282,7 +282,6 @@ describe("createHandler", () => {
     mock.module("../../core/process/tmux.ts", {
       namedExports: {
         isInsideTmux: mock.fn(() => Promise.resolve(false)),
-        parseTmuxDirection: mock.fn(),
         executeTmuxCommand: mock.fn(),
       },
     });
@@ -351,9 +350,6 @@ describe("createHandler", () => {
     mock.module("../../core/process/tmux.ts", {
       namedExports: {
         isInsideTmux: mock.fn(() => Promise.resolve(true)),
-        parseTmuxDirection: mock.fn((value) =>
-          value === "" || value === true ? "new" : value,
-        ),
         executeTmuxCommand: executeTmuxCommandMock,
       },
     });
@@ -441,7 +437,6 @@ describe("createHandler", () => {
     mock.module("../../core/process/tmux.ts", {
       namedExports: {
         isInsideTmux: mock.fn(() => Promise.resolve(true)),
-        parseTmuxDirection: mock.fn((value) => value),
         executeTmuxCommand: executeTmuxCommandMock,
       },
     });
@@ -467,7 +462,7 @@ describe("createHandler", () => {
     });
 
     const { createHandler } = await import("./create.ts");
-    await createHandler(["feature", "--tmux", "vertical"]);
+    await createHandler(["feature", "--tmux-vertical"]);
 
     strictEqual(createWorktreeMock.mock.calls.length, 1);
     strictEqual(executeTmuxCommandMock.mock.calls.length, 1);

--- a/src/cli/handlers/create.ts
+++ b/src/cli/handlers/create.ts
@@ -2,11 +2,7 @@ import { parseArgs } from "node:util";
 import { getGitRoot } from "../../core/git/libs/get-git-root.ts";
 import { execInWorktree } from "../../core/process/exec.ts";
 import { shellInWorktree } from "../../core/process/shell.ts";
-import {
-  buildWorktreeShellCommand,
-  executeTmuxCommand,
-  isInsideTmux,
-} from "../../core/process/tmux.ts";
+import { executeTmuxCommand, isInsideTmux } from "../../core/process/tmux.ts";
 import { isErr, isOk } from "../../core/types/result.ts";
 import { createWorktree as createWorktreeCore } from "../../core/worktree/create.ts";
 import { WorktreeAlreadyExistsError } from "../../core/worktree/errors.ts";
@@ -154,15 +150,17 @@ export async function createHandler(args: string[]): Promise<void> {
         `\nOpening worktree '${worktreeName}' in tmux ${tmuxDirection === "new" ? "window" : "pane"}...`,
       );
 
-      const command = buildWorktreeShellCommand(
-        result.value.path,
-        worktreeName,
-      );
+      const shell = process.env.SHELL || "/bin/sh";
 
       const tmuxResult = await executeTmuxCommand({
         direction: tmuxDirection,
-        command,
+        command: shell,
         cwd: result.value.path,
+        env: {
+          PHANTOM: "1",
+          PHANTOM_NAME: worktreeName,
+          PHANTOM_PATH: result.value.path,
+        },
       });
 
       if (isErr(tmuxResult)) {

--- a/src/core/process/tmux.test.ts
+++ b/src/core/process/tmux.test.ts
@@ -1,6 +1,6 @@
 import { strictEqual } from "node:assert";
 import { describe, it } from "node:test";
-import { buildWorktreeShellCommand, isInsideTmux } from "./tmux.ts";
+import { isInsideTmux } from "./tmux.ts";
 
 describe("tmux", () => {
   describe("isInsideTmux", () => {
@@ -30,56 +30,6 @@ describe("tmux", () => {
       if (originalTmux !== undefined) {
         process.env.TMUX = originalTmux;
       }
-    });
-  });
-
-  describe("buildWorktreeShellCommand", () => {
-    it("should build correct command with default shell", () => {
-      const originalShell = process.env.SHELL;
-      process.env.SHELL = "/bin/bash";
-
-      const command = buildWorktreeShellCommand(
-        "/path/to/worktree",
-        "feature-branch",
-      );
-
-      strictEqual(
-        command,
-        "/bin/bash -c 'PHANTOM=1 PHANTOM_NAME=feature-branch PHANTOM_PATH=/path/to/worktree exec /bin/bash'",
-      );
-
-      if (originalShell === undefined) {
-        // biome-ignore lint/performance/noDelete: Need to actually remove env var for test
-        delete process.env.SHELL;
-      } else {
-        process.env.SHELL = originalShell;
-      }
-    });
-
-    it("should use custom shell when provided", () => {
-      const command = buildWorktreeShellCommand(
-        "/path/to/worktree",
-        "feature-branch",
-        "/usr/bin/zsh",
-      );
-
-      strictEqual(
-        command,
-        "/usr/bin/zsh -c 'PHANTOM=1 PHANTOM_NAME=feature-branch PHANTOM_PATH=/path/to/worktree exec /usr/bin/zsh'",
-      );
-    });
-
-    it("should handle paths with spaces", () => {
-      const command = buildWorktreeShellCommand(
-        "/path with spaces/worktree",
-        "feature branch",
-        "/bin/sh",
-      );
-
-      strictEqual(
-        command,
-        '/bin/sh -c \'PHANTOM=1 PHANTOM_NAME="feature branch" PHANTOM_PATH="/path with spaces/worktree" exec /bin/sh\'',
-      );
     });
   });
 });

--- a/src/core/process/tmux.test.ts
+++ b/src/core/process/tmux.test.ts
@@ -1,6 +1,6 @@
 import { strictEqual } from "node:assert";
 import { describe, it } from "node:test";
-import { isInsideTmux, parseTmuxDirection } from "./tmux.ts";
+import { isInsideTmux } from "./tmux.ts";
 
 describe("tmux", () => {
   describe("isInsideTmux", () => {
@@ -30,37 +30,6 @@ describe("tmux", () => {
       if (originalTmux !== undefined) {
         process.env.TMUX = originalTmux;
       }
-    });
-  });
-
-  describe("parseTmuxDirection", () => {
-    it("should parse valid directions", () => {
-      strictEqual(parseTmuxDirection("new"), "new");
-      strictEqual(parseTmuxDirection("vertical"), "vertical");
-      strictEqual(parseTmuxDirection("horizontal"), "horizontal");
-      strictEqual(parseTmuxDirection("v"), "v");
-      strictEqual(parseTmuxDirection("h"), "h");
-    });
-
-    it("should return 'new' for boolean true", () => {
-      strictEqual(parseTmuxDirection(true), "new");
-    });
-
-    it("should return 'new' for empty string", () => {
-      strictEqual(parseTmuxDirection(""), "new");
-    });
-
-    it("should return 'new' for invalid values", () => {
-      strictEqual(parseTmuxDirection("invalid"), "new");
-      strictEqual(parseTmuxDirection("diagonal"), "new");
-    });
-
-    it("should be case insensitive", () => {
-      strictEqual(parseTmuxDirection("NEW"), "new");
-      strictEqual(parseTmuxDirection("Vertical"), "vertical");
-      strictEqual(parseTmuxDirection("HORIZONTAL"), "horizontal");
-      strictEqual(parseTmuxDirection("V"), "v");
-      strictEqual(parseTmuxDirection("H"), "h");
     });
   });
 });

--- a/src/core/process/tmux.test.ts
+++ b/src/core/process/tmux.test.ts
@@ -45,7 +45,7 @@ describe("tmux", () => {
 
       strictEqual(
         command,
-        "/bin/bash -c 'PHANTOM=1 && PHANTOM_NAME=feature-branch && PHANTOM_PATH=/path/to/worktree && exec /bin/bash'",
+        "/bin/bash -c 'PHANTOM=1 PHANTOM_NAME=feature-branch PHANTOM_PATH=/path/to/worktree exec /bin/bash'",
       );
 
       if (originalShell === undefined) {
@@ -65,7 +65,7 @@ describe("tmux", () => {
 
       strictEqual(
         command,
-        "/usr/bin/zsh -c 'PHANTOM=1 && PHANTOM_NAME=feature-branch && PHANTOM_PATH=/path/to/worktree && exec /usr/bin/zsh'",
+        "/usr/bin/zsh -c 'PHANTOM=1 PHANTOM_NAME=feature-branch PHANTOM_PATH=/path/to/worktree exec /usr/bin/zsh'",
       );
     });
 
@@ -78,7 +78,7 @@ describe("tmux", () => {
 
       strictEqual(
         command,
-        "/bin/sh -c 'PHANTOM=1 && PHANTOM_NAME=feature branch && PHANTOM_PATH=/path with spaces/worktree && exec /bin/sh'",
+        '/bin/sh -c \'PHANTOM=1 PHANTOM_NAME="feature branch" PHANTOM_PATH="/path with spaces/worktree" exec /bin/sh\'',
       );
     });
   });

--- a/src/core/process/tmux.test.ts
+++ b/src/core/process/tmux.test.ts
@@ -1,0 +1,66 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { isInsideTmux, parseTmuxDirection } from "./tmux.ts";
+
+describe("tmux", () => {
+  describe("isInsideTmux", () => {
+    it("should return true when TMUX env var is set", async () => {
+      const originalTmux = process.env.TMUX;
+      process.env.TMUX = "/tmp/tmux-1000/default,12345,0";
+
+      const result = await isInsideTmux();
+      strictEqual(result, true);
+
+      if (originalTmux === undefined) {
+        // biome-ignore lint/performance/noDelete: Need to actually remove env var for test
+        delete process.env.TMUX;
+      } else {
+        process.env.TMUX = originalTmux;
+      }
+    });
+
+    it("should return false when TMUX env var is not set", async () => {
+      const originalTmux = process.env.TMUX;
+      // biome-ignore lint/performance/noDelete: Need to actually remove env var for test
+      delete process.env.TMUX;
+
+      const result = await isInsideTmux();
+      strictEqual(result, false);
+
+      if (originalTmux !== undefined) {
+        process.env.TMUX = originalTmux;
+      }
+    });
+  });
+
+  describe("parseTmuxDirection", () => {
+    it("should parse valid directions", () => {
+      strictEqual(parseTmuxDirection("new"), "new");
+      strictEqual(parseTmuxDirection("vertical"), "vertical");
+      strictEqual(parseTmuxDirection("horizontal"), "horizontal");
+      strictEqual(parseTmuxDirection("v"), "v");
+      strictEqual(parseTmuxDirection("h"), "h");
+    });
+
+    it("should return 'new' for boolean true", () => {
+      strictEqual(parseTmuxDirection(true), "new");
+    });
+
+    it("should return 'new' for empty string", () => {
+      strictEqual(parseTmuxDirection(""), "new");
+    });
+
+    it("should return 'new' for invalid values", () => {
+      strictEqual(parseTmuxDirection("invalid"), "new");
+      strictEqual(parseTmuxDirection("diagonal"), "new");
+    });
+
+    it("should be case insensitive", () => {
+      strictEqual(parseTmuxDirection("NEW"), "new");
+      strictEqual(parseTmuxDirection("Vertical"), "vertical");
+      strictEqual(parseTmuxDirection("HORIZONTAL"), "horizontal");
+      strictEqual(parseTmuxDirection("V"), "v");
+      strictEqual(parseTmuxDirection("H"), "h");
+    });
+  });
+});

--- a/src/core/process/tmux.test.ts
+++ b/src/core/process/tmux.test.ts
@@ -45,7 +45,7 @@ describe("tmux", () => {
 
       strictEqual(
         command,
-        "/bin/bash -c 'cd /path/to/worktree && PHANTOM=1 && PHANTOM_NAME=feature-branch && PHANTOM_PATH=/path/to/worktree && exec /bin/bash'",
+        "/bin/bash -c 'PHANTOM=1 && PHANTOM_NAME=feature-branch && PHANTOM_PATH=/path/to/worktree && exec /bin/bash'",
       );
 
       if (originalShell === undefined) {
@@ -65,7 +65,7 @@ describe("tmux", () => {
 
       strictEqual(
         command,
-        "/usr/bin/zsh -c 'cd /path/to/worktree && PHANTOM=1 && PHANTOM_NAME=feature-branch && PHANTOM_PATH=/path/to/worktree && exec /usr/bin/zsh'",
+        "/usr/bin/zsh -c 'PHANTOM=1 && PHANTOM_NAME=feature-branch && PHANTOM_PATH=/path/to/worktree && exec /usr/bin/zsh'",
       );
     });
 
@@ -78,7 +78,7 @@ describe("tmux", () => {
 
       strictEqual(
         command,
-        "/bin/sh -c 'cd /path with spaces/worktree && PHANTOM=1 && PHANTOM_NAME=feature branch && PHANTOM_PATH=/path with spaces/worktree && exec /bin/sh'",
+        "/bin/sh -c 'PHANTOM=1 && PHANTOM_NAME=feature branch && PHANTOM_PATH=/path with spaces/worktree && exec /bin/sh'",
       );
     });
   });

--- a/src/core/process/tmux.ts
+++ b/src/core/process/tmux.ts
@@ -22,7 +22,6 @@ export function buildWorktreeShellCommand(
   shell: string = process.env.SHELL || "/bin/sh",
 ): string {
   const envVars = [
-    `cd ${worktreePath}`,
     "PHANTOM=1",
     `PHANTOM_NAME=${worktreeName}`,
     `PHANTOM_PATH=${worktreePath}`,

--- a/src/core/process/tmux.ts
+++ b/src/core/process/tmux.ts
@@ -1,0 +1,70 @@
+import type { Result } from "../types/result.ts";
+import type { ProcessError } from "./errors.ts";
+import { type SpawnSuccess, spawnProcess } from "./spawn.ts";
+
+export type TmuxSplitDirection = "new" | "vertical" | "horizontal" | "v" | "h";
+
+export interface TmuxOptions {
+  direction: TmuxSplitDirection;
+  command: string;
+  cwd?: string;
+}
+
+export type TmuxSuccess = SpawnSuccess;
+
+export async function isInsideTmux(): Promise<boolean> {
+  return process.env.TMUX !== undefined;
+}
+
+export async function executeTmuxCommand(
+  options: TmuxOptions,
+): Promise<Result<TmuxSuccess, ProcessError>> {
+  const { direction, command, cwd } = options;
+
+  const tmuxArgs: string[] = [];
+
+  switch (direction) {
+    case "new":
+      tmuxArgs.push("new-window");
+      break;
+    case "vertical":
+    case "v":
+      tmuxArgs.push("split-window", "-v");
+      break;
+    case "horizontal":
+    case "h":
+      tmuxArgs.push("split-window", "-h");
+      break;
+    default:
+      tmuxArgs.push("new-window");
+  }
+
+  if (cwd) {
+    tmuxArgs.push("-c", cwd);
+  }
+
+  tmuxArgs.push(command);
+
+  const result = await spawnProcess({
+    command: "tmux",
+    args: tmuxArgs,
+  });
+
+  return result;
+}
+
+export function parseTmuxDirection(
+  value: string | boolean,
+): TmuxSplitDirection {
+  if (value === true || value === "") {
+    return "new";
+  }
+
+  const normalized = typeof value === "string" ? value.toLowerCase() : "new";
+
+  if (["new", "vertical", "horizontal", "v", "h"].includes(normalized)) {
+    return normalized as TmuxSplitDirection;
+  }
+
+  return "new";
+}

--- a/src/core/process/tmux.ts
+++ b/src/core/process/tmux.ts
@@ -16,6 +16,22 @@ export async function isInsideTmux(): Promise<boolean> {
   return process.env.TMUX !== undefined;
 }
 
+export function buildWorktreeShellCommand(
+  worktreePath: string,
+  worktreeName: string,
+  shell: string = process.env.SHELL || "/bin/sh",
+): string {
+  const envVars = [
+    `cd ${worktreePath}`,
+    "PHANTOM=1",
+    `PHANTOM_NAME=${worktreeName}`,
+    `PHANTOM_PATH=${worktreePath}`,
+    `exec ${shell}`,
+  ].join(" && ");
+
+  return `${shell} -c '${envVars}'`;
+}
+
 export async function executeTmuxCommand(
   options: TmuxOptions,
 ): Promise<Result<TmuxSuccess, ProcessError>> {

--- a/src/core/process/tmux.ts
+++ b/src/core/process/tmux.ts
@@ -2,7 +2,7 @@ import type { Result } from "../types/result.ts";
 import type { ProcessError } from "./errors.ts";
 import { type SpawnSuccess, spawnProcess } from "./spawn.ts";
 
-export type TmuxSplitDirection = "new" | "vertical" | "horizontal" | "v" | "h";
+export type TmuxSplitDirection = "new" | "vertical" | "horizontal";
 
 export interface TmuxOptions {
   direction: TmuxSplitDirection;
@@ -28,15 +28,11 @@ export async function executeTmuxCommand(
       tmuxArgs.push("new-window");
       break;
     case "vertical":
-    case "v":
       tmuxArgs.push("split-window", "-v");
       break;
     case "horizontal":
-    case "h":
       tmuxArgs.push("split-window", "-h");
       break;
-    default:
-      tmuxArgs.push("new-window");
   }
 
   if (cwd) {
@@ -51,20 +47,4 @@ export async function executeTmuxCommand(
   });
 
   return result;
-}
-
-export function parseTmuxDirection(
-  value: string | boolean,
-): TmuxSplitDirection {
-  if (value === true || value === "") {
-    return "new";
-  }
-
-  const normalized = typeof value === "string" ? value.toLowerCase() : "new";
-
-  if (["new", "vertical", "horizontal", "v", "h"].includes(normalized)) {
-    return normalized as TmuxSplitDirection;
-  }
-
-  return "new";
 }

--- a/src/core/process/tmux.ts
+++ b/src/core/process/tmux.ts
@@ -21,14 +21,18 @@ export function buildWorktreeShellCommand(
   worktreeName: string,
   shell: string = process.env.SHELL || "/bin/sh",
 ): string {
-  const envVars = [
-    "PHANTOM=1",
-    `PHANTOM_NAME=${worktreeName}`,
-    `PHANTOM_PATH=${worktreePath}`,
-    `exec ${shell}`,
-  ].join(" && ");
+  // Quote values that may contain spaces
+  const quotedName = worktreeName.includes(" ")
+    ? `"${worktreeName}"`
+    : worktreeName;
+  const quotedPath = worktreePath.includes(" ")
+    ? `"${worktreePath}"`
+    : worktreePath;
 
-  return `${shell} -c '${envVars}'`;
+  // Set environment variables and execute the shell
+  const command = `PHANTOM=1 PHANTOM_NAME=${quotedName} PHANTOM_PATH=${quotedPath} exec ${shell}`;
+
+  return `${shell} -c '${command}'`;
 }
 
 export async function executeTmuxCommand(


### PR DESCRIPTION
## Summary
This PR implements enhanced tmux integration for the `phantom create` command, allowing users to create worktrees and automatically open them in tmux windows or panes.

Closes #55

## Features
- Added tmux options to `phantom create` command:
  - `--tmux`: Creates worktree and opens in new tmux window
  - `--tmux-vertical` or `--tmux-v`: Creates worktree and splits tmux pane vertically  
  - `--tmux-horizontal` or `--tmux-h`: Creates worktree and splits tmux pane horizontally

## Implementation Details
- Created new `src/core/process/tmux.ts` module with:
  - `isInsideTmux()`: Checks if running inside tmux session
  - `executeTmuxCommand()`: Executes tmux commands with proper arguments and environment variables
- Updated `create` command handler to support tmux options
- Added validation to ensure tmux options only work inside tmux sessions
- Prevents using `--tmux` with `--shell` or `--exec` options
- Uses tmux's `-e` flag to safely pass environment variables, preventing command injection

## Security Improvements
- Removed string-based command building that had potential command injection vulnerabilities
- Environment variables (PHANTOM, PHANTOM_NAME, PHANTOM_PATH) are now passed using tmux's `-e` flag
- This approach completely avoids shell metacharacter issues

## Testing
- Added comprehensive tests for tmux functionality
- Added tests for create command with various tmux options
- All existing tests continue to pass

## Documentation
- Updated README.md with tmux option documentation
- Updated README.ja.md with Japanese translation
- Updated CLI help text

## Example Usage
```bash
# Create worktree and open in new tmux window
phantom create feature-branch --tmux

# Create worktree and split current pane vertically
phantom create bugfix --tmux-vertical
phantom create bugfix --tmux-v  # short form

# Create worktree and split current pane horizontally  
phantom create hotfix --tmux-horizontal
phantom create hotfix --tmux-h  # short form
```