### PR TITLE
fix: add engines field to published package.json for Node.js badge

### DIFF
--- a/packages/cli/dist/package.json
+++ b/packages/cli/dist/package.json
@@ -31,5 +31,8 @@
     "README.md",
     "LICENSE"
   ],
+  "engines": {
+    "node": ">=22.0.0"
+  },
   "dependencies": {}
 }


### PR DESCRIPTION
## Summary
- Added `engines` field to the published package.json to fix the Node.js version badge in README
- The badge was showing "not specified" because the npm package metadata was missing the Node.js version requirement

## Details
The monorepo root `package.json` has `engines.node: ">=22.0.0"`, but the published package at `packages/cli/dist/package.json` was missing this field. This caused the Node.js version badge in the README to display "not specified" instead of the actual requirement.

## Test plan
- [x] Run `pnpm ready` to ensure all tests pass
- [x] Verified the `engines` field is properly added to `packages/cli/dist/package.json`
- [ ] After publishing, the Node.js badge should display ">=22.0.0" instead of "not specified"

🤖 Generated with [Claude Code](https://claude.ai/code)