### PR TITLE
feat: add --fzf flag to delete command for interactive selection

### DIFF
--- a/src/cli/handlers/delete.test.js
+++ b/src/cli/handlers/delete.test.js
@@ -180,13 +180,13 @@ describe("deleteHandler", () => {
 
     await rejects(
       async () => await deleteHandler(["feature", "--current"]),
-      /Exit with code 3: Cannot specify both a worktree name and --current option/,
+      /Exit with code 3: Cannot specify --current with a worktree name or --fzf option/,
     );
 
     strictEqual(consoleErrorMock.mock.calls.length, 1);
     strictEqual(
       consoleErrorMock.mock.calls[0].arguments[0],
-      "Error: Cannot specify both a worktree name and --current option",
+      "Error: Cannot specify --current with a worktree name or --fzf option",
     );
     strictEqual(exitMock.mock.calls[0].arguments[0], 3); // validationError
   });
@@ -196,13 +196,13 @@ describe("deleteHandler", () => {
 
     await rejects(
       async () => await deleteHandler([]),
-      /Exit with code 3: Please provide a worktree name to delete or use --current to delete the current worktree/,
+      /Exit with code 3: Please provide a worktree name to delete, use --current to delete the current worktree, or use --fzf for interactive selection/,
     );
 
     strictEqual(consoleErrorMock.mock.calls.length, 1);
     strictEqual(
       consoleErrorMock.mock.calls[0].arguments[0],
-      "Error: Please provide a worktree name to delete or use --current to delete the current worktree",
+      "Error: Please provide a worktree name to delete, use --current to delete the current worktree, or use --fzf for interactive selection",
     );
     strictEqual(exitMock.mock.calls[0].arguments[0], 3); // validationError
   });

--- a/src/cli/help/delete.ts
+++ b/src/cli/help/delete.ts
@@ -12,6 +12,16 @@ export const deleteHelp: CommandHelp = {
       description:
         "Force deletion even if the worktree has uncommitted or unpushed changes",
     },
+    {
+      name: "--current",
+      type: "boolean",
+      description: "Delete the current worktree",
+    },
+    {
+      name: "--fzf",
+      type: "boolean",
+      description: "Use fzf for interactive selection",
+    },
   ],
   examples: [
     {
@@ -22,9 +32,18 @@ export const deleteHelp: CommandHelp = {
       description: "Force delete a worktree with uncommitted changes",
       command: "phantom delete experimental --force",
     },
+    {
+      description: "Delete the current worktree",
+      command: "phantom delete --current",
+    },
+    {
+      description: "Delete a worktree with interactive fzf selection",
+      command: "phantom delete --fzf",
+    },
   ],
   notes: [
     "By default, deletion will fail if the worktree has uncommitted changes",
     "The associated branch will also be deleted if it's not checked out elsewhere",
+    "With --fzf, you can interactively select the worktree to delete",
   ],
 };


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Add `--fzf` flag to the `phantom delete` command for interactive worktree selection using fzf
- This enhancement mirrors the functionality previously added to the list command in PR #113
- When used, the command allows users to interactively filter and select a worktree to delete

## Implementation Details
- Created fzf utility modules (`src/core/utils/fzf.ts` and `src/core/worktree/select.ts`) based on the implementation from PR #113
- Modified the delete command handler to:
  - Accept the new `--fzf` flag
  - Use interactive selection when the flag is present
  - Update validation logic to handle the new option
- Updated help documentation to include the new option with examples
- Fixed tests to match the updated error messages

## Test plan
- [ ] Test `phantom delete <name>` - should work as before
- [ ] Test `phantom delete --current` - should work as before
- [ ] Test `phantom delete --fzf` with fzf installed - should show interactive selection
- [ ] Test `phantom delete --fzf` without fzf installed - should show helpful error message
- [ ] Test selecting a worktree with fzf - should delete the selected worktree
- [ ] Test canceling fzf selection (ESC or Ctrl+C) - should exit gracefully without deleting
- [ ] Test `phantom delete --fzf --force` - should allow force deletion with interactive selection
- [ ] Verify help documentation is accurate with `phantom delete --help`
- [ ] All existing tests should pass

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)