### PR TITLE
feat: add --names option to list command

### DIFF
--- a/src/cli/handlers/list.test.js
+++ b/src/cli/handlers/list.test.js
@@ -1,0 +1,283 @@
+import { rejects, strictEqual } from "node:assert";
+import { describe, it, mock } from "node:test";
+import { err, ok } from "../../core/types/result.ts";
+
+const exitMock = mock.fn();
+const consoleLogMock = mock.fn();
+const consoleErrorMock = mock.fn();
+const getGitRootMock = mock.fn();
+const listWorktreesCoreMock = mock.fn();
+const selectWorktreeWithFzfMock = mock.fn();
+const exitWithErrorMock = mock.fn((message, code) => {
+  if (message) consoleErrorMock(`Error: ${message}`);
+  exitMock(code);
+  throw new Error(`Exit with code ${code}: ${message}`);
+});
+
+// Mock process module
+mock.module("node:process", {
+  namedExports: {
+    exit: exitMock,
+  },
+});
+
+mock.module("../../core/git/libs/get-git-root.ts", {
+  namedExports: {
+    getGitRoot: getGitRootMock,
+  },
+});
+
+mock.module("../../core/worktree/list.ts", {
+  namedExports: {
+    listWorktrees: listWorktreesCoreMock,
+  },
+});
+
+mock.module("../../core/worktree/select.ts", {
+  namedExports: {
+    selectWorktreeWithFzf: selectWorktreeWithFzfMock,
+  },
+});
+
+mock.module("../output.ts", {
+  namedExports: {
+    output: {
+      log: consoleLogMock,
+      error: consoleErrorMock,
+    },
+  },
+});
+
+mock.module("../errors.ts", {
+  namedExports: {
+    exitCodes: {
+      success: 0,
+      generalError: 1,
+    },
+    exitWithError: exitWithErrorMock,
+  },
+});
+
+const { listHandler } = await import("./list.ts");
+
+describe("listHandler", () => {
+  const resetMocks = () => {
+    exitMock.mock.resetCalls();
+    consoleLogMock.mock.resetCalls();
+    consoleErrorMock.mock.resetCalls();
+    getGitRootMock.mock.resetCalls();
+    listWorktreesCoreMock.mock.resetCalls();
+    selectWorktreeWithFzfMock.mock.resetCalls();
+    exitWithErrorMock.mock.resetCalls();
+  };
+
+  it("should list worktrees in default format", async () => {
+    resetMocks();
+    getGitRootMock.mock.mockImplementation(() => Promise.resolve("/test/repo"));
+    listWorktreesCoreMock.mock.mockImplementation(() =>
+      Promise.resolve(
+        ok({
+          worktrees: [
+            {
+              name: "feature-1",
+              path: "/test/repo/.git/phantom/worktrees/feature-1",
+              branch: "feature-1",
+              isClean: true,
+            },
+            {
+              name: "feature-2",
+              path: "/test/repo/.git/phantom/worktrees/feature-2",
+              branch: "feature-2",
+              isClean: false,
+            },
+          ],
+        }),
+      ),
+    );
+
+    await rejects(async () => await listHandler([]), /Exit with code 0/);
+
+    strictEqual(getGitRootMock.mock.calls.length, 1);
+    strictEqual(listWorktreesCoreMock.mock.calls.length, 1);
+    strictEqual(consoleLogMock.mock.calls.length, 2);
+    strictEqual(
+      consoleLogMock.mock.calls[0].arguments[0],
+      "feature-1  (feature-1)",
+    );
+    strictEqual(
+      consoleLogMock.mock.calls[1].arguments[0],
+      "feature-2  (feature-2) [dirty]",
+    );
+    strictEqual(exitMock.mock.calls[0].arguments[0], 0);
+  });
+
+  it("should list only worktree names with --names option", async () => {
+    resetMocks();
+    getGitRootMock.mock.mockImplementation(() => Promise.resolve("/test/repo"));
+    listWorktreesCoreMock.mock.mockImplementation(() =>
+      Promise.resolve(
+        ok({
+          worktrees: [
+            {
+              name: "feature-1",
+              path: "/test/repo/.git/phantom/worktrees/feature-1",
+              branch: "feature-1",
+              isClean: true,
+            },
+            {
+              name: "feature-2",
+              path: "/test/repo/.git/phantom/worktrees/feature-2",
+              branch: "feature-2",
+              isClean: false,
+            },
+            {
+              name: "bugfix-3",
+              path: "/test/repo/.git/phantom/worktrees/bugfix-3",
+              branch: "bugfix-3",
+              isClean: true,
+            },
+          ],
+        }),
+      ),
+    );
+
+    await rejects(
+      async () => await listHandler(["--names"]),
+      /Exit with code 0/,
+    );
+
+    strictEqual(getGitRootMock.mock.calls.length, 1);
+    strictEqual(listWorktreesCoreMock.mock.calls.length, 1);
+    strictEqual(consoleLogMock.mock.calls.length, 3);
+    strictEqual(consoleLogMock.mock.calls[0].arguments[0], "feature-1");
+    strictEqual(consoleLogMock.mock.calls[1].arguments[0], "feature-2");
+    strictEqual(consoleLogMock.mock.calls[2].arguments[0], "bugfix-3");
+    strictEqual(exitMock.mock.calls[0].arguments[0], 0);
+  });
+
+  it("should handle empty worktree list with default format", async () => {
+    resetMocks();
+    getGitRootMock.mock.mockImplementation(() => Promise.resolve("/test/repo"));
+    listWorktreesCoreMock.mock.mockImplementation(() =>
+      Promise.resolve(
+        ok({
+          worktrees: [],
+          message: "No worktrees found",
+        }),
+      ),
+    );
+
+    await rejects(async () => await listHandler([]), /Exit with code 0/);
+
+    strictEqual(consoleLogMock.mock.calls.length, 1);
+    strictEqual(
+      consoleLogMock.mock.calls[0].arguments[0],
+      "No worktrees found",
+    );
+    strictEqual(exitMock.mock.calls[0].arguments[0], 0);
+  });
+
+  it("should output nothing for empty worktree list with --names option", async () => {
+    resetMocks();
+    getGitRootMock.mock.mockImplementation(() => Promise.resolve("/test/repo"));
+    listWorktreesCoreMock.mock.mockImplementation(() =>
+      Promise.resolve(
+        ok({
+          worktrees: [],
+          message: "No worktrees found",
+        }),
+      ),
+    );
+
+    await rejects(
+      async () => await listHandler(["--names"]),
+      /Exit with code 0/,
+    );
+
+    strictEqual(consoleLogMock.mock.calls.length, 0);
+    strictEqual(exitMock.mock.calls[0].arguments[0], 0);
+  });
+
+  it("should handle fzf selection", async () => {
+    resetMocks();
+    getGitRootMock.mock.mockImplementation(() => Promise.resolve("/test/repo"));
+    selectWorktreeWithFzfMock.mock.mockImplementation(() =>
+      Promise.resolve(
+        ok({
+          name: "feature-1",
+          path: "/test/repo/.git/phantom/worktrees/feature-1",
+          branch: "feature-1",
+          isClean: true,
+        }),
+      ),
+    );
+
+    await rejects(async () => await listHandler(["--fzf"]), /Exit with code 0/);
+
+    strictEqual(getGitRootMock.mock.calls.length, 1);
+    strictEqual(selectWorktreeWithFzfMock.mock.calls.length, 1);
+    strictEqual(listWorktreesCoreMock.mock.calls.length, 0);
+    strictEqual(consoleLogMock.mock.calls.length, 1);
+    strictEqual(consoleLogMock.mock.calls[0].arguments[0], "feature-1");
+    strictEqual(exitMock.mock.calls[0].arguments[0], 0);
+  });
+
+  it("should handle fzf selection error", async () => {
+    resetMocks();
+    getGitRootMock.mock.mockImplementation(() => Promise.resolve("/test/repo"));
+    selectWorktreeWithFzfMock.mock.mockImplementation(() =>
+      Promise.resolve(err({ message: "fzf not found" })),
+    );
+
+    await rejects(
+      async () => await listHandler(["--fzf"]),
+      /Exit with code 1: fzf not found/,
+    );
+
+    strictEqual(getGitRootMock.mock.calls.length, 1);
+    strictEqual(selectWorktreeWithFzfMock.mock.calls.length, 1);
+    strictEqual(consoleErrorMock.mock.calls.length, 1);
+    strictEqual(
+      consoleErrorMock.mock.calls[0].arguments[0],
+      "Error: fzf not found",
+    );
+    strictEqual(exitMock.mock.calls[0].arguments[0], 1);
+  });
+
+  it("should handle listWorktrees error", async () => {
+    resetMocks();
+    getGitRootMock.mock.mockImplementation(() => Promise.resolve("/test/repo"));
+    listWorktreesCoreMock.mock.mockImplementation(() =>
+      Promise.resolve(err({ message: "Failed to list worktrees" })),
+    );
+
+    await rejects(
+      async () => await listHandler([]),
+      /Exit with code 1: Failed to list worktrees/,
+    );
+
+    strictEqual(getGitRootMock.mock.calls.length, 1);
+    strictEqual(listWorktreesCoreMock.mock.calls.length, 1);
+    strictEqual(consoleErrorMock.mock.calls.length, 1);
+    strictEqual(
+      consoleErrorMock.mock.calls[0].arguments[0],
+      "Error: Failed to list worktrees",
+    );
+    strictEqual(exitMock.mock.calls[0].arguments[0], 1);
+  });
+
+  it("should handle fzf selection with no result", async () => {
+    resetMocks();
+    getGitRootMock.mock.mockImplementation(() => Promise.resolve("/test/repo"));
+    selectWorktreeWithFzfMock.mock.mockImplementation(() =>
+      Promise.resolve(ok(null)),
+    );
+
+    await rejects(async () => await listHandler(["--fzf"]), /Exit with code 0/);
+
+    strictEqual(getGitRootMock.mock.calls.length, 1);
+    strictEqual(selectWorktreeWithFzfMock.mock.calls.length, 1);
+    strictEqual(consoleLogMock.mock.calls.length, 0);
+    strictEqual(exitMock.mock.calls[0].arguments[0], 0);
+  });
+});

--- a/src/cli/handlers/list.ts
+++ b/src/cli/handlers/list.ts
@@ -14,6 +14,10 @@ export async function listHandler(args: string[] = []): Promise<void> {
         type: "boolean",
         default: false,
       },
+      names: {
+        type: "boolean",
+        default: false,
+      },
     },
     strict: true,
     allowPositionals: false,
@@ -41,18 +45,28 @@ export async function listHandler(args: string[] = []): Promise<void> {
       const { worktrees, message } = result.value;
 
       if (worktrees.length === 0) {
-        output.log(message || "No worktrees found.");
+        if (!values.names) {
+          output.log(message || "No worktrees found.");
+        }
         process.exit(exitCodes.success);
       }
 
-      const maxNameLength = Math.max(...worktrees.map((wt) => wt.name.length));
+      if (values.names) {
+        for (const worktree of worktrees) {
+          output.log(worktree.name);
+        }
+      } else {
+        const maxNameLength = Math.max(
+          ...worktrees.map((wt) => wt.name.length),
+        );
 
-      for (const worktree of worktrees) {
-        const paddedName = worktree.name.padEnd(maxNameLength + 2);
-        const branchInfo = worktree.branch ? `(${worktree.branch})` : "";
-        const status = !worktree.isClean ? " [dirty]" : "";
+        for (const worktree of worktrees) {
+          const paddedName = worktree.name.padEnd(maxNameLength + 2);
+          const branchInfo = worktree.branch ? `(${worktree.branch})` : "";
+          const status = !worktree.isClean ? " [dirty]" : "";
 
-        output.log(`${paddedName} ${branchInfo}${status}`);
+          output.log(`${paddedName} ${branchInfo}${status}`);
+        }
       }
     }
 

--- a/src/cli/help/list.ts
+++ b/src/cli/help/list.ts
@@ -10,6 +10,11 @@ export const listHelp: CommandHelp = {
       type: "boolean",
       description: "Use fzf for interactive selection",
     },
+    {
+      name: "--names",
+      type: "boolean",
+      description: "Output only phantom names (for scripts and completion)",
+    },
   ],
   examples: [
     {
@@ -20,10 +25,15 @@ export const listHelp: CommandHelp = {
       description: "List worktrees with interactive fzf selection",
       command: "phantom list --fzf",
     },
+    {
+      description: "List only worktree names",
+      command: "phantom list --names",
+    },
   ],
   notes: [
     "Shows all worktrees with their paths and associated branches",
     "The main worktree is marked as '(bare)' if using a bare repository",
     "With --fzf, outputs only the selected worktree name",
+    "Use --names for shell completion scripts and automation",
   ],
 };


### PR DESCRIPTION
## Summary
- Add a new `--names` flag to the `list` command that outputs only worktree names, one per line
- Provide a machine-readable format useful for shell scripts and automation

## Motivation
When using phantom in scripts or for command completion, it's helpful to have a simple output format that lists only the worktree names without additional formatting or information. This follows the pattern of many CLI tools that offer a "plain" or "names-only" output option.

## Changes
- Added `--names` boolean option to the list command arguments
- Modified the output logic to print only worktree names when the flag is used
- Added comprehensive tests for the list handler
- Updated help documentation with the new flag and example

## Test plan
- [ ] Run `phantom list` - should show the normal formatted output with branches and status
- [ ] Run `phantom list --names` - should show only worktree names, one per line
- [ ] Run `phantom list --names` when no worktrees exist - should output nothing
- [ ] Use `phantom list --names` in a shell script or pipe to other commands
- [ ] Run the test suite: `pnpm test src/cli/handlers/list.test.js`

🤖 Generated with [Claude Code](https://claude.ai/code)