### PR TITLE
feat: add validation for phantom.config.json content

### DIFF
--- a/src/core/config/validate.test.ts
+++ b/src/core/config/validate.test.ts
@@ -1,0 +1,370 @@
+import assert from "node:assert";
+import { describe, test } from "node:test";
+import { isErr, isOk } from "../types/result.ts";
+import { ConfigValidationError, validateConfig } from "./validate.ts";
+
+describe("validateConfig", () => {
+  test("should accept valid config with postCreate and copyFiles", () => {
+    const config = {
+      postCreate: {
+        copyFiles: [".env", "config.local.json"],
+      },
+    };
+
+    const result = validateConfig(config);
+
+    assert.strictEqual(isOk(result), true);
+    if (isOk(result)) {
+      assert.deepStrictEqual(result.value, config);
+    }
+  });
+
+  test("should accept empty config object", () => {
+    const config = {};
+
+    const result = validateConfig(config);
+
+    assert.strictEqual(isOk(result), true);
+    if (isOk(result)) {
+      assert.deepStrictEqual(result.value, config);
+    }
+  });
+
+  test("should accept config with empty postCreate", () => {
+    const config = {
+      postCreate: {},
+    };
+
+    const result = validateConfig(config);
+
+    assert.strictEqual(isOk(result), true);
+    if (isOk(result)) {
+      assert.deepStrictEqual(result.value, config);
+    }
+  });
+
+  test("should accept config with empty copyFiles array", () => {
+    const config = {
+      postCreate: {
+        copyFiles: [],
+      },
+    };
+
+    const result = validateConfig(config);
+
+    assert.strictEqual(isOk(result), true);
+    if (isOk(result)) {
+      assert.deepStrictEqual(result.value, config);
+    }
+  });
+
+  describe("error cases", () => {
+    test("should reject string config", () => {
+      const result = validateConfig("not an object");
+
+      assert.strictEqual(isErr(result), true);
+      if (isErr(result)) {
+        assert.ok(result.error instanceof ConfigValidationError);
+        assert.strictEqual(
+          result.error.message,
+          "Invalid phantom.config.json: Configuration must be an object",
+        );
+      }
+    });
+
+    test("should reject number config", () => {
+      const result = validateConfig(123);
+
+      assert.strictEqual(isErr(result), true);
+      if (isErr(result)) {
+        assert.ok(result.error instanceof ConfigValidationError);
+        assert.strictEqual(
+          result.error.message,
+          "Invalid phantom.config.json: Configuration must be an object",
+        );
+      }
+    });
+
+    test("should reject boolean config", () => {
+      const result = validateConfig(true);
+
+      assert.strictEqual(isErr(result), true);
+      if (isErr(result)) {
+        assert.ok(result.error instanceof ConfigValidationError);
+        assert.strictEqual(
+          result.error.message,
+          "Invalid phantom.config.json: Configuration must be an object",
+        );
+      }
+    });
+
+    test("should reject null config", () => {
+      const result = validateConfig(null);
+
+      assert.strictEqual(isErr(result), true);
+      if (isErr(result)) {
+        assert.ok(result.error instanceof ConfigValidationError);
+        assert.strictEqual(
+          result.error.message,
+          "Invalid phantom.config.json: Configuration must be an object",
+        );
+      }
+    });
+
+    test("should reject undefined config", () => {
+      const result = validateConfig(undefined);
+
+      assert.strictEqual(isErr(result), true);
+      if (isErr(result)) {
+        assert.ok(result.error instanceof ConfigValidationError);
+        assert.strictEqual(
+          result.error.message,
+          "Invalid phantom.config.json: Configuration must be an object",
+        );
+      }
+    });
+
+    test("should reject array config", () => {
+      const result = validateConfig([]);
+
+      assert.strictEqual(isErr(result), true);
+      if (isErr(result)) {
+        assert.ok(result.error instanceof ConfigValidationError);
+        assert.strictEqual(
+          result.error.message,
+          "Invalid phantom.config.json: Configuration must be an object",
+        );
+      }
+    });
+
+    test("should reject when postCreate is string", () => {
+      const result = validateConfig({ postCreate: "invalid" });
+
+      assert.strictEqual(isErr(result), true);
+      if (isErr(result)) {
+        assert.ok(result.error instanceof ConfigValidationError);
+        assert.strictEqual(
+          result.error.message,
+          "Invalid phantom.config.json: postCreate must be an object",
+        );
+      }
+    });
+
+    test("should reject when postCreate is number", () => {
+      const result = validateConfig({ postCreate: 123 });
+
+      assert.strictEqual(isErr(result), true);
+      if (isErr(result)) {
+        assert.ok(result.error instanceof ConfigValidationError);
+        assert.strictEqual(
+          result.error.message,
+          "Invalid phantom.config.json: postCreate must be an object",
+        );
+      }
+    });
+
+    test("should reject when postCreate is array", () => {
+      const result = validateConfig({ postCreate: [] });
+
+      assert.strictEqual(isErr(result), true);
+      if (isErr(result)) {
+        assert.ok(result.error instanceof ConfigValidationError);
+        assert.strictEqual(
+          result.error.message,
+          "Invalid phantom.config.json: postCreate must be an object",
+        );
+      }
+    });
+
+    test("should reject when postCreate is null", () => {
+      const result = validateConfig({ postCreate: null });
+
+      assert.strictEqual(isErr(result), true);
+      if (isErr(result)) {
+        assert.ok(result.error instanceof ConfigValidationError);
+        assert.strictEqual(
+          result.error.message,
+          "Invalid phantom.config.json: postCreate must be an object",
+        );
+      }
+    });
+
+    test("should reject when copyFiles is string", () => {
+      const result = validateConfig({ postCreate: { copyFiles: "invalid" } });
+
+      assert.strictEqual(isErr(result), true);
+      if (isErr(result)) {
+        assert.ok(result.error instanceof ConfigValidationError);
+        assert.strictEqual(
+          result.error.message,
+          "Invalid phantom.config.json: postCreate.copyFiles must be an array",
+        );
+      }
+    });
+
+    test("should reject when copyFiles is number", () => {
+      const result = validateConfig({ postCreate: { copyFiles: 123 } });
+
+      assert.strictEqual(isErr(result), true);
+      if (isErr(result)) {
+        assert.ok(result.error instanceof ConfigValidationError);
+        assert.strictEqual(
+          result.error.message,
+          "Invalid phantom.config.json: postCreate.copyFiles must be an array",
+        );
+      }
+    });
+
+    test("should reject when copyFiles is object", () => {
+      const result = validateConfig({ postCreate: { copyFiles: {} } });
+
+      assert.strictEqual(isErr(result), true);
+      if (isErr(result)) {
+        assert.ok(result.error instanceof ConfigValidationError);
+        assert.strictEqual(
+          result.error.message,
+          "Invalid phantom.config.json: postCreate.copyFiles must be an array",
+        );
+      }
+    });
+
+    test("should reject when copyFiles contains non-string values", () => {
+      const result = validateConfig({
+        postCreate: { copyFiles: ["valid", 123, true] },
+      });
+
+      assert.strictEqual(isErr(result), true);
+      if (isErr(result)) {
+        assert.ok(result.error instanceof ConfigValidationError);
+        assert.strictEqual(
+          result.error.message,
+          "Invalid phantom.config.json: postCreate.copyFiles must contain only strings",
+        );
+      }
+    });
+
+    test("should reject when copyFiles contains null", () => {
+      const result = validateConfig({
+        postCreate: { copyFiles: ["valid", null] },
+      });
+
+      assert.strictEqual(isErr(result), true);
+      if (isErr(result)) {
+        assert.ok(result.error instanceof ConfigValidationError);
+        assert.strictEqual(
+          result.error.message,
+          "Invalid phantom.config.json: postCreate.copyFiles must contain only strings",
+        );
+      }
+    });
+
+    test("should reject when copyFiles contains undefined", () => {
+      const result = validateConfig({
+        postCreate: { copyFiles: ["valid", undefined] },
+      });
+
+      assert.strictEqual(isErr(result), true);
+      if (isErr(result)) {
+        assert.ok(result.error instanceof ConfigValidationError);
+        assert.strictEqual(
+          result.error.message,
+          "Invalid phantom.config.json: postCreate.copyFiles must contain only strings",
+        );
+      }
+    });
+
+    test("should reject when copyFiles contains objects", () => {
+      const result = validateConfig({
+        postCreate: { copyFiles: ["valid", { file: "test" }] },
+      });
+
+      assert.strictEqual(isErr(result), true);
+      if (isErr(result)) {
+        assert.ok(result.error instanceof ConfigValidationError);
+        assert.strictEqual(
+          result.error.message,
+          "Invalid phantom.config.json: postCreate.copyFiles must contain only strings",
+        );
+      }
+    });
+
+    test("should reject when copyFiles contains arrays", () => {
+      const result = validateConfig({
+        postCreate: { copyFiles: ["valid", ["nested"]] },
+      });
+
+      assert.strictEqual(isErr(result), true);
+      if (isErr(result)) {
+        assert.ok(result.error instanceof ConfigValidationError);
+        assert.strictEqual(
+          result.error.message,
+          "Invalid phantom.config.json: postCreate.copyFiles must contain only strings",
+        );
+      }
+    });
+  });
+
+  describe("edge cases", () => {
+    test("should accept config with unknown properties", () => {
+      const config = {
+        postCreate: {
+          copyFiles: [".env"],
+        },
+        unknownProperty: "should be ignored",
+      };
+
+      const result = validateConfig(config);
+
+      assert.strictEqual(isOk(result), true);
+      if (isOk(result)) {
+        assert.deepStrictEqual(result.value, config);
+      }
+    });
+
+    test("should accept postCreate with unknown properties", () => {
+      const config = {
+        postCreate: {
+          copyFiles: [".env"],
+          unknownProperty: "should be ignored",
+        },
+      };
+
+      const result = validateConfig(config);
+
+      assert.strictEqual(isOk(result), true);
+      if (isOk(result)) {
+        assert.deepStrictEqual(result.value, config);
+      }
+    });
+
+    test("should accept copyFiles with empty strings", () => {
+      const config = {
+        postCreate: {
+          copyFiles: ["", "valid", ""],
+        },
+      };
+
+      const result = validateConfig(config);
+
+      assert.strictEqual(isOk(result), true);
+      if (isOk(result)) {
+        assert.deepStrictEqual(result.value, config);
+      }
+    });
+
+    test("should accept copyFiles with special characters", () => {
+      const config = {
+        postCreate: {
+          copyFiles: ["@#$%", "file with spaces.txt", "../relative/path.js"],
+        },
+      };
+
+      const result = validateConfig(config);
+
+      assert.strictEqual(isOk(result), true);
+      if (isOk(result)) {
+        assert.deepStrictEqual(result.value, config);
+      }
+    });
+  });
+});

--- a/src/core/config/validate.ts
+++ b/src/core/config/validate.ts
@@ -1,0 +1,48 @@
+import { type Result, err, ok } from "../types/result.ts";
+import type { PhantomConfig } from "./loader.ts";
+
+export class ConfigValidationError extends Error {
+  constructor(message: string) {
+    super(`Invalid phantom.config.json: ${message}`);
+    this.name = "ConfigValidationError";
+  }
+}
+
+export function validateConfig(
+  config: unknown,
+): Result<PhantomConfig, ConfigValidationError> {
+  if (typeof config !== "object" || config === null || Array.isArray(config)) {
+    return err(new ConfigValidationError("Configuration must be an object"));
+  }
+
+  const cfg = config as Record<string, unknown>;
+
+  if (cfg.postCreate !== undefined) {
+    if (
+      typeof cfg.postCreate !== "object" ||
+      cfg.postCreate === null ||
+      Array.isArray(cfg.postCreate)
+    ) {
+      return err(new ConfigValidationError("postCreate must be an object"));
+    }
+
+    const postCreate = cfg.postCreate as Record<string, unknown>;
+    if (postCreate.copyFiles !== undefined) {
+      if (!Array.isArray(postCreate.copyFiles)) {
+        return err(
+          new ConfigValidationError("postCreate.copyFiles must be an array"),
+        );
+      }
+
+      if (!postCreate.copyFiles.every((f: unknown) => typeof f === "string")) {
+        return err(
+          new ConfigValidationError(
+            "postCreate.copyFiles must contain only strings",
+          ),
+        );
+      }
+    }
+  }
+
+  return ok(config as PhantomConfig);
+}


### PR DESCRIPTION
## Summary
- Add proper validation for `phantom.config.json` to prevent runtime errors from invalid configurations
- Implement comprehensive error messages to help users fix configuration issues
- Extract validation logic into a separate module for better code organization

## Changes
- Add `ConfigValidationError` class for validation-specific errors
- Implement `validateConfig` function that validates:
  - Configuration is an object (not array, null, or primitive)
  - `postCreate` is an object if present
  - `copyFiles` is an array of strings if present
- Move validation logic to `src/core/config/validate.ts` for separation of concerns
- Add comprehensive test suite with 26 test cases covering all validation scenarios

## Test Plan
- [x] All existing tests pass
- [x] Added unit tests for the new `validateConfig` function
- [x] Added integration tests for various invalid configuration scenarios
- [x] Tested edge cases like unknown properties and special characters
- [x] Verified that valid configurations still work as expected

Fixes #99