### PR TITLE
docs: remove non-existent command options

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -34,7 +34,6 @@ phantom create <name> [options]
 - `--tmux-vertical` / `--tmux-v` - Create and split tmux pane vertically
 - `--tmux-horizontal` / `--tmux-h` - Create and split tmux pane horizontally
 - `--copy-file <file>` - Copy specific files from current worktree (can be used multiple times)
-- `--base <branch>` - Base branch to create from (default: origin/main)
 
 **Examples:**
 ```bash
@@ -49,9 +48,6 @@ phantom create feature-auth --tmux
 
 # Create and copy environment files
 phantom create feature-auth --copy-file .env --copy-file .env.local
-
-# Create from specific branch
-phantom create hotfix --base origin/production
 ```
 
 ### attach
@@ -65,9 +61,6 @@ phantom attach <branch-name> [options]
 **Options:**
 - `--shell` - Attach and enter interactive shell
 - `--exec <command>` - Attach and execute command
-- `--tmux` / `-t` - Attach and open in new tmux window
-- `--tmux-vertical` / `--tmux-v` - Attach and split tmux pane vertically
-- `--tmux-horizontal` / `--tmux-h` - Attach and split tmux pane horizontally
 
 **Examples:**
 ```bash


### PR DESCRIPTION
## Summary
- Remove `--base` option from `create` command documentation
- Remove tmux options (`--tmux`, `--tmux-vertical`, `--tmux-horizontal`) from `attach` command documentation

## Context
These options were documented in `/docs/commands.md` but are not actually implemented in the codebase. This PR fixes the documentation to match the actual implementation.

## Test plan
- [ ] Verify that all documented options for `create` command exist in `src/cli/handlers/create.ts`
- [ ] Verify that all documented options for `attach` command exist in `src/cli/handlers/attach.ts`
- [ ] Check that no other commands have similar documentation issues

🤖 Generated with [Claude Code](https://claude.ai/code)