### PR TITLE
Fix incorrect terminology: "phantom" used instead of "worktree" in multiple files

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,7 +26,7 @@ npm install -g @aku11i/phantom
 
 ### What is a Phantom?
 
-A "phantom" is a Git worktree managed by Phantom. When you create a phantom, it creates a new working directory at `.git/phantom/worktrees/<branch-name>` where you can work independently from your main workspace.
+Phantom is a tool that manages Git worktrees. When you create a worktree with Phantom, it creates a new working directory at `.git/phantom/worktrees/<branch-name>` where you can work independently from your main workspace.
 
 ### Why Use Phantom?
 
@@ -47,15 +47,15 @@ Benefits:
 - **Centralized management** - All worktrees in one predictable location
 - **Simple commands** - Intuitive interface for complex Git operations
 
-## 👻 Your First Phantom
+## 👻 Your First Worktree
 
-Let's create your first phantom:
+Let's create your first worktree:
 
 ```bash
 # Create a new feature branch in its own workspace
 phantom create my-first-feature
 
-# Enter the phantom's workspace
+# Enter the worktree's workspace
 phantom shell my-first-feature
 
 # You're now in a separate workspace!
@@ -67,29 +67,29 @@ exit
 
 ## 🎯 Essential Commands
 
-These five commands will cover 90% of your phantom usage:
+These five commands will cover 90% of your Phantom usage:
 
-### 1. Create a Phantom
+### 1. Create a Worktree
 ```bash
 phantom create feature-name
 ```
 
-### 2. Enter a Phantom
+### 2. Enter a Worktree
 ```bash
 phantom shell feature-name
 ```
 
-### 3. List Your Phantoms
+### 3. List Your Worktrees
 ```bash
 phantom list
 ```
 
-### 4. Run Commands in a Phantom
+### 4. Run Commands in a Worktree
 ```bash
 phantom exec feature-name npm test
 ```
 
-### 5. Delete a Phantom
+### 5. Delete a Worktree
 ```bash
 phantom delete feature-name
 ```
@@ -121,7 +121,7 @@ phantom shell feature-a
 A critical bug needs fixing while you're in the middle of feature development:
 
 ```bash
-# Create a hotfix phantom
+# Create a hotfix worktree
 phantom create hotfix-critical --shell
 
 # You're now in the hotfix workspace
@@ -135,7 +135,7 @@ phantom shell my-feature
 ### Reviewing a Pull Request
 
 ```bash
-# Create phantom from a remote branch
+# Create worktree from a remote branch
 phantom attach origin/pr-branch --shell
 
 # Review code, run tests

--- a/src/cli/help/create.ts
+++ b/src/cli/help/create.ts
@@ -2,7 +2,7 @@ import type { CommandHelp } from "../help.ts";
 
 export const createHelp: CommandHelp = {
   name: "create",
-  description: "Create a new Git worktree (phantom)",
+  description: "Create a new Git worktree",
   usage: "phantom create <name> [options]",
   options: [
     {

--- a/src/cli/help/delete.ts
+++ b/src/cli/help/delete.ts
@@ -2,7 +2,7 @@ import type { CommandHelp } from "../help.ts";
 
 export const deleteHelp: CommandHelp = {
   name: "delete",
-  description: "Delete a Git worktree (phantom)",
+  description: "Delete a Git worktree",
   usage: "phantom delete <name> [options]",
   options: [
     {

--- a/src/cli/help/list.ts
+++ b/src/cli/help/list.ts
@@ -2,7 +2,7 @@ import type { CommandHelp } from "../help.ts";
 
 export const listHelp: CommandHelp = {
   name: "list",
-  description: "List all Git worktrees (phantoms)",
+  description: "List all Git worktrees",
   usage: "phantom list [options]",
   options: [
     {
@@ -13,7 +13,7 @@ export const listHelp: CommandHelp = {
     {
       name: "--names",
       type: "boolean",
-      description: "Output only phantom names (for scripts and completion)",
+      description: "Output only worktree names (for scripts and completion)",
     },
   ],
   examples: [

--- a/src/core/worktree/select.ts
+++ b/src/core/worktree/select.ts
@@ -34,7 +34,7 @@ export async function selectWorktreeWithFzf(
 
   const fzfResult = await selectWithFzf(list, {
     prompt: "Select worktree> ",
-    header: "Git Worktrees (Phantoms)",
+    header: "Git Worktrees",
   });
 
   if (isErr(fzfResult)) {


### PR DESCRIPTION
## Summary
- Fixed incorrect terminology where Git worktrees were referred to as "phantom" instead of "worktree"
- Clarified that Phantom is the tool name, not a term for what it manages

## Changes
### Help Text Files
- Removed "(phantom)" suffix from command descriptions in `create.ts`, `list.ts`, and `delete.ts`
- Changed "phantom names" to "worktree names" in list command help

### FZF Interface
- Updated header from "Git Worktrees (Phantoms)" to "Git Worktrees" in `select.ts`

### Documentation
- Revised `docs/getting-started.md` to consistently use proper terminology:
  - "Phantom" = The name of the tool
  - "Worktree" = What the tool manages (Git worktrees)
- Updated 12 instances throughout the documentation

## Test plan
- [x] Verified all lint checks pass (`pnpm lint`)
- [x] Verified TypeScript compilation succeeds (`pnpm typecheck`)
- [ ] Manual testing of help commands to ensure clarity

Fixes #134

🤖 Generated with [Claude Code](https://claude.ai/code)