### PR TITLE
Fix typo in README link formatting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # Claude Context for phantom
 
 ## Project Overview
-Phantom is a CLI tool for managing Git worktrees (called "phantoms") with enhanced functionality. For detailed project information, features, and usage, see [](./README.md).
+Phantom is a CLI tool for managing Git worktrees (called "phantoms") with enhanced functionality. For detailed project information, features, and usage, see [README.md](./README.md).
 
 ## Development Guidelines
 - All files, issues, and pull requests in this repository must be written in English


### PR DESCRIPTION
This PR fixes a minor formatting issue in the CLAUDE.md file where the README.md link was incorrectly formatted as an empty Markdown link [](...). The corrected version now properly displays the link text.

No functional changes — just a typo fix to improve clarity.

