### PR TITLE
refactor: restructure preDelete to match postCreate architecture

### DIFF
--- a/packages/cli/src/handlers/delete.ts
+++ b/packages/cli/src/handlers/delete.ts
@@ -94,6 +94,7 @@ export async function deleteHandler(args: string[]): Promise<void> {
       {
         force: forceDelete,
       },
+      context.config?.preDelete?.commands,
     );
 
     if (isErr(result)) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,5 +12,6 @@ export * from "./worktree/validate.ts";
 export * from "./worktree/select.ts";
 export * from "./worktree/file-copier.ts";
 export * from "./worktree/post-create.ts";
+export * from "./worktree/pre-delete.ts";
 export * from "./exec.ts";
 export * from "./shell.ts";

--- a/packages/core/src/worktree/pre-delete.test.js
+++ b/packages/core/src/worktree/pre-delete.test.js
@@ -1,0 +1,112 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it, mock } from "node:test";
+import { isErr, isOk } from "@aku11i/phantom-shared";
+
+const execInWorktreeMock = mock.fn();
+
+mock.module("../exec.ts", {
+  namedExports: {
+    execInWorktree: execInWorktreeMock,
+  },
+});
+
+const { executePreDeleteCommands } = await import("./pre-delete.ts");
+const { ok, err } = await import("@aku11i/phantom-shared");
+
+describe("executePreDeleteCommands", () => {
+  const resetPreDeleteMocks = () => {
+    execInWorktreeMock.mock.resetCalls();
+  };
+
+  it("should execute pre-delete commands successfully", async () => {
+    resetPreDeleteMocks();
+    execInWorktreeMock.mock.mockImplementation(() =>
+      Promise.resolve(ok({ exitCode: 0, stdout: "", stderr: "" })),
+    );
+
+    const result = await executePreDeleteCommands({
+      gitRoot: "/test/repo",
+      worktreesDirectory: "/test/repo/.git/phantom/worktrees",
+      worktreeName: "feature",
+      commands: ["docker compose down", "rm -rf temp"],
+    });
+
+    strictEqual(isOk(result), true);
+    if (isOk(result)) {
+      deepStrictEqual(result.value.executedCommands, [
+        "docker compose down",
+        "rm -rf temp",
+      ]);
+    }
+    strictEqual(execInWorktreeMock.mock.calls.length, 2);
+  });
+
+  it("should handle command execution failure", async () => {
+    resetPreDeleteMocks();
+    execInWorktreeMock.mock.mockImplementation(() =>
+      Promise.resolve(err(new Error("Command failed"))),
+    );
+
+    const result = await executePreDeleteCommands({
+      gitRoot: "/test/repo",
+      worktreesDirectory: "/test/repo/.git/phantom/worktrees",
+      worktreeName: "feature",
+      commands: ["docker compose down"],
+    });
+
+    strictEqual(isErr(result), true);
+    if (isErr(result)) {
+      strictEqual(
+        result.error.message,
+        'Failed to execute pre-delete command "docker compose down": Command failed',
+      );
+    }
+    strictEqual(execInWorktreeMock.mock.calls.length, 1);
+  });
+
+  it("should handle command exit code failure", async () => {
+    resetPreDeleteMocks();
+    execInWorktreeMock.mock.mockImplementation(() =>
+      Promise.resolve(ok({ exitCode: 1, stdout: "", stderr: "Error" })),
+    );
+
+    const result = await executePreDeleteCommands({
+      gitRoot: "/test/repo",
+      worktreesDirectory: "/test/repo/.git/phantom/worktrees",
+      worktreeName: "feature",
+      commands: ["docker compose down"],
+    });
+
+    strictEqual(isErr(result), true);
+    if (isErr(result)) {
+      strictEqual(
+        result.error.message,
+        "Pre-delete command failed with exit code 1: docker compose down",
+      );
+    }
+    strictEqual(execInWorktreeMock.mock.calls.length, 1);
+  });
+
+  it("should stop execution on first command failure", async () => {
+    resetPreDeleteMocks();
+    execInWorktreeMock.mock.mockImplementationOnce(() =>
+      Promise.resolve(ok({ exitCode: 1, stdout: "", stderr: "Error" })),
+    );
+
+    const result = await executePreDeleteCommands({
+      gitRoot: "/test/repo",
+      worktreesDirectory: "/test/repo/.git/phantom/worktrees",
+      worktreeName: "feature",
+      commands: ["echo 'first'", "exit 1", "echo 'should not run'"],
+    });
+
+    strictEqual(isErr(result), true);
+    if (isErr(result)) {
+      strictEqual(
+        result.error.message,
+        "Pre-delete command failed with exit code 1: echo 'first'",
+      );
+    }
+    strictEqual(execInWorktreeMock.mock.calls.length, 1);
+  });
+});

--- a/packages/core/src/worktree/pre-delete.ts
+++ b/packages/core/src/worktree/pre-delete.ts
@@ -1,0 +1,57 @@
+import { type Result, err, isErr, ok } from "@aku11i/phantom-shared";
+import { execInWorktree } from "../exec.ts";
+
+export interface PreDeleteExecutionOptions {
+  gitRoot: string;
+  worktreesDirectory: string;
+  worktreeName: string;
+  commands: string[];
+}
+
+export interface PreDeleteExecutionResult {
+  executedCommands: string[];
+}
+
+export async function executePreDeleteCommands(
+  options: PreDeleteExecutionOptions,
+): Promise<Result<PreDeleteExecutionResult>> {
+  const { gitRoot, worktreesDirectory, worktreeName, commands } = options;
+
+  const executedCommands: string[] = [];
+
+  for (const command of commands) {
+    console.log(`Executing pre-delete command: ${command}`);
+    const shell = process.env.SHELL || "/bin/sh";
+    const cmdResult = await execInWorktree(
+      gitRoot,
+      worktreesDirectory,
+      worktreeName,
+      [shell, "-c", command],
+    );
+
+    if (isErr(cmdResult)) {
+      const errorMessage =
+        cmdResult.error instanceof Error
+          ? cmdResult.error.message
+          : String(cmdResult.error);
+      return err(
+        new Error(
+          `Failed to execute pre-delete command "${command}": ${errorMessage}`,
+        ),
+      );
+    }
+
+    // Check exit code
+    if (cmdResult.value.exitCode !== 0) {
+      return err(
+        new Error(
+          `Pre-delete command failed with exit code ${cmdResult.value.exitCode}: ${command}`,
+        ),
+      );
+    }
+
+    executedCommands.push(command);
+  }
+
+  return ok({ executedCommands });
+}

--- a/packages/mcp/src/tools/delete-worktree.test.js
+++ b/packages/mcp/src/tools/delete-worktree.test.js
@@ -67,6 +67,7 @@ describe("deleteWorktreeTool", () => {
       Promise.resolve({
         gitRoot,
         worktreesDirectory: "/path/to/repo/.git/phantom/worktrees",
+        config: null,
       }),
     );
     deleteWorktreeMock.mock.mockImplementation(() =>
@@ -82,6 +83,7 @@ describe("deleteWorktreeTool", () => {
       "/path/to/repo/.git/phantom/worktrees",
       "feature-1",
       { force: undefined },
+      undefined,
     ]);
 
     strictEqual(result.content.length, 1);
@@ -103,6 +105,7 @@ describe("deleteWorktreeTool", () => {
       Promise.resolve({
         gitRoot,
         worktreesDirectory: "/path/to/repo/.git/phantom/worktrees",
+        config: null,
       }),
     );
     deleteWorktreeMock.mock.mockImplementation(() =>
@@ -120,6 +123,7 @@ describe("deleteWorktreeTool", () => {
       "/path/to/repo/.git/phantom/worktrees",
       "feature-2",
       { force: true },
+      undefined,
     ]);
 
     const parsedContent = JSON.parse(result.content[0].text);
@@ -141,6 +145,7 @@ describe("deleteWorktreeTool", () => {
       Promise.resolve({
         gitRoot,
         worktreesDirectory: "/path/to/repo/.git/phantom/worktrees",
+        config: null,
       }),
     );
     deleteWorktreeMock.mock.mockImplementation(() =>

--- a/packages/mcp/src/tools/delete-worktree.ts
+++ b/packages/mcp/src/tools/delete-worktree.ts
@@ -26,6 +26,7 @@ export const deleteWorktreeTool: Tool<typeof schema> = {
       {
         force,
       },
+      context.config?.preDelete?.commands,
     );
 
     if (!isOk(result)) {


### PR DESCRIPTION
## Summary

This PR refactors the preDelete implementation to match the postCreate structure for consistency.

### Changes:
- Move `executePreDeleteCommands` from `delete.ts` to new `pre-delete.ts` file
- Update `deleteWorktree` function to accept `preDeleteCommands` parameter from context
- Remove inline config loading from `delete.ts`
- Update CLI handler to pass config from context
- Add pre-delete module to core exports
- Update all tests to match new structure

This ensures consistency between preDelete and postCreate implementations, following the same architectural patterns and separation of concerns.

## Related to
- Builds on top of #193 

🤖 Generated with [Claude Code](https://claude.ai/code)