### PR TITLE
[claude] feat: Support native git worktrees in phantom commands

### DIFF
--- a/packages/cli/src/handlers/list.ts
+++ b/packages/cli/src/handlers/list.ts
@@ -68,14 +68,20 @@ export async function listHandler(args: string[] = []): Promise<void> {
       } else {
         const maxNameLength = Math.max(
           ...worktrees.map((wt) => wt.name.length),
+          4,
         );
+        const maxTypeLength = 7;
+
+        output.log(`${"Name".padEnd(maxNameLength + 2)} ${"Type".padEnd(maxTypeLength)} Branch`);
+        output.log("─".repeat(maxNameLength + maxTypeLength + 20));
 
         for (const worktree of worktrees) {
           const paddedName = worktree.name.padEnd(maxNameLength + 2);
-          const branchInfo = worktree.branch ? `(${worktree.branch})` : "";
+          const paddedType = worktree.type.padEnd(maxTypeLength);
+          const branchInfo = worktree.branch || "(detached HEAD)";
           const status = !worktree.isClean ? " [dirty]" : "";
 
-          output.log(`${paddedName} ${branchInfo}${status}`);
+          output.log(`${paddedName} ${paddedType} ${branchInfo}${status}`);
         }
       }
     }

--- a/packages/core/src/exec.ts
+++ b/packages/core/src/exec.ts
@@ -6,7 +6,7 @@ import {
 } from "@aku11i/phantom-process";
 import { type Result, err, isErr } from "@aku11i/phantom-shared";
 import type { WorktreeNotFoundError } from "./worktree/errors.ts";
-import { validateWorktreeExists } from "./worktree/validate.ts";
+import { resolveWorktreeNameOrBranch } from "./worktree/resolve.ts";
 
 export type ExecInWorktreeSuccess = SpawnSuccess;
 
@@ -23,16 +23,16 @@ export async function execInWorktree(
 ): Promise<
   Result<ExecInWorktreeSuccess, WorktreeNotFoundError | ProcessError>
 > {
-  const validation = await validateWorktreeExists(
+  const resolution = await resolveWorktreeNameOrBranch(
     gitRoot,
     worktreeDirectory,
     worktreeName,
   );
-  if (isErr(validation)) {
-    return err(validation.error);
+  if (isErr(resolution)) {
+    return err(resolution.error);
   }
 
-  const worktreePath = validation.value.path;
+  const worktreePath = resolution.value.path;
   const [cmd, ...args] = command;
 
   const stdio: StdioOptions = options?.interactive

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,6 +9,7 @@ export * from "./worktree/list.ts";
 export * from "./worktree/attach.ts";
 export * from "./worktree/where.ts";
 export * from "./worktree/validate.ts";
+export * from "./worktree/resolve.ts";
 export * from "./worktree/select.ts";
 export * from "./worktree/file-copier.ts";
 export * from "./worktree/post-create.ts";

--- a/packages/core/src/shell.ts
+++ b/packages/core/src/shell.ts
@@ -6,7 +6,7 @@ import {
 } from "@aku11i/phantom-process";
 import { type Result, err, isErr } from "@aku11i/phantom-shared";
 import type { WorktreeNotFoundError } from "./worktree/errors.ts";
-import { validateWorktreeExists } from "./worktree/validate.ts";
+import { resolveWorktreeNameOrBranch } from "./worktree/resolve.ts";
 
 export type ShellInWorktreeSuccess = SpawnSuccess;
 
@@ -17,16 +17,16 @@ export async function shellInWorktree(
 ): Promise<
   Result<ShellInWorktreeSuccess, WorktreeNotFoundError | ProcessError>
 > {
-  const validation = await validateWorktreeExists(
+  const resolution = await resolveWorktreeNameOrBranch(
     gitRoot,
     worktreeDirectory,
     worktreeName,
   );
-  if (isErr(validation)) {
-    return err(validation.error);
+  if (isErr(resolution)) {
+    return err(resolution.error);
   }
 
-  const worktreePath = validation.value.path;
+  const worktreePath = resolution.value.path;
   const shell = process.env.SHELL || "/bin/sh";
 
   return spawnProcess({
@@ -36,7 +36,7 @@ export async function shellInWorktree(
       cwd: worktreePath,
       env: {
         ...process.env,
-        ...getPhantomEnv(worktreeName, worktreePath),
+        ...getPhantomEnv(resolution.value.name, worktreePath),
       },
     },
   });

--- a/packages/core/src/worktree/resolve.ts
+++ b/packages/core/src/worktree/resolve.ts
@@ -1,0 +1,42 @@
+import { type Result, err, ok } from "@aku11i/phantom-shared";
+import { listWorktrees } from "./list.ts";
+import { WorktreeNotFoundError } from "./errors.ts";
+import { getWorktreePathFromDirectory } from "../paths.ts";
+import fs from "node:fs/promises";
+
+export interface ResolveWorktreeSuccess {
+  name: string;
+  path: string;
+  branch: string;
+  isClean: boolean;
+  type: "phantom" | "native";
+}
+
+export async function resolveWorktreeNameOrBranch(
+  gitRoot: string,
+  worktreeDirectory: string,
+  nameOrBranch: string,
+): Promise<Result<ResolveWorktreeSuccess, WorktreeNotFoundError>> {
+  const listResult = await listWorktrees(gitRoot, worktreeDirectory);
+  if (listResult.isErr) {
+    return err(new WorktreeNotFoundError(nameOrBranch));
+  }
+
+  let worktree = listResult.value.worktrees.find(
+    (wt) => wt.name === nameOrBranch,
+  );
+
+  if (worktree) {
+    return ok(worktree);
+  }
+
+  worktree = listResult.value.worktrees.find(
+    (wt) => wt.branch === nameOrBranch,
+  );
+
+  if (worktree) {
+    return ok(worktree);
+  }
+
+  return err(new WorktreeNotFoundError(nameOrBranch));
+}


### PR DESCRIPTION
## Summary
- Adds support for native git worktrees (created with `git worktree add`) to phantom commands
- Native worktrees are now visible in `phantom list` alongside phantom-managed ones
- Implements branch name resolution for exec/shell commands (partial implementation)

## Related Issue
Fixes #145

## Changes
- Added `type` field to `WorktreeInfo` to distinguish between phantom and native worktrees
- Modified `listWorktrees()` to include native worktrees from `git worktree list`
- Created `resolveWorktreeNameOrBranch()` function for name/branch resolution
- Updated `phantom list` output to show worktree type in a new column
- Updated exec/shell commands to use the new resolution logic

## Current Status (Draft)
This PR is still in progress. Remaining tasks:
- [ ] Fix exec/shell handlers to properly use the resolution function
- [ ] Add comprehensive tests for native worktree support
- [ ] Update documentation to explain native worktree support
- [ ] Test edge cases and error handling

## Test Plan
- [ ] Create native worktrees and verify they appear in `phantom list`
- [ ] Test exec/shell commands with both worktree names and branch names
- [ ] Verify phantom-managed worktrees continue to work as before
- [ ] Test fzf selection includes both types of worktrees
- [ ] Ensure proper error messages for non-existent worktrees/branches

🤖 Generated with [Claude Code](https://claude.ai/code)