### PR TITLE
feat: add tmux options to phantom shell command

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,13 +85,18 @@ Phantom supports full shell completion for fish and zsh. Use tab key to complete
 When creating worktrees, you can use tmux to open them in new windows or panes. This allows you to manage multiple work environments simultaneously.
 
 ```bash
-# Open worktree in new window
+# Create and open worktree in new window
 phantom create feature-x --tmux
-# Open with split panes
+# Create with split panes
 phantom create feature-y --tmux-vertical
 phantom create feature-z --tmux-horizontal
 
-# Result: 3 worktrees displayed simultaneously, each allowing independent work
+# Open existing worktrees in tmux
+phantom shell feature-x --tmux
+phantom shell feature-y --tmux-v
+phantom shell feature-z --tmux-h
+
+# Result: Multiple worktrees displayed simultaneously, each allowing independent work
 ```
 
 #### Editor Integration

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -170,6 +170,9 @@ phantom shell <name> [options]
 
 **Options:**
 - `--fzf` - Select worktree with fzf and open shell
+- `--tmux`, `-t` - Open shell in new tmux window
+- `--tmux-vertical`, `--tmux-v` - Open shell in vertical split pane
+- `--tmux-horizontal`, `--tmux-h` - Open shell in horizontal split pane
 
 **Environment Variables:**
 When in a phantom shell, these environment variables are set:
@@ -184,7 +187,20 @@ phantom shell feature-auth
 
 # Interactive selection
 phantom shell --fzf
+
+# Open in new tmux window
+phantom shell feature-auth --tmux
+
+# Open in vertical split pane
+phantom shell feature-auth --tmux-v
+
+# Open in horizontal split pane
+phantom shell feature-auth --tmux-h
 ```
+
+**Notes:**
+- tmux options require being inside a tmux session
+- Cannot use `--fzf` with tmux options
 
 ### exec
 

--- a/src/cli/help/shell.ts
+++ b/src/cli/help/shell.ts
@@ -10,6 +10,21 @@ export const shellHelp: CommandHelp = {
       type: "boolean",
       description: "Use fzf for interactive selection",
     },
+    {
+      name: "--tmux, -t",
+      type: "boolean",
+      description: "Open shell in new tmux window",
+    },
+    {
+      name: "--tmux-vertical, --tmux-v",
+      type: "boolean",
+      description: "Open shell in vertical split pane",
+    },
+    {
+      name: "--tmux-horizontal, --tmux-h",
+      type: "boolean",
+      description: "Open shell in horizontal split pane",
+    },
   ],
   examples: [
     {
@@ -20,11 +35,21 @@ export const shellHelp: CommandHelp = {
       description: "Open a shell with interactive fzf selection",
       command: "phantom shell --fzf",
     },
+    {
+      description: "Open a shell in a new tmux window",
+      command: "phantom shell feature-auth --tmux",
+    },
+    {
+      description: "Open a shell in a vertical tmux pane",
+      command: "phantom shell feature-auth --tmux-v",
+    },
   ],
   notes: [
     "Uses your default shell from the SHELL environment variable",
     "The shell starts with the worktree directory as the working directory",
     "Type 'exit' to return to your original directory",
     "With --fzf, you can interactively select the worktree to enter",
+    "Tmux options require being inside a tmux session",
+    "Cannot use --fzf with tmux options",
   ],
 };


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
This PR adds tmux integration options to the `phantom shell` command, providing consistency with the existing tmux options in `phantom create`.

Closes #130

## Changes
- ✅ Added tmux option parsing to shell command handler
- ✅ Added validation for mutual exclusivity between tmux and --fzf options  
- ✅ Implemented tmux execution logic using existing `executeTmuxCommand` utility
- ✅ Updated help documentation for shell command
- ✅ Added comprehensive unit tests for all tmux options
- ✅ Updated README.md with tmux shell examples
- ✅ Updated docs/commands.md with complete tmux documentation

## Implementation Details
The implementation reuses the existing tmux infrastructure from the create command:
- `--tmux` / `-t`: Opens shell in new tmux window
- `--tmux-vertical` / `--tmux-v`: Opens shell in vertical split pane
- `--tmux-horizontal` / `--tmux-h`: Opens shell in horizontal split pane

All tmux options:
- Require being inside a tmux session (validated with `isInsideTmux()`)
- Are mutually exclusive with the `--fzf` option
- Set appropriate phantom environment variables (PHANTOM, PHANTOM_NAME, PHANTOM_PATH)
- Use the window name for new tmux windows

## Test plan
- [x] All existing tests pass
- [x] Added new unit tests for tmux functionality
- [x] `pnpm ready` passes (lint, typecheck, test)
- [ ] Manual testing of tmux options

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)