### PR TITLE
feat: generate PhantomConfig type from Zod schema inference

### DIFF
--- a/packages/core/src/config/loader.ts
+++ b/packages/core/src/config/loader.ts
@@ -1,18 +1,14 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { type Result, err, ok } from "@aku11i/phantom-shared";
-import { type ConfigValidationError, validateConfig } from "./validate.ts";
+import type { z } from "zod";
+import {
+  type ConfigValidationError,
+  type phantomConfigSchema,
+  validateConfig,
+} from "./validate.ts";
 
-export interface PhantomConfig {
-  postCreate?: {
-    copyFiles?: string[];
-    commands?: string[];
-  };
-  preDelete?: {
-    commands?: string[];
-  };
-  worktreesDirectory?: string;
-}
+export type PhantomConfig = z.infer<typeof phantomConfigSchema>;
 
 export class ConfigNotFoundError extends Error {
   constructor() {

--- a/packages/core/src/config/validate.ts
+++ b/packages/core/src/config/validate.ts
@@ -9,7 +9,7 @@ export class ConfigValidationError extends Error {
   }
 }
 
-const phantomConfigSchema = z
+export const phantomConfigSchema = z
   .object({
     postCreate: z
       .object({


### PR DESCRIPTION
## Summary
- Replace manually defined `PhantomConfig` interface with Zod type inference
- Export `phantomConfigSchema` to enable `z.infer<typeof phantomConfigSchema>`
- Ensure single source of truth for configuration structure

## Changes
- Export `phantomConfigSchema` from `validate.ts`
- Replace `PhantomConfig` interface in `loader.ts` with `z.infer<typeof phantomConfigSchema>`
- Maintain full backward compatibility - no breaking changes

## Benefits
- Single source of truth for the configuration structure
- Automatic type synchronization when schema changes
- Reduced maintenance overhead
- Better type safety

## Test Plan
- [x] All existing tests pass
- [x] Type checking passes (`pnpm typecheck`)
- [x] Linting passes (`pnpm lint`)
- [x] No breaking changes to public API

Fixes #194

🤖 Generated with [Claude Code](https://claude.ai/code)