### PR TITLE
feat: automatically set tmux window name when creating phantoms

### DIFF
--- a/src/cli/handlers/create.test.js
+++ b/src/cli/handlers/create.test.js
@@ -277,6 +277,7 @@ describe("createHandler", () => {
     const tmuxArgs = executeTmuxCommandMock.mock.calls[0].arguments[0];
     strictEqual(tmuxArgs.direction, "new");
     strictEqual(tmuxArgs.cwd, "/test/repo/.git/phantom/worktrees/feature");
+    strictEqual(tmuxArgs.windowName, "feature");
 
     strictEqual(
       consoleLogMock.mock.calls[0].arguments[0],
@@ -321,6 +322,7 @@ describe("createHandler", () => {
     const tmuxArgs = executeTmuxCommandMock.mock.calls[0].arguments[0];
     strictEqual(tmuxArgs.direction, "vertical");
     strictEqual(tmuxArgs.cwd, "/test/repo/.git/phantom/worktrees/feature");
+    strictEqual(tmuxArgs.windowName, undefined);
 
     strictEqual(
       consoleLogMock.mock.calls[0].arguments[0],

--- a/src/cli/handlers/create.ts
+++ b/src/cli/handlers/create.ts
@@ -244,6 +244,7 @@ export async function createHandler(args: string[]): Promise<void> {
           PHANTOM_NAME: worktreeName,
           PHANTOM_PATH: result.value.path,
         },
+        windowName: tmuxDirection === "new" ? worktreeName : undefined,
       });
 
       if (isErr(tmuxResult)) {

--- a/src/core/process/tmux.ts
+++ b/src/core/process/tmux.ts
@@ -9,6 +9,7 @@ export interface TmuxOptions {
   command: string;
   cwd?: string;
   env?: Record<string, string>;
+  windowName?: string;
 }
 
 export type TmuxSuccess = SpawnSuccess;
@@ -20,13 +21,16 @@ export async function isInsideTmux(): Promise<boolean> {
 export async function executeTmuxCommand(
   options: TmuxOptions,
 ): Promise<Result<TmuxSuccess, ProcessError>> {
-  const { direction, command, cwd, env } = options;
+  const { direction, command, cwd, env, windowName } = options;
 
   const tmuxArgs: string[] = [];
 
   switch (direction) {
     case "new":
       tmuxArgs.push("new-window");
+      if (windowName) {
+        tmuxArgs.push("-n", windowName);
+      }
       break;
     case "vertical":
       tmuxArgs.push("split-window", "-v");


### PR DESCRIPTION
## Summary
- Implements automatic naming of tmux windows when creating phantoms with `--tmux new`
- The tmux window is named after the phantom being created, improving user experience
- Closes #122

## Changes
- Added `windowName` parameter to `TmuxOptions` interface
- Modified `executeTmuxCommand` to use the `-n` flag when creating new windows with a name
- Updated `createHandler` to pass the phantom name as the window name when using `--tmux new`
- Added tests to verify the window naming behavior

## Test plan
- [ ] Run `phantom create feature-branch --tmux new` and verify the new tmux window is named "feature-branch"
- [ ] Run `phantom create feature-branch --tmux vertical` and verify no window name is set (split pane only)
- [ ] Run `phantom create feature-branch --tmux horizontal` and verify no window name is set (split pane only)
- [ ] Run existing tests with `pnpm test` to ensure no regressions
- [ ] Verify the feature works in an actual tmux session

🤖 Generated with [Claude Code](https://claude.ai/code)