### PR TITLE
feat: implement global preferences file for user-specific settings

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,21 +2,42 @@
 
 ## Table of Contents
 
-- [Configuration File](#configuration-file)
+- [Global Preferences](#global-preferences)
+- [Project Configuration](#project-configuration)
 - [Configuration Options](#configuration-options)
   - [worktreesDirectory](#worktreebasedirectory)
   - [postCreate.copyFiles](#postcreatecopyfiles)
   - [postCreate.commands](#postcreatecommands)
+- [Configuration Priority](#configuration-priority)
 
-Phantom supports configuration through a `phantom.config.json` file in your repository root. This allows you to define files to be automatically copied and commands to be executed when creating new worktrees.
+Phantom supports two types of configuration files:
+1. **Global Preferences** (`~/.config/phantom/phantom.json`) - User-specific settings that apply to all projects
+2. **Project Configuration** (`phantom.config.json`) - Project-specific settings that are committed to the repository
 
-## Configuration File
+## Global Preferences
 
-Create a `phantom.config.json` file in your repository root:
+The global preferences file allows you to configure user-specific settings that should not be committed to project repositories.
+
+### Location
+
+The preferences file is located at:
+- Linux/macOS: `~/.config/phantom/phantom.json`
+- With XDG_CONFIG_HOME: `$XDG_CONFIG_HOME/phantom/phantom.json`
+
+### Example
 
 ```json
 {
-  "worktreesDirectory": "../phantom-worktrees",
+  "worktreesDirectory": "/home/user/phantom-worktrees"
+}
+```
+
+## Project Configuration
+
+Create a `phantom.config.json` file in your repository root to define project-specific settings. This file is committed to the repository and shared among all contributors.
+
+```json
+{
   "postCreate": {
     "copyFiles": [
       ".env",
@@ -37,6 +58,27 @@ Create a `phantom.config.json` file in your repository root:
 
 A custom base directory where Phantom worktrees will be created. By default, Phantom creates all worktrees in `.git/phantom/worktrees/`, but you can customize this location using the `worktreesDirectory` option.
 
+> **⚠️ Deprecation Notice**
+> 
+> Setting `worktreesDirectory` in `phantom.config.json` is deprecated and will be removed in a future version.
+> Please move this setting to the global preferences file (`~/.config/phantom/phantom.json`).
+
+**Migration Guide:**
+
+1. Create the global preferences directory:
+   ```bash
+   mkdir -p ~/.config/phantom
+   ```
+
+2. Create or update `~/.config/phantom/phantom.json`:
+   ```json
+   {
+     "worktreesDirectory": "/your/preferred/path"
+   }
+   ```
+
+3. Remove `worktreesDirectory` from your project's `phantom.config.json`
+
 **Use Cases:**
 - Store worktrees outside the main repository directory
 - Use a shared location for multiple repositories
@@ -45,21 +87,21 @@ A custom base directory where Phantom worktrees will be created. By default, Pha
 
 **Examples:**
 
-**Relative path (relative to repository root):**
+**In global preferences (`~/.config/phantom/phantom.json`):**
+
+Relative path (relative to repository root):
 ```json
 {
   "worktreesDirectory": "../phantom-worktrees"
 }
 ```
-This creates worktrees directly in `../phantom-worktrees/` (e.g., `../phantom-worktrees/feature-1`)
 
-**Absolute path:**
+Absolute path:
 ```json
 {
   "worktreesDirectory": "/tmp/my-phantom-worktrees"
 }
 ```
-This creates worktrees directly in `/tmp/my-phantom-worktrees/` (e.g., `/tmp/my-phantom-worktrees/feature-1`)
 
 **Directory Structure:**
 With `worktreesDirectory` set to `../phantom-worktrees`, your directory structure will look like:
@@ -144,3 +186,20 @@ An array of commands to execute after creating a new worktree.
 - Commands run in the new worktree's directory
 - Output is displayed in real-time
 
+## Configuration Priority
+
+Phantom uses the following priority order when determining configuration values:
+
+1. **Global Preferences** (`~/.config/phantom/phantom.json`) - Highest priority
+2. **Project Configuration** (`phantom.config.json`) - Lower priority
+3. **Default Values** - Lowest priority
+
+This means that user-specific settings in the global preferences file will override project-specific settings, allowing users to customize their workflow without modifying shared project files.
+
+### Example
+
+If both files contain `worktreesDirectory`:
+- Global preferences: `"worktreesDirectory": "/home/user/all-worktrees"`
+- Project config: `"worktreesDirectory": "../project-worktrees"`
+
+Phantom will use `/home/user/all-worktrees` from the global preferences.

--- a/packages/core/src/context.test.js
+++ b/packages/core/src/context.test.js
@@ -1,0 +1,151 @@
+import assert from "node:assert";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, mock, test } from "node:test";
+import { createContext } from "./context.ts";
+
+describe("createContext", () => {
+  let tempDir;
+  let gitRoot;
+  let originalXdgConfigHome;
+  let originalHome;
+  let consoleWarnMock;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(path.join(tmpdir(), "phantom-context-test-"));
+    gitRoot = path.join(tempDir, "project");
+    await mkdir(gitRoot, { recursive: true });
+
+    originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
+    originalHome = process.env.HOME;
+
+    // Set HOME to temp directory for testing
+    process.env.HOME = tempDir;
+    // Clear XDG_CONFIG_HOME to test default behavior
+    // biome-ignore lint/performance/noDelete: Need to actually delete env var, not set to "undefined"
+    delete process.env.XDG_CONFIG_HOME;
+
+    // Mock console.warn
+    consoleWarnMock = mock.method(console, "warn");
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+
+    // Restore original environment
+    if (originalXdgConfigHome !== undefined) {
+      process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
+    } else {
+      // biome-ignore lint/performance/noDelete: Need to actually delete env var, not set to "undefined"
+      delete process.env.XDG_CONFIG_HOME;
+    }
+    process.env.HOME = originalHome;
+
+    // Restore console.warn
+    consoleWarnMock.mock.restore();
+  });
+
+  test("should use default worktreesDirectory when no config or preferences", async () => {
+    const context = await createContext(gitRoot);
+
+    assert.strictEqual(context.gitRoot, gitRoot);
+    assert.strictEqual(
+      context.worktreesDirectory,
+      path.join(gitRoot, ".git", "phantom", "worktrees"),
+    );
+    assert.strictEqual(context.config, null);
+    assert.strictEqual(context.preferences, null);
+  });
+
+  test("should use preferences worktreesDirectory when available", async () => {
+    // Create preferences file
+    const configPath = path.join(tempDir, ".config", "phantom");
+    await mkdir(configPath, { recursive: true });
+    await writeFile(
+      path.join(configPath, "phantom.json"),
+      JSON.stringify({ worktreesDirectory: "/preferences/worktrees" }),
+    );
+
+    const context = await createContext(gitRoot);
+
+    assert.strictEqual(context.worktreesDirectory, "/preferences/worktrees");
+    assert.notStrictEqual(context.preferences, null);
+  });
+
+  test("should use config worktreesDirectory when preferences not available", async () => {
+    // Create config file
+    await writeFile(
+      path.join(gitRoot, "phantom.config.json"),
+      JSON.stringify({ worktreesDirectory: "/config/worktrees" }),
+    );
+
+    const context = await createContext(gitRoot);
+
+    assert.strictEqual(context.worktreesDirectory, "/config/worktrees");
+    assert.notStrictEqual(context.config, null);
+
+    // Should show deprecation warning
+    assert.strictEqual(consoleWarnMock.mock.calls.length, 1);
+    assert.ok(
+      consoleWarnMock.mock.calls[0].arguments[0].includes("deprecated"),
+    );
+  });
+
+  test("should prioritize preferences over config for worktreesDirectory", async () => {
+    // Create both preferences and config files
+    const configPath = path.join(tempDir, ".config", "phantom");
+    await mkdir(configPath, { recursive: true });
+    await writeFile(
+      path.join(configPath, "phantom.json"),
+      JSON.stringify({ worktreesDirectory: "/preferences/worktrees" }),
+    );
+
+    await writeFile(
+      path.join(gitRoot, "phantom.config.json"),
+      JSON.stringify({ worktreesDirectory: "/config/worktrees" }),
+    );
+
+    const context = await createContext(gitRoot);
+
+    // Should use preferences value, not config
+    assert.strictEqual(context.worktreesDirectory, "/preferences/worktrees");
+
+    // Should still show deprecation warning for config
+    assert.strictEqual(consoleWarnMock.mock.calls.length, 1);
+    assert.ok(
+      consoleWarnMock.mock.calls[0].arguments[0].includes("deprecated"),
+    );
+  });
+
+  test("should handle relative worktreesDirectory from preferences", async () => {
+    // Create preferences file with relative path
+    const configPath = path.join(tempDir, ".config", "phantom");
+    await mkdir(configPath, { recursive: true });
+    await writeFile(
+      path.join(configPath, "phantom.json"),
+      JSON.stringify({ worktreesDirectory: "../phantom-worktrees" }),
+    );
+
+    const context = await createContext(gitRoot);
+
+    // Should resolve relative to gitRoot
+    assert.strictEqual(
+      context.worktreesDirectory,
+      path.join(gitRoot, "../phantom-worktrees"),
+    );
+  });
+
+  test("should not warn when config has no worktreesDirectory", async () => {
+    // Create config file without worktreesDirectory
+    await writeFile(
+      path.join(gitRoot, "phantom.config.json"),
+      JSON.stringify({ postCreate: { commands: ["echo test"] } }),
+    );
+
+    const _context = await createContext(gitRoot);
+
+    // Should not show deprecation warning
+    assert.strictEqual(consoleWarnMock.mock.calls.length, 0);
+  });
+});

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -1,21 +1,45 @@
 import { isOk } from "@aku11i/phantom-shared";
 import { type PhantomConfig, loadConfig } from "./config/loader.ts";
 import { getWorktreesDirectory } from "./paths.ts";
+import {
+  type PhantomPreferences,
+  loadPreferences,
+} from "./preferences/loader.ts";
 
 export interface Context {
   gitRoot: string;
   worktreesDirectory: string;
   config: PhantomConfig | null;
+  preferences: PhantomPreferences | null;
 }
 
 export async function createContext(gitRoot: string): Promise<Context> {
   const configResult = await loadConfig(gitRoot);
   const config = isOk(configResult) ? configResult.value : null;
-  const worktreesDirectory = config?.worktreesDirectory;
+
+  const preferencesResult = await loadPreferences();
+  const preferences = isOk(preferencesResult) ? preferencesResult.value : null;
+
+  // Priority: preferences > config > default
+  let worktreesDirectory = preferences?.worktreesDirectory;
+
+  // Check if config has worktreesDirectory and warn if it does
+  if (config?.worktreesDirectory) {
+    if (!worktreesDirectory) {
+      // Use config value if preferences doesn't have it
+      worktreesDirectory = config.worktreesDirectory;
+    }
+    // Log deprecation warning
+    console.warn(
+      "Warning: 'worktreesDirectory' in phantom.config.json is deprecated and will be removed in a future update.\n" +
+        "Please move this setting to ~/.config/phantom/phantom.json",
+    );
+  }
 
   return {
     gitRoot,
     worktreesDirectory: getWorktreesDirectory(gitRoot, worktreesDirectory),
     config,
+    preferences,
   };
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,8 @@ export * from "./context.ts";
 export * from "./paths.ts";
 export * from "./config/loader.ts";
 export * from "./config/validate.ts";
+export * from "./preferences/loader.ts";
+export * from "./preferences/validate.ts";
 export * from "./worktree/errors.ts";
 export * from "./worktree/create.ts";
 export * from "./worktree/delete.ts";

--- a/packages/core/src/preferences/loader.test.js
+++ b/packages/core/src/preferences/loader.test.js
@@ -1,0 +1,200 @@
+import assert from "node:assert";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, test } from "node:test";
+import { isErr, isOk } from "@aku11i/phantom-shared";
+import {
+  PreferencesNotFoundError,
+  PreferencesParseError,
+  loadPreferences,
+} from "./loader.ts";
+import { PreferencesValidationError } from "./validate.ts";
+
+describe("loadPreferences", () => {
+  let tempDir;
+  let originalXdgConfigHome;
+  let originalHome;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(path.join(tmpdir(), "phantom-pref-test-"));
+    originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
+    originalHome = process.env.HOME;
+
+    // Set HOME to temp directory for testing
+    process.env.HOME = tempDir;
+    // Clear XDG_CONFIG_HOME to test default behavior
+    // biome-ignore lint/performance/noDelete: Need to actually delete env var, not set to "undefined"
+    delete process.env.XDG_CONFIG_HOME;
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+
+    // Restore original environment
+    if (originalXdgConfigHome !== undefined) {
+      process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
+    } else {
+      // biome-ignore lint/performance/noDelete: Need to actually delete env var, not set to "undefined"
+      delete process.env.XDG_CONFIG_HOME;
+    }
+    process.env.HOME = originalHome;
+  });
+
+  test("should load valid preferences file", async () => {
+    const preferences = {
+      worktreesDirectory: "/custom/worktrees/path",
+    };
+
+    const configPath = path.join(tempDir, ".config", "phantom");
+    await mkdir(configPath, { recursive: true });
+    await writeFile(
+      path.join(configPath, "phantom.json"),
+      JSON.stringify(preferences),
+    );
+
+    const result = await loadPreferences();
+
+    assert.strictEqual(isOk(result), true);
+    if (isOk(result)) {
+      assert.deepStrictEqual(result.value, preferences);
+    }
+  });
+
+  test("should respect XDG_CONFIG_HOME when set", async () => {
+    const customConfigDir = path.join(tempDir, "custom-config");
+    process.env.XDG_CONFIG_HOME = customConfigDir;
+
+    const preferences = {
+      worktreesDirectory: "/xdg/worktrees",
+    };
+
+    const configPath = path.join(customConfigDir, "phantom");
+    await mkdir(configPath, { recursive: true });
+    await writeFile(
+      path.join(configPath, "phantom.json"),
+      JSON.stringify(preferences),
+    );
+
+    const result = await loadPreferences();
+
+    assert.strictEqual(isOk(result), true);
+    if (isOk(result)) {
+      assert.deepStrictEqual(result.value, preferences);
+    }
+  });
+
+  test("should return PreferencesNotFoundError when file doesn't exist", async () => {
+    const result = await loadPreferences();
+
+    assert.strictEqual(isErr(result), true);
+    if (isErr(result)) {
+      assert.ok(result.error instanceof PreferencesNotFoundError);
+    }
+  });
+
+  test("should return PreferencesParseError for invalid JSON", async () => {
+    const configPath = path.join(tempDir, ".config", "phantom");
+    await mkdir(configPath, { recursive: true });
+    await writeFile(path.join(configPath, "phantom.json"), "{ invalid json");
+
+    const result = await loadPreferences();
+
+    assert.strictEqual(isErr(result), true);
+    if (isErr(result)) {
+      assert.ok(result.error instanceof PreferencesParseError);
+    }
+  });
+
+  test("should load empty preferences", async () => {
+    const configPath = path.join(tempDir, ".config", "phantom");
+    await mkdir(configPath, { recursive: true });
+    await writeFile(path.join(configPath, "phantom.json"), "{}");
+
+    const result = await loadPreferences();
+
+    assert.strictEqual(isOk(result), true);
+    if (isOk(result)) {
+      assert.deepStrictEqual(result.value, {});
+    }
+  });
+
+  describe("validation", () => {
+    test("should return PreferencesValidationError when preferences is not an object", async () => {
+      const configPath = path.join(tempDir, ".config", "phantom");
+      await mkdir(configPath, { recursive: true });
+      await writeFile(
+        path.join(configPath, "phantom.json"),
+        JSON.stringify("string preferences"),
+      );
+
+      const result = await loadPreferences();
+
+      assert.strictEqual(isErr(result), true);
+      if (isErr(result)) {
+        assert.ok(result.error instanceof PreferencesValidationError);
+        assert.strictEqual(
+          result.error.message,
+          "Invalid phantom.json: Expected object, received string",
+        );
+      }
+    });
+
+    test("should return PreferencesValidationError when preferences is null", async () => {
+      const configPath = path.join(tempDir, ".config", "phantom");
+      await mkdir(configPath, { recursive: true });
+      await writeFile(path.join(configPath, "phantom.json"), "null");
+
+      const result = await loadPreferences();
+
+      assert.strictEqual(isErr(result), true);
+      if (isErr(result)) {
+        assert.ok(result.error instanceof PreferencesValidationError);
+        assert.strictEqual(
+          result.error.message,
+          "Invalid phantom.json: Expected object, received null",
+        );
+      }
+    });
+
+    test("should accept valid preferences with worktreesDirectory", async () => {
+      const preferences = {
+        worktreesDirectory: "../phantom-worktrees",
+      };
+
+      const configPath = path.join(tempDir, ".config", "phantom");
+      await mkdir(configPath, { recursive: true });
+      await writeFile(
+        path.join(configPath, "phantom.json"),
+        JSON.stringify(preferences),
+      );
+
+      const result = await loadPreferences();
+
+      assert.strictEqual(isOk(result), true);
+      if (isOk(result)) {
+        assert.deepStrictEqual(result.value, preferences);
+      }
+    });
+
+    test("should return PreferencesValidationError when preferences is an array", async () => {
+      const configPath = path.join(tempDir, ".config", "phantom");
+      await mkdir(configPath, { recursive: true });
+      await writeFile(
+        path.join(configPath, "phantom.json"),
+        JSON.stringify([]),
+      );
+
+      const result = await loadPreferences();
+
+      assert.strictEqual(isErr(result), true);
+      if (isErr(result)) {
+        assert.ok(result.error instanceof PreferencesValidationError);
+        assert.strictEqual(
+          result.error.message,
+          "Invalid phantom.json: Expected object, received array",
+        );
+      }
+    });
+  });
+});

--- a/packages/core/src/preferences/loader.ts
+++ b/packages/core/src/preferences/loader.ts
@@ -1,0 +1,68 @@
+import fs from "node:fs/promises";
+import { homedir } from "node:os";
+import path from "node:path";
+import { type Result, err, ok } from "@aku11i/phantom-shared";
+import type { z } from "zod";
+import {
+  type PreferencesValidationError,
+  type phantomPreferencesSchema,
+  validatePreferences,
+} from "./validate.ts";
+
+export type PhantomPreferences = z.infer<typeof phantomPreferencesSchema>;
+
+export class PreferencesNotFoundError extends Error {
+  constructor() {
+    super("phantom.json not found");
+    this.name = this.constructor.name;
+  }
+}
+
+export class PreferencesParseError extends Error {
+  constructor(message: string) {
+    super(`Failed to parse phantom.json: ${message}`);
+    this.name = this.constructor.name;
+  }
+}
+
+function getPreferencesPath(): string {
+  const configHome =
+    process.env.XDG_CONFIG_HOME || path.join(homedir(), ".config");
+  return path.join(configHome, "phantom", "phantom.json");
+}
+
+export async function loadPreferences(): Promise<
+  Result<
+    PhantomPreferences,
+    | PreferencesNotFoundError
+    | PreferencesParseError
+    | PreferencesValidationError
+  >
+> {
+  const preferencesPath = getPreferencesPath();
+
+  try {
+    const content = await fs.readFile(preferencesPath, "utf-8");
+    try {
+      const parsed = JSON.parse(content);
+      const validationResult = validatePreferences(parsed);
+
+      if (!validationResult.ok) {
+        return err(validationResult.error);
+      }
+
+      return ok(validationResult.value);
+    } catch (error) {
+      return err(
+        new PreferencesParseError(
+          error instanceof Error ? error.message : String(error),
+        ),
+      );
+    }
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return err(new PreferencesNotFoundError());
+    }
+    throw error;
+  }
+}

--- a/packages/core/src/preferences/validate.test.js
+++ b/packages/core/src/preferences/validate.test.js
@@ -1,0 +1,80 @@
+import assert from "node:assert";
+import { describe, test } from "node:test";
+import { isErr, isOk } from "@aku11i/phantom-shared";
+import { PreferencesValidationError, validatePreferences } from "./validate.ts";
+
+describe("validatePreferences", () => {
+  test("should validate empty object", () => {
+    const result = validatePreferences({});
+
+    assert.strictEqual(isOk(result), true);
+    if (isOk(result)) {
+      assert.deepStrictEqual(result.value, {});
+    }
+  });
+
+  test("should validate object with worktreesDirectory", () => {
+    const preferences = { worktreesDirectory: "/path/to/worktrees" };
+    const result = validatePreferences(preferences);
+
+    assert.strictEqual(isOk(result), true);
+    if (isOk(result)) {
+      assert.deepStrictEqual(result.value, preferences);
+    }
+  });
+
+  test("should validate object with additional properties (passthrough)", () => {
+    const preferences = {
+      worktreesDirectory: "/path/to/worktrees",
+      futureOption: "someValue",
+    };
+    const result = validatePreferences(preferences);
+
+    assert.strictEqual(isOk(result), true);
+    if (isOk(result)) {
+      assert.deepStrictEqual(result.value, preferences);
+    }
+  });
+
+  test("should reject non-object types", () => {
+    const testCases = [
+      { input: "string", expected: "Expected object, received string" },
+      { input: 123, expected: "Expected object, received number" },
+      { input: true, expected: "Expected object, received boolean" },
+      { input: null, expected: "Expected object, received null" },
+      { input: [], expected: "Expected object, received array" },
+    ];
+
+    for (const { input, expected } of testCases) {
+      const result = validatePreferences(input);
+
+      assert.strictEqual(isErr(result), true);
+      if (isErr(result)) {
+        assert.ok(result.error instanceof PreferencesValidationError);
+        assert.strictEqual(
+          result.error.message,
+          `Invalid phantom.json: ${expected}`,
+        );
+      }
+    }
+  });
+
+  test("should reject invalid worktreesDirectory types", () => {
+    const testCases = [
+      { worktreesDirectory: 123 },
+      { worktreesDirectory: true },
+      { worktreesDirectory: [] },
+      { worktreesDirectory: {} },
+    ];
+
+    for (const input of testCases) {
+      const result = validatePreferences(input);
+
+      assert.strictEqual(isErr(result), true);
+      if (isErr(result)) {
+        assert.ok(result.error instanceof PreferencesValidationError);
+        assert.ok(result.error.message.includes("worktreesDirectory"));
+      }
+    }
+  });
+});

--- a/packages/core/src/preferences/validate.ts
+++ b/packages/core/src/preferences/validate.ts
@@ -1,0 +1,37 @@
+import { type Result, err, ok } from "@aku11i/phantom-shared";
+import { z } from "zod";
+import type { PhantomPreferences } from "./loader.ts";
+
+export class PreferencesValidationError extends Error {
+  constructor(message: string) {
+    super(`Invalid phantom.json: ${message}`);
+    this.name = this.constructor.name;
+  }
+}
+
+export const phantomPreferencesSchema = z
+  .object({
+    worktreesDirectory: z.string().optional(),
+  })
+  .passthrough();
+
+export function validatePreferences(
+  preferences: unknown,
+): Result<PhantomPreferences, PreferencesValidationError> {
+  const result = phantomPreferencesSchema.safeParse(preferences);
+
+  if (!result.success) {
+    const error = result.error;
+
+    // Get the first error message from Zod's formatted output
+    const firstError = error.errors[0];
+    const path = firstError.path.join(".");
+    const message = path
+      ? `${path}: ${firstError.message}`
+      : firstError.message;
+
+    return err(new PreferencesValidationError(message));
+  }
+
+  return ok(result.data as PhantomPreferences);
+}


### PR DESCRIPTION
## Summary
- Implements global preferences file at `~/.config/phantom/phantom.json` to store user-specific settings
- Adds support for XDG_CONFIG_HOME environment variable following XDG Base Directory specification
- Migrates `worktreesDirectory` setting from project config to global preferences with deprecation warning

## Implementation Details

### New Features
- **Global preferences file**: Located at `~/.config/phantom/phantom.json` (or `$XDG_CONFIG_HOME/phantom/phantom.json`)
- **Configuration priority system**: Global preferences > Project config > Default values
- **Deprecation warning**: Shows when `worktreesDirectory` is found in project config

### Code Changes
- Created new `preferences` module in `packages/core/src/preferences/`
  - `loader.ts` - Handles loading preferences from filesystem
  - `validate.ts` - Validates preferences using Zod schema
- Updated `context.ts` to load both project config and user preferences
- Added comprehensive test coverage for all new functionality

### Documentation
- Updated configuration documentation with:
  - New global preferences section
  - Migration guide for `worktreesDirectory`
  - Configuration priority explanation

## Test Plan
- [x] All existing tests pass
- [x] New tests for preferences loading and validation
- [x] Tests for XDG_CONFIG_HOME handling
- [x] Tests for configuration priority system
- [x] Tests for deprecation warnings
- [ ] Manual testing with actual preferences file
- [ ] Test migration from project config to global preferences

## Breaking Changes
None - the implementation maintains backward compatibility. The `worktreesDirectory` in project config still works but shows a deprecation warning.

## Future Considerations
This establishes a pattern for other user-specific settings that may be added in the future, keeping project configuration separate from personal preferences.

Closes #196

🤖 Generated with [Claude Code](https://claude.ai/code)