### PR TITLE
Release v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aku11i/phantom-monorepo",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "packageManager": "pnpm@10.8.1",
   "private": true,
   "type": "module",

--- a/packages/cli/dist/package.json
+++ b/packages/cli/dist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aku11i/phantom",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "description": "A powerful CLI tool for managing Git worktrees for parallel development",
   "keywords": [
     "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aku11i/phantom-cli",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aku11i/phantom-core",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aku11i/phantom-git",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aku11i/phantom-github",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aku11i/phantom-mcp",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/process/package.json
+++ b/packages/process/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aku11i/phantom-process",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aku11i/phantom-shared",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",


### PR DESCRIPTION
## Summary
- Bump version from 1.3.0 to 2.0.0
- This release includes a breaking change in worktree naming convention for GitHub checkout

## Changes Included
- feat\!: change worktree naming convention for GitHub checkout (#199)
- fix: prevent "refusing to fetch into branch" error when re-checking out PR (#203)
- fix: add engines field to published package.json for Node.js badge (#202)
- feat: generate PhantomConfig type from Zod schema inference (#198)
- refactor: restructure preDelete to match postCreate architecture (#197)

## Release Plan
After this PR is merged:
1. Create git tag v2.0.0
2. Build the project
3. Publish to npm
4. Create GitHub release with detailed notes