### PR TITLE
fix: update attach handler to use shell for --exec option

### DIFF
--- a/src/cli/handlers/attach.test.js
+++ b/src/cli/handlers/attach.test.js
@@ -147,4 +147,27 @@ describe("attachHandler", () => {
       "feature",
     ]);
   });
+
+  it("should execute command when --exec flag is provided", async () => {
+    exitWithErrorMock.mock.resetCalls();
+    outputLogMock.mock.resetCalls();
+    execInWorktreeMock.mock.resetCalls();
+    execInWorktreeMock.mock.mockImplementation(() =>
+      Promise.resolve(ok({ exitCode: 0 })),
+    );
+    getGitRootMock.mock.mockImplementation(() => Promise.resolve("/repo"));
+    attachWorktreeCoreMock.mock.mockImplementation(() =>
+      Promise.resolve(ok("/repo/.git/phantom/worktrees/feature")),
+    );
+
+    process.env.SHELL = "/bin/bash";
+    await attachHandler(["feature", "--exec", "echo hello"]);
+
+    deepStrictEqual(execInWorktreeMock.mock.calls[0].arguments[0], "/repo");
+    deepStrictEqual(execInWorktreeMock.mock.calls[0].arguments[1], "feature");
+    const execArgs = execInWorktreeMock.mock.calls[0].arguments[2];
+    deepStrictEqual(execArgs[0], "/bin/bash");
+    deepStrictEqual(execArgs[1], "-c");
+    deepStrictEqual(execArgs[2], "echo hello");
+  });
 });

--- a/src/cli/handlers/attach.ts
+++ b/src/cli/handlers/attach.ts
@@ -67,10 +67,11 @@ export async function attachHandler(args: string[]): Promise<void> {
       exitWithError(shellResult.error.message, exitCodes.generalError);
     }
   } else if (values.exec) {
+    const shell = process.env.SHELL || "/bin/sh";
     const execResult = await execInWorktree(
       gitRoot,
       branchName,
-      values.exec.split(" "),
+      [shell, "-c", values.exec],
       { interactive: true },
     );
     if (isErr(execResult)) {


### PR DESCRIPTION
## Summary
This PR updates the `attach` handler's `--exec` option to use shell execution, making it consistent with the `create` handler's behavior.

## Changes
- Changed `values.exec.split(" ")` to `[shell, "-c", values.exec]` in the attach handler
- This allows users to use shell features (pipes, redirects, environment variables) in their exec commands

## Background
After discussion in #87, we decided that since the `--exec` option value is directly provided by the user via command line, it's acceptable to execute it through a shell. This gives users the flexibility to use shell features when needed.

## Test plan
- [x] All existing tests pass (`pnpm ready`)
- [ ] Manual testing with shell features (pipes, redirects, etc.)

🤖 Generated with [Claude Code](https://claude.ai/code)