### PR TITLE
fix: remove skippedFiles log output from phantom create command

### DIFF
--- a/src/cli/handlers/create.ts
+++ b/src/cli/handlers/create.ts
@@ -133,12 +133,6 @@ export async function createHandler(args: string[]): Promise<void> {
       );
     }
 
-    if (result.value.skippedFiles && result.value.skippedFiles.length > 0) {
-      output.warn(
-        `\nSkipped copying these files (not found or directories): ${result.value.skippedFiles.join(", ")}`,
-      );
-    }
-
     if (execCommand && isOk(result)) {
       output.log(
         `\nExecuting command in worktree '${worktreeName}': ${execCommand}`,


### PR DESCRIPTION
## Summary
- Removes the warning message displayed when files specified for copying are skipped
- Provides a cleaner user experience when using the `phantom create` command

## Test plan
- [x] All existing tests pass
- [x] Ran `pnpm ready` to ensure lint, typecheck, and tests succeed
- [x] Verified the skippedFiles warning no longer appears in the output

Fixes #101

🤖 Generated with [Claude Code](https://claude.ai/code)