### PR TITLE
docs: update shell completion documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Phantom is a powerful CLI tool that dramatically boosts your development product
 brew install aku11i/tap/phantom
 ```
 
+> **Note:** Shell completions for Fish and Zsh are installed automatically with Homebrew. For Bash completion, see the [Shell Completion](#shell-completion) section below.
+
 #### Using npm
 
 ```bash
@@ -81,6 +83,15 @@ Phantom provides perfect functionality as a command-line tool. Developers feel t
 #### Shell Completion
 
 Phantom supports full shell completion for Fish, Zsh, and Bash. Use tab key to complete commands and worktree names.
+
+When installed via Homebrew, completions for Fish and Zsh are installed automatically. For Bash, you need to manually set up the completion:
+
+```bash
+# Prerequisites: bash-completion v2 must be installed
+
+# For Bash (add to your .bashrc or .bash_profile)
+eval "$(phantom completion bash)"
+```
 
 #### tmux Integration
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -272,16 +272,21 @@ phantom completion <shell>
 **Supported Shells:**
 - `fish` - Fish shell
 - `zsh` - Z shell
+- `bash` - Bash shell
 
 **Installation:**
+
+When installed via Homebrew, completions for Fish and Zsh are installed automatically. For Bash, manual setup is required:
+
 ```bash
-# For Fish
+# For Fish (manual installation if needed)
 phantom completion fish > ~/.config/fish/completions/phantom.fish
 
-# For Zsh (add to .zshrc)
+# For Zsh (manual installation if needed, or add to .zshrc)
 eval "$(phantom completion zsh)"
 
-# For Bash (add to .bashrc)
+# For Bash (always requires manual setup - add to .bashrc or .bash_profile)
+# Prerequisites: bash-completion v2 must be installed
 eval "$(phantom completion bash)"
 ```
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -279,13 +279,13 @@ phantom completion <shell>
 When installed via Homebrew, completions for Fish and Zsh are installed automatically. For Bash, manual setup is required:
 
 ```bash
-# For Fish (manual installation if needed)
-phantom completion fish > ~/.config/fish/completions/phantom.fish
+# For Fish
+phantom completion fish | source
 
-# For Zsh (manual installation if needed, or add to .zshrc)
+# For Zsh (add to .zshrc)
 eval "$(phantom completion zsh)"
 
-# For Bash (always requires manual setup - add to .bashrc or .bash_profile)
+# For Bash (add to .bashrc or .bash_profile)
 # Prerequisites: bash-completion v2 must be installed
 eval "$(phantom completion bash)"
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,6 +22,12 @@ npm install -g @aku11i/phantom
 # Optional tools for better experience: fzf and tmux
 ```
 
+> **Note:** When installed via Homebrew, shell completions for Fish and Zsh are set up automatically. For Bash users, you need bash-completion v2 installed first, then add this to your `.bashrc` or `.bash_profile`:
+> ```bash
+> # Prerequisites: bash-completion v2 must be installed
+> eval "$(phantom completion bash)"
+> ```
+
 ## 💡 Basic Concepts
 
 ### What is a Phantom?

--- a/packages/cli/src/handlers/completion.ts
+++ b/packages/cli/src/handlers/completion.ts
@@ -2,7 +2,7 @@ import { exit } from "node:process";
 import { output } from "../output.ts";
 
 const FISH_COMPLETION_SCRIPT = `# Fish completion for phantom
-# Place this in ~/.config/fish/completions/phantom.fish
+# Load with: phantom completion fish | source
 
 function __phantom_list_worktrees
     phantom list --names 2>/dev/null
@@ -91,8 +91,7 @@ complete -c phantom -n "__phantom_using_command completion" -a "fish zsh bash" -
 
 const ZSH_COMPLETION_SCRIPT = `#compdef phantom
 # Zsh completion for phantom
-# Place this in a directory in your $fpath (e.g., ~/.zsh/completions/)
-# Or load dynamically with: eval "$(phantom completion zsh)"
+# Load with: eval "$(phantom completion zsh)"
 
 # Only define the function, don't execute it
 _phantom() {
@@ -193,8 +192,7 @@ if [[ -n \${ZSH_VERSION} ]]; then
 fi`;
 
 const BASH_COMPLETION_SCRIPT = `# Bash completion for phantom
-# Place this in /etc/bash_completion.d/phantom or ~/.bash_completion
-# Or load dynamically with: eval "$(phantom completion bash)"
+# Load with: eval "$(phantom completion bash)"
 
 _phantom_list_worktrees() {
     phantom list --names 2>/dev/null || true

--- a/packages/cli/src/help/completion.ts
+++ b/packages/cli/src/help/completion.ts
@@ -6,36 +6,22 @@ export const completionHelp: CommandHelp = {
   description: "Generate shell completion scripts for fish, zsh, or bash",
   examples: [
     {
-      command:
-        "phantom completion fish > ~/.config/fish/completions/phantom.fish",
-      description: "Generate and install Fish completion",
-    },
-    {
       command: "phantom completion fish | source",
       description: "Load Fish completion in current session",
     },
     {
-      command: "phantom completion zsh > ~/.zsh/completions/_phantom",
-      description: "Generate and install Zsh completion",
-    },
-    {
       command: 'eval "$(phantom completion zsh)"',
-      description: "Load Zsh completion in current session",
-    },
-    {
-      command: "phantom completion bash > ~/.bash_completion.d/phantom",
-      description: "Generate and install Bash completion",
+      description: "Load Zsh completion (add to .zshrc for persistence)",
     },
     {
       command: 'eval "$(phantom completion bash)"',
-      description: "Load Bash completion in current session",
+      description: "Load Bash completion (add to .bashrc for persistence)",
     },
   ],
   notes: [
     "Supported shells: fish, zsh, bash",
-    "After installing completions, you may need to restart your shell or source the completion file",
-    "For Fish: completions are loaded automatically from ~/.config/fish/completions/",
-    "For Zsh: ensure the completion file is in a directory in your $fpath",
-    "For Bash: ensure bash-completion is installed and source the completion file",
+    "For Fish: use 'source' to load in current session",
+    "For Zsh: add the eval command to your .zshrc for persistence",
+    "For Bash: requires bash-completion v2, add the eval command to your .bashrc for persistence",
   ],
 };


### PR DESCRIPTION
## Summary
- Clarify that bash completion requires manual setup even when installed via Homebrew
- Add note that bash-completion v2 is a prerequisite for bash completion
- Remove file placement instructions for shell completions, only show eval/source methods

## Changes
- Updated README.md to add notes about bash completion manual setup
- Updated docs/commands.md completion section with clearer instructions
- Updated docs/getting-started.md with bash completion setup notes
- Updated help text in completion.ts to only show eval/source methods
- Removed all references to placing completion files in specific directories

## Test plan
- [x] All tests pass (`pnpm ready`)
- [x] Documentation is clear and consistent

🤖 Generated with [Claude Code](https://claude.ai/code)