### PR TITLE
refactor: simplify test mock implementations

### DIFF
--- a/packages/cli/src/handlers/attach.test.js
+++ b/packages/cli/src/handlers/attach.test.js
@@ -14,6 +14,19 @@ const getGitRootMock = mock.fn();
 const attachWorktreeCoreMock = mock.fn();
 const shellInWorktreeMock = mock.fn();
 const execInWorktreeMock = mock.fn();
+const createContextMock = mock.fn((gitRoot) =>
+  Promise.resolve({
+    gitRoot,
+    worktreesDirectory: `${gitRoot}/.git/phantom/worktrees`,
+  }),
+);
+const loadConfigMock = mock.fn(() =>
+  Promise.resolve({ ok: false, error: new Error("Config not found") }),
+);
+const getWorktreesDirectoryMock = mock.fn(
+  (gitRoot, worktreesDirectory) =>
+    worktreesDirectory || `${gitRoot}/.git/phantom/worktrees`,
+);
 
 mock.module("../errors.ts", {
   namedExports: {
@@ -46,18 +59,9 @@ mock.module("@aku11i/phantom-core", {
     WorktreeAlreadyExistsError,
     shellInWorktree: shellInWorktreeMock,
     execInWorktree: execInWorktreeMock,
-    createContext: mock.fn((gitRoot) =>
-      Promise.resolve({
-        gitRoot,
-        worktreesDirectory: `${gitRoot}/.git/phantom/worktrees`,
-      }),
-    ),
-    loadConfig: mock.fn(() =>
-      Promise.resolve({ ok: false, error: new Error("Config not found") }),
-    ),
-    getWorktreesDirectory: mock.fn((gitRoot, worktreesDirectory) => {
-      return worktreesDirectory || `${gitRoot}/.git/phantom/worktrees`;
-    }),
+    createContext: createContextMock,
+    loadConfig: loadConfigMock,
+    getWorktreesDirectory: getWorktreesDirectoryMock,
   },
 });
 

--- a/packages/cli/src/handlers/create.test.js
+++ b/packages/cli/src/handlers/create.test.js
@@ -20,6 +20,16 @@ const loadConfigMock = mock.fn();
 const isInsideTmuxMock = mock.fn();
 const executeTmuxCommandMock = mock.fn();
 const getPhantomEnvMock = mock.fn();
+const createContextMock = mock.fn((gitRoot) =>
+  Promise.resolve({
+    gitRoot,
+    worktreesDirectory: `${gitRoot}/.git/phantom/worktrees`,
+  }),
+);
+const getWorktreesDirectoryMock = mock.fn(
+  (gitRoot, worktreesDirectory) =>
+    worktreesDirectory || `${gitRoot}/.git/phantom/worktrees`,
+);
 const exitWithErrorMock = mock.fn((message, code) => {
   if (message) consoleErrorMock(`Error: ${message}`);
   exitMock(code);
@@ -55,15 +65,8 @@ mock.module("@aku11i/phantom-core", {
     ConfigParseError,
     ConfigValidationError,
     WorktreeAlreadyExistsError,
-    createContext: mock.fn((gitRoot) =>
-      Promise.resolve({
-        gitRoot,
-        worktreesDirectory: `${gitRoot}/.git/phantom/worktrees`,
-      }),
-    ),
-    getWorktreesDirectory: mock.fn((gitRoot, worktreesDirectory) => {
-      return worktreesDirectory || `${gitRoot}/.git/phantom/worktrees`;
-    }),
+    createContext: createContextMock,
+    getWorktreesDirectory: getWorktreesDirectoryMock,
   },
 });
 

--- a/packages/cli/src/handlers/delete.test.js
+++ b/packages/cli/src/handlers/delete.test.js
@@ -10,6 +10,19 @@ const getGitRootMock = mock.fn();
 const deleteWorktreeMock = mock.fn();
 const selectWorktreeWithFzfMock = mock.fn();
 const getCurrentWorktreeMock = mock.fn();
+const createContextMock = mock.fn((gitRoot) =>
+  Promise.resolve({
+    gitRoot,
+    worktreesDirectory: `${gitRoot}/.git/phantom/worktrees`,
+  }),
+);
+const loadConfigMock = mock.fn(() =>
+  Promise.resolve({ ok: false, error: new Error("Config not found") }),
+);
+const getWorktreesDirectoryMock = mock.fn(
+  (gitRoot, worktreesDirectory) =>
+    worktreesDirectory || `${gitRoot}/.git/phantom/worktrees`,
+);
 const exitWithErrorMock = mock.fn((message, code) => {
   consoleErrorMock(`Error: ${message}`);
   exitMock(code);
@@ -39,18 +52,9 @@ mock.module("@aku11i/phantom-core", {
     selectWorktreeWithFzf: selectWorktreeWithFzfMock,
     WorktreeError,
     WorktreeNotFoundError,
-    createContext: mock.fn((gitRoot) =>
-      Promise.resolve({
-        gitRoot,
-        worktreesDirectory: `${gitRoot}/.git/phantom/worktrees`,
-      }),
-    ),
-    loadConfig: mock.fn(() =>
-      Promise.resolve({ ok: false, error: new Error("Config not found") }),
-    ),
-    getWorktreesDirectory: mock.fn((gitRoot, worktreesDirectory) => {
-      return worktreesDirectory || `${gitRoot}/.git/phantom/worktrees`;
-    }),
+    createContext: createContextMock,
+    loadConfig: loadConfigMock,
+    getWorktreesDirectory: getWorktreesDirectoryMock,
   },
 });
 

--- a/packages/cli/src/handlers/exec.test.js
+++ b/packages/cli/src/handlers/exec.test.js
@@ -18,6 +18,19 @@ const selectWorktreeWithFzfMock = mock.fn();
 const isInsideTmuxMock = mock.fn();
 const executeTmuxCommandMock = mock.fn();
 const getPhantomEnvMock = mock.fn();
+const createContextMock = mock.fn((gitRoot) =>
+  Promise.resolve({
+    gitRoot,
+    worktreesDirectory: `${gitRoot}/.git/phantom/worktrees`,
+  }),
+);
+const loadConfigMock = mock.fn(() =>
+  Promise.resolve({ ok: false, error: new Error("Config not found") }),
+);
+const getWorktreesDirectoryMock = mock.fn(
+  (gitRoot, worktreesDirectory) =>
+    worktreesDirectory || `${gitRoot}/.git/phantom/worktrees`,
+);
 const exitWithErrorMock = mock.fn((message, code) => {
   consoleErrorMock(`Error: ${message}`);
   exitMock(code);
@@ -52,18 +65,9 @@ mock.module("@aku11i/phantom-core", {
     selectWorktreeWithFzf: selectWorktreeWithFzfMock,
     execInWorktree: execInWorktreeMock,
     WorktreeNotFoundError,
-    createContext: mock.fn((gitRoot) =>
-      Promise.resolve({
-        gitRoot,
-        worktreesDirectory: `${gitRoot}/.git/phantom/worktrees`,
-      }),
-    ),
-    loadConfig: mock.fn(() =>
-      Promise.resolve({ ok: false, error: new Error("Config not found") }),
-    ),
-    getWorktreesDirectory: mock.fn((gitRoot, worktreesDirectory) => {
-      return worktreesDirectory || `${gitRoot}/.git/phantom/worktrees`;
-    }),
+    createContext: createContextMock,
+    loadConfig: loadConfigMock,
+    getWorktreesDirectory: getWorktreesDirectoryMock,
   },
 });
 

--- a/packages/cli/src/handlers/shell.test.js
+++ b/packages/cli/src/handlers/shell.test.js
@@ -12,6 +12,24 @@ const validateWorktreeExistsMock = mock.fn();
 const selectWorktreeWithFzfMock = mock.fn();
 const isInsideTmuxMock = mock.fn();
 const executeTmuxCommandMock = mock.fn();
+const getPhantomEnvMock = mock.fn((name, path) => ({
+  PHANTOM: "1",
+  PHANTOM_NAME: name,
+  PHANTOM_PATH: path,
+}));
+const createContextMock = mock.fn((gitRoot) =>
+  Promise.resolve({
+    gitRoot,
+    worktreesDirectory: `${gitRoot}/.git/phantom/worktrees`,
+  }),
+);
+const loadConfigMock = mock.fn(() =>
+  Promise.resolve({ ok: false, error: new Error("Config not found") }),
+);
+const getWorktreesDirectoryMock = mock.fn(
+  (gitRoot, worktreesDirectory) =>
+    worktreesDirectory || `${gitRoot}/.git/phantom/worktrees`,
+);
 const exitWithErrorMock = mock.fn((message, code) => {
   consoleErrorMock(`Error: ${message}`);
   exitMock(code);
@@ -38,11 +56,7 @@ mock.module("@aku11i/phantom-process", {
   namedExports: {
     isInsideTmux: isInsideTmuxMock,
     executeTmuxCommand: executeTmuxCommandMock,
-    getPhantomEnv: mock.fn((name, path) => ({
-      PHANTOM: "1",
-      PHANTOM_NAME: name,
-      PHANTOM_PATH: path,
-    })),
+    getPhantomEnv: getPhantomEnvMock,
   },
 });
 
@@ -52,18 +66,9 @@ mock.module("@aku11i/phantom-core", {
     selectWorktreeWithFzf: selectWorktreeWithFzfMock,
     shellInWorktree: shellInWorktreeMock,
     WorktreeNotFoundError,
-    createContext: mock.fn((gitRoot) =>
-      Promise.resolve({
-        gitRoot,
-        worktreesDirectory: `${gitRoot}/.git/phantom/worktrees`,
-      }),
-    ),
-    loadConfig: mock.fn(() =>
-      Promise.resolve({ ok: false, error: new Error("Config not found") }),
-    ),
-    getWorktreesDirectory: mock.fn((gitRoot, worktreesDirectory) => {
-      return worktreesDirectory || `${gitRoot}/.git/phantom/worktrees`;
-    }),
+    createContext: createContextMock,
+    loadConfig: loadConfigMock,
+    getWorktreesDirectory: getWorktreesDirectoryMock,
   },
 });
 

--- a/packages/cli/src/handlers/where.test.js
+++ b/packages/cli/src/handlers/where.test.js
@@ -9,6 +9,19 @@ const consoleErrorMock = mock.fn();
 const getGitRootMock = mock.fn();
 const whereWorktreeMock = mock.fn();
 const selectWorktreeWithFzfMock = mock.fn();
+const createContextMock = mock.fn((gitRoot) =>
+  Promise.resolve({
+    gitRoot,
+    worktreesDirectory: `${gitRoot}/.git/phantom/worktrees`,
+  }),
+);
+const loadConfigMock = mock.fn(() =>
+  Promise.resolve({ ok: false, error: new Error("Config not found") }),
+);
+const getWorktreesDirectoryMock = mock.fn(
+  (gitRoot, worktreesDirectory) =>
+    worktreesDirectory || `${gitRoot}/.git/phantom/worktrees`,
+);
 const exitWithErrorMock = mock.fn((message, code) => {
   consoleErrorMock(`Error: ${message}`);
   exitMock(code);
@@ -36,18 +49,9 @@ mock.module("@aku11i/phantom-core", {
     whereWorktree: whereWorktreeMock,
     selectWorktreeWithFzf: selectWorktreeWithFzfMock,
     WorktreeNotFoundError,
-    createContext: mock.fn((gitRoot) =>
-      Promise.resolve({
-        gitRoot,
-        worktreesDirectory: `${gitRoot}/.git/phantom/worktrees`,
-      }),
-    ),
-    loadConfig: mock.fn(() =>
-      Promise.resolve({ ok: false, error: new Error("Config not found") }),
-    ),
-    getWorktreesDirectory: mock.fn((gitRoot, worktreesDirectory) => {
-      return worktreesDirectory || `${gitRoot}/.git/phantom/worktrees`;
-    }),
+    createContext: createContextMock,
+    loadConfig: loadConfigMock,
+    getWorktreesDirectory: getWorktreesDirectoryMock,
   },
 });
 


### PR DESCRIPTION
## Summary
- Extract inline mock functions to named variables for better readability
- Remove unnecessary return keywords in arrow functions  
- Keep complex mocks that require conditional logic as-is

## Details
This PR refactors test files to improve readability by:
1. Moving inline mock functions defined in `mock.module()` calls to named variables
2. Simplifying arrow function syntax by removing unnecessary braces and return statements
3. Maintaining complex mock implementations that use conditional logic or event emitters

Note: Initially attempted to use `mockImplementationOnce` for sequential calls, but reverted since Node.js native test framework doesn't support chaining like Jest.

## Test plan
- [x] Run `pnpm ready` (lint, typecheck, tests)
- [x] All tests pass without modification to test behavior

🤖 Generated with [Claude Code](https://claude.ai/code)