### PR TITLE
build: add prepublishOnly script to CLI package

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,7 +8,8 @@
     "prebuild": "git clean -fdx dist",
     "build": "node build.ts",
     "typecheck": "tsc --noEmit",
-    "test": "node --test --experimental-strip-types --experimental-test-module-mocks \"src/**/*.test.js\""
+    "test": "node --test --experimental-strip-types --experimental-test-module-mocks \"src/**/*.test.js\"",
+    "prepublishOnly": "pnpm build"
   },
   "dependencies": {
     "@aku11i/phantom-core": "workspace:*",


### PR DESCRIPTION
## Summary
- Add `prepublishOnly` script to packages/cli/package.json that runs `pnpm build`
- Ensures the package is built before publishing

## Test plan
- [ ] Verify that `pnpm build` runs successfully when publishing the package
- [ ] Check that the dist directory is created with the built files

🤖 Generated with [Claude Code](https://claude.ai/code)