### PR TITLE
fix: prevent "refusing to fetch into branch" error when re-checking out PR

### DIFF
--- a/packages/github/src/checkout/issue.test.js
+++ b/packages/github/src/checkout/issue.test.js
@@ -208,12 +208,12 @@ describe("checkoutIssue", () => {
     const result = await checkoutIssue(mockIssue);
 
     ok(result.value);
-    equal(
-      result.value.message,
-      "Issue #111 is already checked out",
-    );
+    equal(result.value.message, "Issue #111 is already checked out");
     equal(result.value.alreadyExists, true);
-    equal(result.value.path, `${mockGitRoot}/.git/phantom/worktrees/issues/111`);
+    equal(
+      result.value.path,
+      `${mockGitRoot}/.git/phantom/worktrees/issues/111`,
+    );
 
     // Verify that createWorktreeCore was not called
     equal(createWorktreeCoreMock.mock.calls.length, 0);

--- a/packages/github/src/checkout/issue.test.js
+++ b/packages/github/src/checkout/issue.test.js
@@ -6,6 +6,7 @@ const createWorktreeCoreMock = mock.fn();
 const isPullRequestMock = mock.fn();
 const createContextMock = mock.fn();
 const getWorktreePathFromDirectoryMock = mock.fn();
+const validateWorktreeExistsMock = mock.fn();
 
 // Mock the WorktreeAlreadyExistsError class
 class MockWorktreeAlreadyExistsError extends Error {
@@ -27,6 +28,7 @@ mock.module("@aku11i/phantom-core", {
     WorktreeAlreadyExistsError: MockWorktreeAlreadyExistsError,
     createContext: createContextMock,
     getWorktreePathFromDirectory: getWorktreePathFromDirectoryMock,
+    validateWorktreeExists: validateWorktreeExistsMock,
   },
 });
 
@@ -43,6 +45,7 @@ describe("checkoutIssue", () => {
     getGitRootMock.mock.resetCalls();
     createWorktreeCoreMock.mock.resetCalls();
     isPullRequestMock.mock.resetCalls();
+    validateWorktreeExistsMock.mock.resetCalls();
   };
 
   it("should export checkoutIssue function", () => {
@@ -103,6 +106,11 @@ describe("checkoutIssue", () => {
       gitRoot: mockGitRoot,
       worktreesDirectory: `${mockGitRoot}/.git/phantom/worktrees`,
     }));
+    // Mock that worktree doesn't exist
+    validateWorktreeExistsMock.mock.mockImplementation(async () => ({
+      ok: false,
+      error: new Error("Worktree not found"),
+    }));
     createWorktreeCoreMock.mock.mockImplementation(async () => ({
       ok: true,
       value: {
@@ -153,6 +161,11 @@ describe("checkoutIssue", () => {
       gitRoot: mockGitRoot,
       worktreesDirectory: `${mockGitRoot}/.git/phantom/worktrees`,
     }));
+    // Mock that worktree doesn't exist
+    validateWorktreeExistsMock.mock.mockImplementation(async () => ({
+      ok: false,
+      error: new Error("Worktree not found"),
+    }));
     createWorktreeCoreMock.mock.mockImplementation(async () => ({
       ok: true,
       value: {
@@ -186,22 +199,24 @@ describe("checkoutIssue", () => {
       gitRoot: mockGitRoot,
       worktreesDirectory: `${mockGitRoot}/.git/phantom/worktrees`,
     }));
-    createWorktreeCoreMock.mock.mockImplementation(async () => ({
-      ok: false,
-      error: new MockWorktreeAlreadyExistsError("Worktree already exists"),
+    // Mock that worktree already exists
+    validateWorktreeExistsMock.mock.mockImplementation(async () => ({
+      ok: true,
+      value: { path: `${mockGitRoot}/.git/phantom/worktrees/issues/111` },
     }));
-    getWorktreePathFromDirectoryMock.mock.mockImplementation(
-      (dir, name) => `${dir}/${name}`,
-    );
 
     const result = await checkoutIssue(mockIssue);
 
     ok(result.value);
     equal(
       result.value.message,
-      "Worktree for issue #111 is already checked out",
+      "Issue #111 is already checked out",
     );
     equal(result.value.alreadyExists, true);
+    equal(result.value.path, `${mockGitRoot}/.git/phantom/worktrees/issues/111`);
+
+    // Verify that createWorktreeCore was not called
+    equal(createWorktreeCoreMock.mock.calls.length, 0);
   });
 
   it("should pass through other errors", async () => {
@@ -216,6 +231,11 @@ describe("checkoutIssue", () => {
     createContextMock.mock.mockImplementation(async () => ({
       gitRoot: mockGitRoot,
       worktreesDirectory: `${mockGitRoot}/.git/phantom/worktrees`,
+    }));
+    // Mock that worktree doesn't exist
+    validateWorktreeExistsMock.mock.mockImplementation(async () => ({
+      ok: false,
+      error: new Error("Worktree not found"),
     }));
     const expectedError = new Error("Permission denied");
     createWorktreeCoreMock.mock.mockImplementation(async () => ({
@@ -241,6 +261,11 @@ describe("checkoutIssue", () => {
     createContextMock.mock.mockImplementation(async () => ({
       gitRoot: mockGitRoot,
       worktreesDirectory: `${mockGitRoot}/.git/phantom/worktrees`,
+    }));
+    // Mock that worktree doesn't exist
+    validateWorktreeExistsMock.mock.mockImplementation(async () => ({
+      ok: false,
+      error: new Error("Worktree not found"),
     }));
     createWorktreeCoreMock.mock.mockImplementation(async () => ({
       ok: true,

--- a/packages/github/src/checkout/pr.test.js
+++ b/packages/github/src/checkout/pr.test.js
@@ -7,6 +7,7 @@ const attachWorktreeCoreMock = mock.fn();
 const setUpstreamBranchMock = mock.fn();
 const createContextMock = mock.fn();
 const getWorktreePathFromDirectoryMock = mock.fn();
+const validateWorktreeExistsMock = mock.fn();
 
 // Mock the WorktreeAlreadyExistsError class
 class MockWorktreeAlreadyExistsError extends Error {
@@ -30,6 +31,7 @@ mock.module("@aku11i/phantom-core", {
     WorktreeAlreadyExistsError: MockWorktreeAlreadyExistsError,
     createContext: createContextMock,
     getWorktreePathFromDirectory: getWorktreePathFromDirectoryMock,
+    validateWorktreeExists: validateWorktreeExistsMock,
   },
 });
 
@@ -41,6 +43,7 @@ describe("checkoutPullRequest", () => {
     fetchMock.mock.resetCalls();
     attachWorktreeCoreMock.mock.resetCalls();
     setUpstreamBranchMock.mock.resetCalls();
+    validateWorktreeExistsMock.mock.resetCalls();
   };
 
   it("should export checkoutPullRequest function", () => {
@@ -75,6 +78,11 @@ describe("checkoutPullRequest", () => {
     createContextMock.mock.mockImplementation(async () => ({
       gitRoot: mockGitRoot,
       worktreesDirectory: `${mockGitRoot}/.git/phantom/worktrees`,
+    }));
+    // Mock that worktree doesn't exist
+    validateWorktreeExistsMock.mock.mockImplementation(async () => ({
+      ok: false,
+      error: new Error("Worktree not found"),
     }));
     fetchMock.mock.mockImplementation(async () => ({
       ok: true,
@@ -146,31 +154,25 @@ describe("checkoutPullRequest", () => {
       gitRoot: mockGitRoot,
       worktreesDirectory: `${mockGitRoot}/.git/phantom/worktrees`,
     }));
-    fetchMock.mock.mockImplementation(async () => ({
+    // Mock that worktree already exists
+    validateWorktreeExistsMock.mock.mockImplementation(async () => ({
       ok: true,
-      value: undefined,
+      value: { path: `${mockGitRoot}/.git/phantom/worktrees/pulls/456` },
     }));
-    attachWorktreeCoreMock.mock.mockImplementation(async () => ({
-      ok: false,
-      error: new MockWorktreeAlreadyExistsError("Worktree already exists"),
-    }));
-    setUpstreamBranchMock.mock.mockImplementation(async () => ({
-      ok: true,
-      value: undefined,
-    }));
-    getWorktreePathFromDirectoryMock.mock.mockImplementation(
-      (dir, name) => `${dir}/${name}`,
-    );
 
     const result = await checkoutPullRequest(mockPullRequest);
 
     ok(result.value);
-    equal(result.value.message, "Worktree for PR #456 is already checked out");
+    equal(result.value.message, "PR #456 is already checked out");
     equal(result.value.alreadyExists, true);
+    equal(result.value.path, `${mockGitRoot}/.git/phantom/worktrees/pulls/456`);
 
-    // Verify upstream function was called even when worktree already exists
-    // (since fetch succeeded and upstream is set before attach)
-    equal(setUpstreamBranchMock.mock.calls.length, 1);
+    // Verify that fetch was not called when worktree already exists
+    equal(fetchMock.mock.calls.length, 0);
+    // Verify that attachWorktreeCore was not called
+    equal(attachWorktreeCoreMock.mock.calls.length, 0);
+    // Verify that setUpstreamBranch was not called
+    equal(setUpstreamBranchMock.mock.calls.length, 0);
   });
 
   it("should pass through other errors", async () => {
@@ -196,6 +198,11 @@ describe("checkoutPullRequest", () => {
     createContextMock.mock.mockImplementation(async () => ({
       gitRoot: mockGitRoot,
       worktreesDirectory: `${mockGitRoot}/.git/phantom/worktrees`,
+    }));
+    // Mock that worktree doesn't exist
+    validateWorktreeExistsMock.mock.mockImplementation(async () => ({
+      ok: false,
+      error: new Error("Worktree not found"),
     }));
     fetchMock.mock.mockImplementation(async () => ({
       ok: true,
@@ -245,6 +252,11 @@ describe("checkoutPullRequest", () => {
       gitRoot: mockGitRoot,
       worktreesDirectory: `${mockGitRoot}/.git/phantom/worktrees`,
     }));
+    // Mock that worktree doesn't exist
+    validateWorktreeExistsMock.mock.mockImplementation(async () => ({
+      ok: false,
+      error: new Error("Worktree not found"),
+    }));
     fetchMock.mock.mockImplementation(async () => ({
       ok: true,
       value: undefined,
@@ -289,6 +301,11 @@ describe("checkoutPullRequest", () => {
     createContextMock.mock.mockImplementation(async () => ({
       gitRoot: mockGitRoot,
       worktreesDirectory: `${mockGitRoot}/.git/phantom/worktrees`,
+    }));
+    // Mock that worktree doesn't exist
+    validateWorktreeExistsMock.mock.mockImplementation(async () => ({
+      ok: false,
+      error: new Error("Worktree not found"),
     }));
     fetchMock.mock.mockImplementation(async () => ({
       ok: true,
@@ -350,6 +367,11 @@ describe("checkoutPullRequest", () => {
     createContextMock.mock.mockImplementation(async () => ({
       gitRoot: mockGitRoot,
       worktreesDirectory: `${mockGitRoot}/.git/phantom/worktrees`,
+    }));
+    // Mock that worktree doesn't exist
+    validateWorktreeExistsMock.mock.mockImplementation(async () => ({
+      ok: false,
+      error: new Error("Worktree not found"),
     }));
     fetchMock.mock.mockImplementation(async () => ({
       ok: false,


### PR DESCRIPTION
## Summary
- Fixed error that occurs when attempting to checkout a PR that has already been checked out
- Added worktree existence check before attempting to fetch
- Returns friendly message instead of git error

## Problem
When trying to checkout a PR that was already checked out, users would see:
```
Error: Failed to fetch PR #168: git fetch failed: fatal: refusing to fetch into branch 'refs/heads/pulls/168' checked out at '/path/to/worktree'
```

## Solution
- Check if worktree already exists using `validateWorktreeExists` before attempting to fetch
- Return early with a friendly message: `PR #168 is already checked out`
- Remove duplicate handling of `WorktreeAlreadyExistsError` since we now check earlier

## Test Plan
- [x] All existing tests pass
- [x] Updated test to verify new behavior
- [x] Manually tested checking out and re-checking out a PR
- [x] Verified the error no longer occurs

Fixes #201

🤖 Generated with [Claude Code](https://claude.ai/code)