### PR TITLE
feat: add --fzf flag to where command for interactive selection

### DIFF
--- a/src/cli/handlers/where.test.js
+++ b/src/cli/handlers/where.test.js
@@ -1,0 +1,239 @@
+import { rejects, strictEqual } from "node:assert";
+import { describe, it, mock } from "node:test";
+import { err, ok } from "../../core/types/result.ts";
+import { WorktreeNotFoundError } from "../../core/worktree/errors.ts";
+
+const exitMock = mock.fn();
+const consoleLogMock = mock.fn();
+const consoleErrorMock = mock.fn();
+const getGitRootMock = mock.fn();
+const whereWorktreeMock = mock.fn();
+const selectWorktreeWithFzfMock = mock.fn();
+const exitWithErrorMock = mock.fn((message, code) => {
+  consoleErrorMock(`Error: ${message}`);
+  exitMock(code);
+  throw new Error(`Exit with code ${code}: ${message}`);
+});
+const exitWithSuccessMock = mock.fn(() => {
+  exitMock(0);
+  throw new Error("Exit with code 0: success");
+});
+
+mock.module("node:process", {
+  namedExports: {
+    exit: exitMock,
+  },
+});
+
+mock.module("../../core/git/libs/get-git-root.ts", {
+  namedExports: {
+    getGitRoot: getGitRootMock,
+  },
+});
+
+mock.module("../../core/worktree/where.ts", {
+  namedExports: {
+    whereWorktree: whereWorktreeMock,
+  },
+});
+
+mock.module("../../core/worktree/select.ts", {
+  namedExports: {
+    selectWorktreeWithFzf: selectWorktreeWithFzfMock,
+  },
+});
+
+mock.module("../output.ts", {
+  namedExports: {
+    output: {
+      log: consoleLogMock,
+      error: consoleErrorMock,
+    },
+  },
+});
+
+mock.module("../errors.ts", {
+  namedExports: {
+    exitWithError: exitWithErrorMock,
+    exitWithSuccess: exitWithSuccessMock,
+    exitCodes: {
+      success: 0,
+      generalError: 1,
+      notFound: 2,
+      validationError: 3,
+    },
+  },
+});
+
+const { whereHandler } = await import("./where.ts");
+
+describe("whereHandler", () => {
+  it("should error when no worktree name and no --fzf flag provided", async () => {
+    exitMock.mock.resetCalls();
+    consoleErrorMock.mock.resetCalls();
+
+    await rejects(
+      async () => await whereHandler([]),
+      /Exit with code 3: Usage: phantom where <worktree-name> or phantom where --fzf/,
+    );
+
+    strictEqual(consoleErrorMock.mock.calls.length, 1);
+    strictEqual(
+      consoleErrorMock.mock.calls[0].arguments[0],
+      "Error: Usage: phantom where <worktree-name> or phantom where --fzf",
+    );
+    strictEqual(exitMock.mock.calls[0].arguments[0], 3); // validationError
+  });
+
+  it("should error when both worktree name and --fzf flag are provided", async () => {
+    exitMock.mock.resetCalls();
+    consoleErrorMock.mock.resetCalls();
+
+    await rejects(
+      async () => await whereHandler(["feature", "--fzf"]),
+      /Exit with code 3: Cannot specify both a worktree name and --fzf option/,
+    );
+
+    strictEqual(consoleErrorMock.mock.calls.length, 1);
+    strictEqual(
+      consoleErrorMock.mock.calls[0].arguments[0],
+      "Error: Cannot specify both a worktree name and --fzf option",
+    );
+    strictEqual(exitMock.mock.calls[0].arguments[0], 3); // validationError
+  });
+
+  it("should output path for specified worktree", async () => {
+    exitMock.mock.resetCalls();
+    consoleLogMock.mock.resetCalls();
+    getGitRootMock.mock.resetCalls();
+    whereWorktreeMock.mock.resetCalls();
+
+    getGitRootMock.mock.mockImplementation(() => "/repo");
+    whereWorktreeMock.mock.mockImplementation(() =>
+      ok({ path: "/repo/.git/phantom/worktrees/feature" }),
+    );
+    exitMock.mock.mockImplementation((code) => {
+      throw new Error(`Process exit with code ${code}`);
+    });
+
+    await rejects(
+      async () => await whereHandler(["feature"]),
+      /Process exit with code 0/,
+    );
+
+    strictEqual(getGitRootMock.mock.calls.length, 1);
+    strictEqual(whereWorktreeMock.mock.calls.length, 1);
+    strictEqual(whereWorktreeMock.mock.calls[0].arguments[0], "/repo");
+    strictEqual(whereWorktreeMock.mock.calls[0].arguments[1], "feature");
+    strictEqual(consoleLogMock.mock.calls.length, 1);
+    strictEqual(
+      consoleLogMock.mock.calls[0].arguments[0],
+      "/repo/.git/phantom/worktrees/feature",
+    );
+  });
+
+  it("should output path with fzf selection", async () => {
+    exitMock.mock.resetCalls();
+    consoleLogMock.mock.resetCalls();
+    getGitRootMock.mock.resetCalls();
+    selectWorktreeWithFzfMock.mock.resetCalls();
+    whereWorktreeMock.mock.resetCalls();
+
+    getGitRootMock.mock.mockImplementation(() => "/repo");
+    selectWorktreeWithFzfMock.mock.mockImplementation(() =>
+      ok({
+        name: "feature-fzf",
+        branch: "feature-fzf",
+        isClean: true,
+      }),
+    );
+    whereWorktreeMock.mock.mockImplementation(() =>
+      ok({ path: "/repo/.git/phantom/worktrees/feature-fzf" }),
+    );
+    exitMock.mock.mockImplementation((code) => {
+      throw new Error(`Process exit with code ${code}`);
+    });
+
+    await rejects(
+      async () => await whereHandler(["--fzf"]),
+      /Process exit with code 0/,
+    );
+
+    strictEqual(getGitRootMock.mock.calls.length, 1);
+    strictEqual(selectWorktreeWithFzfMock.mock.calls.length, 1);
+    strictEqual(selectWorktreeWithFzfMock.mock.calls[0].arguments[0], "/repo");
+    strictEqual(whereWorktreeMock.mock.calls.length, 1);
+    strictEqual(whereWorktreeMock.mock.calls[0].arguments[1], "feature-fzf");
+    strictEqual(consoleLogMock.mock.calls.length, 1);
+    strictEqual(
+      consoleLogMock.mock.calls[0].arguments[0],
+      "/repo/.git/phantom/worktrees/feature-fzf",
+    );
+  });
+
+  it("should exit gracefully when fzf selection is cancelled", async () => {
+    exitMock.mock.resetCalls();
+    getGitRootMock.mock.resetCalls();
+    selectWorktreeWithFzfMock.mock.resetCalls();
+    exitWithSuccessMock.mock.resetCalls();
+
+    getGitRootMock.mock.mockImplementation(() => "/repo");
+    selectWorktreeWithFzfMock.mock.mockImplementation(() => ok(null));
+
+    await rejects(
+      async () => await whereHandler(["--fzf"]),
+      /Process exit with code 0/,
+    );
+
+    strictEqual(selectWorktreeWithFzfMock.mock.calls.length, 1);
+    strictEqual(exitWithSuccessMock.mock.calls.length, 1);
+  });
+
+  it("should handle fzf selection error", async () => {
+    exitMock.mock.resetCalls();
+    consoleErrorMock.mock.resetCalls();
+    getGitRootMock.mock.resetCalls();
+    selectWorktreeWithFzfMock.mock.resetCalls();
+
+    getGitRootMock.mock.mockImplementation(() => "/repo");
+    selectWorktreeWithFzfMock.mock.mockImplementation(() =>
+      err(new Error("fzf not found")),
+    );
+
+    await rejects(
+      async () => await whereHandler(["--fzf"]),
+      /Process exit with code 1/,
+    );
+
+    strictEqual(consoleErrorMock.mock.calls.length, 1);
+    strictEqual(
+      consoleErrorMock.mock.calls[0].arguments[0],
+      "Error: fzf not found",
+    );
+    strictEqual(exitMock.mock.calls[0].arguments[0], 1); // generalError
+  });
+
+  it("should error when worktree not found", async () => {
+    exitMock.mock.resetCalls();
+    consoleErrorMock.mock.resetCalls();
+    getGitRootMock.mock.resetCalls();
+    whereWorktreeMock.mock.resetCalls();
+
+    getGitRootMock.mock.mockImplementation(() => "/repo");
+    whereWorktreeMock.mock.mockImplementation(() =>
+      err(new WorktreeNotFoundError("nonexistent")),
+    );
+
+    await rejects(
+      async () => await whereHandler(["nonexistent"]),
+      /Process exit with code 2/,
+    );
+
+    strictEqual(consoleErrorMock.mock.calls.length, 1);
+    strictEqual(
+      consoleErrorMock.mock.calls[0].arguments[0],
+      "Error: Worktree 'nonexistent' not found",
+    );
+    strictEqual(exitMock.mock.calls[0].arguments[0], 2); // notFound
+  });
+});

--- a/src/cli/handlers/where.ts
+++ b/src/cli/handlers/where.ts
@@ -1,38 +1,71 @@
 import { parseArgs } from "node:util";
 import { getGitRoot } from "../../core/git/libs/get-git-root.ts";
 import { isErr } from "../../core/types/result.ts";
+import { selectWorktreeWithFzf } from "../../core/worktree/select.ts";
 import { whereWorktree as whereWorktreeCore } from "../../core/worktree/where.ts";
 import { exitCodes, exitWithError, exitWithSuccess } from "../errors.ts";
 import { output } from "../output.ts";
 
 export async function whereHandler(args: string[]): Promise<void> {
-  const { positionals } = parseArgs({
+  const { positionals, values } = parseArgs({
     args,
-    options: {},
+    options: {
+      fzf: {
+        type: "boolean",
+        default: false,
+      },
+    },
     strict: true,
     allowPositionals: true,
   });
 
-  if (positionals.length === 0) {
-    exitWithError("Please provide a worktree name", exitCodes.validationError);
+  const useFzf = values.fzf ?? false;
+
+  if (positionals.length === 0 && !useFzf) {
+    exitWithError(
+      "Usage: phantom where <worktree-name> or phantom where --fzf",
+      exitCodes.validationError,
+    );
   }
 
-  const worktreeName = positionals[0];
+  if (positionals.length > 0 && useFzf) {
+    exitWithError(
+      "Cannot specify both a worktree name and --fzf option",
+      exitCodes.validationError,
+    );
+  }
+
+  let worktreeName: string;
+  let gitRoot: string;
 
   try {
-    const gitRoot = await getGitRoot();
-    const result = await whereWorktreeCore(gitRoot, worktreeName);
-
-    if (isErr(result)) {
-      exitWithError(result.error.message, exitCodes.notFound);
-    }
-
-    output.log(result.value.path);
-    exitWithSuccess();
+    gitRoot = await getGitRoot();
   } catch (error) {
     exitWithError(
       error instanceof Error ? error.message : String(error),
       exitCodes.generalError,
     );
   }
+
+  if (useFzf) {
+    const selectResult = await selectWorktreeWithFzf(gitRoot);
+    if (isErr(selectResult)) {
+      exitWithError(selectResult.error.message, exitCodes.generalError);
+    }
+    if (!selectResult.value) {
+      exitWithSuccess();
+    }
+    worktreeName = selectResult.value.name;
+  } else {
+    worktreeName = positionals[0];
+  }
+
+  const result = await whereWorktreeCore(gitRoot, worktreeName);
+
+  if (isErr(result)) {
+    exitWithError(result.error.message, exitCodes.notFound);
+  }
+
+  output.log(result.value.path);
+  exitWithSuccess();
 }

--- a/src/cli/help/where.ts
+++ b/src/cli/help/where.ts
@@ -3,7 +3,14 @@ import type { CommandHelp } from "../help.ts";
 export const whereHelp: CommandHelp = {
   name: "where",
   description: "Output the filesystem path of a specific worktree",
-  usage: "phantom where <worktree-name>",
+  usage: "phantom where <worktree-name> [options]",
+  options: [
+    {
+      name: "--fzf",
+      type: "boolean",
+      description: "Use fzf for interactive selection",
+    },
+  ],
   examples: [
     {
       description: "Get the path of a worktree",
@@ -13,9 +20,18 @@ export const whereHelp: CommandHelp = {
       description: "Change directory to a worktree",
       command: "cd $(phantom where staging)",
     },
+    {
+      description: "Get path with interactive fzf selection",
+      command: "phantom where --fzf",
+    },
+    {
+      description: "Change directory using fzf selection",
+      command: "cd $(phantom where --fzf)",
+    },
   ],
   notes: [
     "Outputs only the path, making it suitable for use in scripts",
     "Exits with an error code if the worktree doesn't exist",
+    "With --fzf, you can interactively select the worktree",
   ],
 };


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Add `--fzf` flag to the `phantom where` command for interactive worktree selection using fzf
- This enhancement follows the same pattern as previously implemented for list (#113), delete (#115), and shell (#116) commands
- When used, the command allows users to interactively filter and select a worktree to get its path

## Implementation Details
- Modified the where command handler to:
  - Accept the new `--fzf` flag
  - Use interactive selection when the flag is present
  - Validate that users don't provide both a worktree name and the `--fzf` flag
- Updated help documentation to include the new option with examples
- Added comprehensive tests for all scenarios including fzf selection
- Refactored error handling to ensure proper exit codes are returned

## Test plan
- [ ] Test `phantom where <name>` - should work as before
- [ ] Test `phantom where --fzf` with fzf installed - should show interactive selection
- [ ] Test `phantom where --fzf` without fzf installed - should show helpful error message
- [ ] Test selecting a worktree with fzf - should output the selected worktree path
- [ ] Test canceling fzf selection (ESC or Ctrl+C) - should exit gracefully
- [ ] Test `phantom where <name> --fzf` - should show error about not using both
- [ ] Verify help documentation is accurate with `phantom where --help`
- [ ] All existing tests should pass

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)