### PR TITLE
fix: Change phantom review to use 'reviewit HEAD' instead of 'reviewit .'

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -291,7 +291,7 @@ phantom review --fzf --base origin/staging
 
 **Requirements:**
 - [reviewit](https://github.com/yoshiko-pg/reviewit) must be installed separately (`npm install -g reviewit`)
-- Command executes `reviewit . <base-ref>` in the specified worktree
+- Command executes `reviewit HEAD <base-ref>` in the specified worktree
 
 **Notes:**
 - This is an experimental feature subject to change

--- a/packages/cli/src/handlers/review.test.js
+++ b/packages/cli/src/handlers/review.test.js
@@ -109,7 +109,7 @@ describe("reviewHandler", () => {
     strictEqual(execCall.arguments[0], "/repo");
     strictEqual(execCall.arguments[1], "/repo/.git/phantom/worktrees");
     strictEqual(execCall.arguments[2], "feature");
-    strictEqual(execCall.arguments[3].join(" "), "reviewit . origin/main");
+    strictEqual(execCall.arguments[3].join(" "), "reviewit HEAD origin/main");
     strictEqual(execCall.arguments[4].interactive, true);
   });
 
@@ -132,7 +132,10 @@ describe("reviewHandler", () => {
     );
 
     const execCall = execInWorktreeMock.mock.calls[0];
-    strictEqual(execCall.arguments[3].join(" "), "reviewit . origin/develop");
+    strictEqual(
+      execCall.arguments[3].join(" "),
+      "reviewit HEAD origin/develop",
+    );
   });
 
   it("should execute reviewit with local branch as base", async () => {
@@ -154,7 +157,7 @@ describe("reviewHandler", () => {
     );
 
     const execCall = execInWorktreeMock.mock.calls[0];
-    strictEqual(execCall.arguments[3].join(" "), "reviewit . main");
+    strictEqual(execCall.arguments[3].join(" "), "reviewit HEAD main");
   });
 
   it("should use defaultBranch from config when available", async () => {
@@ -200,7 +203,10 @@ describe("reviewHandler", () => {
     );
 
     const execCall = execInWorktreeMock.mock.calls[0];
-    strictEqual(execCall.arguments[3].join(" "), "reviewit . origin/develop");
+    strictEqual(
+      execCall.arguments[3].join(" "),
+      "reviewit HEAD origin/develop",
+    );
   });
 
   it("should select worktree with fzf when --fzf is used", async () => {

--- a/packages/cli/src/handlers/review.ts
+++ b/packages/cli/src/handlers/review.ts
@@ -88,7 +88,7 @@ export async function reviewHandler(args: string[]): Promise<void> {
     );
 
     // Execute reviewit command
-    const command = ["reviewit", ".", baseRef];
+    const command = ["reviewit", "HEAD", baseRef];
     const result = await execInWorktree(
       context.gitRoot,
       context.worktreesDirectory,


### PR DESCRIPTION
## Summary
- Changes `phantom review` command to execute `reviewit HEAD` instead of `reviewit .`
- Updates all corresponding tests to reflect the new argument format
- Minor improvement for consistency with git conventions

## Test plan
- [x] All existing tests pass
- [x] Updated test assertions to match new command format
- [x] Ran `pnpm ready` successfully (lint, typecheck, tests)

🤖 Generated with [Claude Code](https://claude.ai/code)