### PR TITLE
feat: add --base option to phantom create command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -34,6 +34,7 @@ phantom create <name> [options]
 - `--tmux-vertical` / `--tmux-v` - Create and split tmux pane vertically
 - `--tmux-horizontal` / `--tmux-h` - Create and split tmux pane horizontally
 - `--copy-file <file>` - Copy specific files from current worktree (can be used multiple times)
+- `--base <branch/commit>` - Branch or commit to create the new worktree from (defaults to HEAD)
 
 **Examples:**
 ```bash
@@ -48,6 +49,12 @@ phantom create feature-auth --tmux
 
 # Create and copy environment files
 phantom create feature-auth --copy-file .env --copy-file .env.local
+
+# Create from main branch
+phantom create feature-auth --base main
+
+# Create from remote branch
+phantom create hotfix --base origin/production
 ```
 
 ### attach

--- a/packages/cli/src/handlers/completion.ts
+++ b/packages/cli/src/handlers/completion.ts
@@ -227,8 +227,12 @@ _phantom_completion() {
                     _filedir
                     return 0
                     ;;
+                --base)
+                    # Don't complete anything specific for base (branch/commit)
+                    return 0
+                    ;;
                 *)
-                    local opts="--shell --exec --tmux --tmux-vertical --tmux-horizontal --copy-file"
+                    local opts="--shell --exec --tmux --tmux-vertical --tmux-horizontal --copy-file --base"
                     COMPREPLY=( \$(compgen -W "\${opts}" -- "\${cur}") )
                     return 0
                     ;;

--- a/packages/cli/src/handlers/completion.ts
+++ b/packages/cli/src/handlers/completion.ts
@@ -52,6 +52,7 @@ complete -c phantom -n "__phantom_using_command create" -l tmux -d "Open the wor
 complete -c phantom -n "__phantom_using_command create" -l tmux-vertical -d "Open the worktree in a vertical tmux pane"
 complete -c phantom -n "__phantom_using_command create" -l tmux-horizontal -d "Open the worktree in a horizontal tmux pane"
 complete -c phantom -n "__phantom_using_command create" -l copy-file -d "Copy specified files from the current worktree" -r
+complete -c phantom -n "__phantom_using_command create" -l base -d "Branch or commit to create the new worktree from (defaults to HEAD)" -x
 
 # attach command options
 complete -c phantom -n "__phantom_using_command attach" -l shell -d "Open an interactive shell in the worktree after attaching (-s)"
@@ -128,6 +129,7 @@ _phantom() {
                         '--tmux-vertical[Open the worktree in a vertical tmux pane]' \\
                         '--tmux-horizontal[Open the worktree in a horizontal tmux pane]' \\
                         '*--copy-file[Copy specified files from the current worktree]:file:_files' \\
+                        '--base[Branch or commit to create the new worktree from (defaults to HEAD)]:branch/commit:' \\
                         '1:name:'
                     ;;
                 attach)

--- a/packages/cli/src/handlers/create.test.js
+++ b/packages/cli/src/handlers/create.test.js
@@ -382,4 +382,98 @@ describe("createHandler", () => {
     );
     strictEqual(exitMock.mock.calls[0].arguments[0], 2);
   });
+
+  it("should create worktree from specified base branch", async () => {
+    resetMocks();
+    getGitRootMock.mock.mockImplementation(() => Promise.resolve("/test/repo"));
+    createWorktreeMock.mock.mockImplementation(() =>
+      Promise.resolve(
+        ok({
+          message:
+            "Created worktree 'feature' at /test/repo/.git/phantom/worktrees/feature",
+          path: "/test/repo/.git/phantom/worktrees/feature",
+        }),
+      ),
+    );
+
+    await rejects(
+      async () => await createHandler(["feature", "--base", "main"]),
+      /Exit with code 0/,
+    );
+
+    strictEqual(createWorktreeMock.mock.calls.length, 1);
+    strictEqual(createWorktreeMock.mock.calls[0].arguments[0], "/test/repo");
+    strictEqual(createWorktreeMock.mock.calls[0].arguments[1], "feature");
+    strictEqual(createWorktreeMock.mock.calls[0].arguments[2].base, "main");
+
+    strictEqual(
+      consoleLogMock.mock.calls[0].arguments[0],
+      "Created worktree 'feature' at /test/repo/.git/phantom/worktrees/feature",
+    );
+    strictEqual(exitMock.mock.calls[0].arguments[0], 0);
+  });
+
+  it("should create worktree from remote branch", async () => {
+    resetMocks();
+    getGitRootMock.mock.mockImplementation(() => Promise.resolve("/test/repo"));
+    createWorktreeMock.mock.mockImplementation(() =>
+      Promise.resolve(
+        ok({
+          message:
+            "Created worktree 'hotfix' at /test/repo/.git/phantom/worktrees/hotfix",
+          path: "/test/repo/.git/phantom/worktrees/hotfix",
+        }),
+      ),
+    );
+
+    await rejects(
+      async () =>
+        await createHandler(["hotfix", "--base", "origin/production"]),
+      /Exit with code 0/,
+    );
+
+    strictEqual(createWorktreeMock.mock.calls.length, 1);
+    strictEqual(createWorktreeMock.mock.calls[0].arguments[0], "/test/repo");
+    strictEqual(createWorktreeMock.mock.calls[0].arguments[1], "hotfix");
+    strictEqual(
+      createWorktreeMock.mock.calls[0].arguments[2].base,
+      "origin/production",
+    );
+
+    strictEqual(
+      consoleLogMock.mock.calls[0].arguments[0],
+      "Created worktree 'hotfix' at /test/repo/.git/phantom/worktrees/hotfix",
+    );
+    strictEqual(exitMock.mock.calls[0].arguments[0], 0);
+  });
+
+  it("should create worktree from commit hash", async () => {
+    resetMocks();
+    getGitRootMock.mock.mockImplementation(() => Promise.resolve("/test/repo"));
+    createWorktreeMock.mock.mockImplementation(() =>
+      Promise.resolve(
+        ok({
+          message:
+            "Created worktree 'experiment' at /test/repo/.git/phantom/worktrees/experiment",
+          path: "/test/repo/.git/phantom/worktrees/experiment",
+        }),
+      ),
+    );
+
+    await rejects(
+      async () => await createHandler(["experiment", "--base", "abc123"]),
+      /Exit with code 0/,
+    );
+
+    strictEqual(createWorktreeMock.mock.calls.length, 1);
+    strictEqual(createWorktreeMock.mock.calls[0].arguments[0], "/test/repo");
+    strictEqual(createWorktreeMock.mock.calls[0].arguments[1], "experiment");
+    strictEqual(createWorktreeMock.mock.calls[0].arguments[2].base, "abc123");
+
+    strictEqual(
+      consoleLogMock.mock.calls[0].arguments[0],
+      "Created worktree 'experiment' at /test/repo/.git/phantom/worktrees/experiment",
+    );
+    strictEqual(exitMock.mock.calls[0].arguments[0], 0);
+  });
 });

--- a/packages/cli/src/handlers/create.ts
+++ b/packages/cli/src/handlers/create.ts
@@ -51,6 +51,9 @@ export async function createHandler(args: string[]): Promise<void> {
         type: "string",
         multiple: true,
       },
+      base: {
+        type: "string",
+      },
     },
     strict: true,
     allowPositionals: true,
@@ -67,6 +70,7 @@ export async function createHandler(args: string[]): Promise<void> {
   const openShell = values.shell ?? false;
   const execCommand = values.exec;
   const copyFileOptions = values["copy-file"];
+  const baseOption = values.base;
 
   // Determine tmux option
   const tmuxOption =
@@ -134,6 +138,7 @@ export async function createHandler(args: string[]): Promise<void> {
 
     const result = await createWorktreeCore(gitRoot, worktreeName, {
       copyFiles: filesToCopy.length > 0 ? filesToCopy : undefined,
+      base: baseOption,
     });
 
     if (isErr(result)) {

--- a/packages/cli/src/help/create.ts
+++ b/packages/cli/src/help/create.ts
@@ -46,6 +46,13 @@ export const createHelp: CommandHelp = {
         "Copy specified files from the current worktree to the new one. Can be used multiple times",
       example: "--copy-file .env --copy-file config.local.json",
     },
+    {
+      name: "base",
+      type: "string",
+      description:
+        "Branch or commit to create the new worktree from (defaults to HEAD)",
+      example: "--base main, --base origin/feature, --base abc123",
+    },
   ],
   examples: [
     {
@@ -68,6 +75,14 @@ export const createHelp: CommandHelp = {
       description: "Create a worktree and copy environment files",
       command:
         "phantom create staging --copy-file .env --copy-file database.yml",
+    },
+    {
+      description: "Create a worktree from main branch",
+      command: "phantom create feature-new --base main",
+    },
+    {
+      description: "Create a worktree from remote branch",
+      command: "phantom create hotfix --base origin/production",
     },
   ],
   notes: [

--- a/packages/cli/src/help/create.ts
+++ b/packages/cli/src/help/create.ts
@@ -51,7 +51,7 @@ export const createHelp: CommandHelp = {
       type: "string",
       description:
         "Branch or commit to create the new worktree from (defaults to HEAD)",
-      example: "--base main, --base origin/feature, --base abc123",
+      example: "--base main, --base origin/release, --base feature",
     },
   ],
   examples: [

--- a/packages/core/src/worktree/create.test.js
+++ b/packages/core/src/worktree/create.test.js
@@ -94,7 +94,7 @@ describe("createWorktree", () => {
       "/test/repo/.git/phantom/worktrees/feature-branch",
     );
     strictEqual(worktreeOptions.branch, "feature-branch");
-    strictEqual(worktreeOptions.commitish, "HEAD");
+    strictEqual(worktreeOptions.base, "HEAD");
   });
 
   it("should create worktrees directory if it doesn't exist", async () => {
@@ -147,12 +147,12 @@ describe("createWorktree", () => {
     addWorktreeMock.mock.mockImplementation(() => Promise.resolve());
     await createWorktree("/test/repo", "feature", {
       branch: "custom-branch",
-      commitish: "main",
+      base: "main",
     });
 
     const worktreeOptions2 = addWorktreeMock.mock.calls[0].arguments[0];
     strictEqual(worktreeOptions2.branch, "custom-branch");
-    strictEqual(worktreeOptions2.commitish, "main");
+    strictEqual(worktreeOptions2.base, "main");
   });
 
   it("should return error when git worktree add fails", async () => {

--- a/packages/core/src/worktree/create.ts
+++ b/packages/core/src/worktree/create.ts
@@ -11,7 +11,7 @@ import {
 
 export interface CreateWorktreeOptions {
   branch?: string;
-  commitish?: string;
+  base?: string;
   copyFiles?: string[];
 }
 
@@ -35,7 +35,7 @@ export async function createWorktree(
     return nameValidation;
   }
 
-  const { branch = name, commitish = "HEAD" } = options;
+  const { branch = name, base = "HEAD" } = options;
 
   const worktreesPath = getPhantomDirectory(gitRoot);
   const worktreePath = getWorktreePath(gitRoot, name);
@@ -55,7 +55,7 @@ export async function createWorktree(
     await addWorktree({
       path: worktreePath,
       branch,
-      commitish,
+      base,
     });
 
     let copiedFiles: string[] | undefined;

--- a/packages/git/src/libs/add-worktree.ts
+++ b/packages/git/src/libs/add-worktree.ts
@@ -3,11 +3,11 @@ import { executeGitCommand } from "../executor.ts";
 export interface AddWorktreeOptions {
   path: string;
   branch: string;
-  commitish?: string;
+  base?: string;
 }
 
 export async function addWorktree(options: AddWorktreeOptions): Promise<void> {
-  const { path, branch, commitish = "HEAD" } = options;
+  const { path, branch, base = "HEAD" } = options;
 
-  await executeGitCommand(["worktree", "add", path, "-b", branch, commitish]);
+  await executeGitCommand(["worktree", "add", path, "-b", branch, base]);
 }

--- a/packages/mcp/src/tools/create-worktree.test.js
+++ b/packages/mcp/src/tools/create-worktree.test.js
@@ -75,7 +75,7 @@ describe("createWorktreeTool", () => {
       "feature-1",
       {
         branch: "feature-1",
-        commitish: undefined,
+        base: undefined,
       },
     ]);
 
@@ -112,7 +112,7 @@ describe("createWorktreeTool", () => {
       "feature-2",
       {
         branch: "feature-2",
-        commitish: "develop",
+        base: "develop",
       },
     ]);
 

--- a/packages/mcp/src/tools/create-worktree.ts
+++ b/packages/mcp/src/tools/create-worktree.ts
@@ -22,7 +22,7 @@ export const createWorktreeTool: Tool<typeof schema> = {
     const gitRoot = await getGitRoot();
     const result = await createWorktree(gitRoot, name, {
       branch: name,
-      commitish: baseBranch,
+      base: baseBranch,
     });
 
     if (!isOk(result)) {


### PR DESCRIPTION
## Summary
- Add `--base` option to `phantom create` command to specify which branch or commit to create the new worktree from
- Default behavior remains unchanged (creates from HEAD)

## Changes
- ✨ Add `--base` option to CLI argument parser
- 🔧 Pass base option through to core worktree creation logic
- 📝 Update documentation and help text with examples
- 🧪 Add comprehensive tests for the new functionality
- 🎨 Rename internal `commitish` parameter to `base` for better clarity
- 🔨 Update shell completions for fish and zsh

## Examples
```bash
# Create from main branch
phantom create new-feature --base main

# Create from remote branch
phantom create hotfix --base origin/production

# Create from specific commit
phantom create experiment --base abc123
```

## Test plan
- [x] Unit tests added for all variations of --base option
- [x] All existing tests pass
- [x] Linting and type checking pass

Closes #148

🤖 Generated with [Claude Code](https://claude.ai/code)