### PR TITLE
feat: add --fzf flag for interactive worktree selection

### DIFF
--- a/src/cli/handlers/list.ts
+++ b/src/cli/handlers/list.ts
@@ -1,14 +1,20 @@
 import { parseArgs } from "node:util";
 import { getGitRoot } from "../../core/git/libs/get-git-root.ts";
 import { isErr } from "../../core/types/result.ts";
+import { selectWithFzf } from "../../core/utils/fzf.ts";
 import { listWorktrees as listWorktreesCore } from "../../core/worktree/list.ts";
 import { exitCodes, exitWithError } from "../errors.ts";
 import { output } from "../output.ts";
 
 export async function listHandler(args: string[] = []): Promise<void> {
-  parseArgs({
+  const { values } = parseArgs({
     args,
-    options: {},
+    options: {
+      fzf: {
+        type: "boolean",
+        default: false,
+      },
+    },
     strict: true,
     allowPositionals: false,
   });
@@ -27,14 +33,36 @@ export async function listHandler(args: string[] = []): Promise<void> {
       process.exit(exitCodes.success);
     }
 
-    const maxNameLength = Math.max(...worktrees.map((wt) => wt.name.length));
+    if (values.fzf) {
+      const list = worktrees.map((wt) => {
+        const branchInfo = wt.branch ? `(${wt.branch})` : "";
+        const status = !wt.isClean ? " [dirty]" : "";
+        return `${wt.name} ${branchInfo}${status}`;
+      });
 
-    for (const worktree of worktrees) {
-      const paddedName = worktree.name.padEnd(maxNameLength + 2);
-      const branchInfo = worktree.branch ? `(${worktree.branch})` : "";
-      const status = !worktree.isClean ? " [dirty]" : "";
+      const fzfResult = await selectWithFzf(list, {
+        prompt: "Select worktree> ",
+        header: "Git Worktrees (Phantoms)",
+      });
 
-      output.log(`${paddedName} ${branchInfo}${status}`);
+      if (isErr(fzfResult)) {
+        exitWithError(fzfResult.error.message, exitCodes.generalError);
+      }
+
+      if (fzfResult.value) {
+        const selectedName = fzfResult.value.split(" ")[0];
+        output.log(selectedName);
+      }
+    } else {
+      const maxNameLength = Math.max(...worktrees.map((wt) => wt.name.length));
+
+      for (const worktree of worktrees) {
+        const paddedName = worktree.name.padEnd(maxNameLength + 2);
+        const branchInfo = worktree.branch ? `(${worktree.branch})` : "";
+        const status = !worktree.isClean ? " [dirty]" : "";
+
+        output.log(`${paddedName} ${branchInfo}${status}`);
+      }
     }
 
     process.exit(exitCodes.success);

--- a/src/cli/help/list.ts
+++ b/src/cli/help/list.ts
@@ -3,15 +3,27 @@ import type { CommandHelp } from "../help.ts";
 export const listHelp: CommandHelp = {
   name: "list",
   description: "List all Git worktrees (phantoms)",
-  usage: "phantom list",
+  usage: "phantom list [options]",
+  options: [
+    {
+      name: "--fzf",
+      type: "boolean",
+      description: "Use fzf for interactive selection",
+    },
+  ],
   examples: [
     {
       description: "List all worktrees",
       command: "phantom list",
     },
+    {
+      description: "List worktrees with interactive fzf selection",
+      command: "phantom list --fzf",
+    },
   ],
   notes: [
     "Shows all worktrees with their paths and associated branches",
     "The main worktree is marked as '(bare)' if using a bare repository",
+    "With --fzf, outputs only the selected worktree name",
   ],
 };

--- a/src/core/utils/fzf.ts
+++ b/src/core/utils/fzf.ts
@@ -1,0 +1,72 @@
+import { spawn } from "node:child_process";
+import { type Result, err, ok } from "../types/result.ts";
+
+export interface FzfOptions {
+  prompt?: string;
+  header?: string;
+  previewCommand?: string;
+}
+
+export async function selectWithFzf(
+  items: string[],
+  options: FzfOptions = {},
+): Promise<Result<string | null, Error>> {
+  return new Promise((resolve) => {
+    const args: string[] = [];
+
+    if (options.prompt) {
+      args.push("--prompt", options.prompt);
+    }
+
+    if (options.header) {
+      args.push("--header", options.header);
+    }
+
+    if (options.previewCommand) {
+      args.push("--preview", options.previewCommand);
+    }
+
+    const fzf = spawn("fzf", args, {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let result = "";
+    let errorOutput = "";
+
+    fzf.stdout.on("data", (data) => {
+      result += data.toString();
+    });
+
+    if (fzf.stderr) {
+      fzf.stderr.on("data", (data) => {
+        errorOutput += data.toString();
+      });
+    }
+
+    fzf.on("error", (error) => {
+      if (error.message.includes("ENOENT")) {
+        resolve(
+          err(new Error("fzf command not found. Please install fzf first.")),
+        );
+      } else {
+        resolve(err(error));
+      }
+    });
+
+    fzf.on("close", (code) => {
+      if (code === 0) {
+        const selected = result.trim();
+        resolve(ok(selected || null));
+      } else if (code === 1) {
+        resolve(ok(null));
+      } else if (code === 130) {
+        resolve(ok(null));
+      } else {
+        resolve(err(new Error(`fzf exited with code ${code}: ${errorOutput}`)));
+      }
+    });
+
+    fzf.stdin.write(items.join("\n"));
+    fzf.stdin.end();
+  });
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Add a new `--fzf` flag to the `phantom list` command that enables interactive worktree selection using fzf
- When used, the command outputs only the selected worktree name instead of displaying the full list
- This feature enhances the CLI experience by allowing users to interactively filter and select worktrees, which is particularly useful for scripting and when dealing with many worktrees

## Implementation Details
- Created a new utility module `src/core/utils/fzf.ts` that handles fzf process spawning and interaction
- Modified the list command handler to check for the `--fzf` flag and use interactive selection when present
- Updated help documentation to include the new option with examples
- Implemented proper error handling for cases where fzf is not installed on the system

## Test plan
- [ ] Test `phantom list` without `--fzf` flag - should work as before
- [ ] Test `phantom list --fzf` with fzf installed - should show interactive selection
- [ ] Test `phantom list --fzf` without fzf installed - should show helpful error message
- [ ] Test selecting a worktree with fzf - should output only the selected worktree name
- [ ] Test canceling fzf selection (ESC or Ctrl+C) - should exit gracefully without output
- [ ] Verify help documentation is accurate with `phantom list --help`

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)