### PR TITLE
refactor: rename reviewit to difit

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -29,7 +29,7 @@ PhantomはGit worktreeをシンプルかつパワフルに操り、開発生産�
 - 🎮 **シェル補完** - Fish,Zsh,Bashの完全な自動補完サポート
 - 🐙 **GitHub統合** - GitHubのPRやイシューから直接ワークツリーを作成
 - 🤖 **MCP統合** - AIが自律的にワークツリーを管理し、並行開発を実現
-- 🔍 **PRレビューインターフェース** - [reviewit](https://github.com/yoshiko-pg/reviewit)を使用してワークツリーの差分をローカルでレビュー（実験的機能）
+- 🔍 **PRレビューインターフェース** - [difit](https://github.com/yoshiko-pg/difit)を使用してワークツリーの差分をローカルでレビュー（実験的機能）
 - ⚡ **高速で軽量** - 最小限の外部依存関係
 
 ## 🚀 インストール

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Phantom is a powerful CLI tool that dramatically boosts your development product
 - 🎮 **Shell completion** - Full autocomplete support for Fish, Zsh, and Bash
 - 🐙 **GitHub Integration** - Create worktrees directly from GitHub PRs and issues
 - 🤖 **MCP Integration** - AI autonomously manages worktrees for parallel development
-- 🔍 **PR Review Interface** - Review worktree differences locally using [reviewit](https://github.com/yoshiko-pg/reviewit) (experimental)
+- 🔍 **PR Review Interface** - Review worktree differences locally using [difit](https://github.com/yoshiko-pg/difit) (experimental)
 - ⚡ **Fast and lightweight** - Minimal external dependencies
 
 ## 🚀 Installation

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -258,7 +258,7 @@ phantom exec --fzf --tmux npm run dev
 
 **⚠️ Experimental Feature**
 
-Launch a GitHub-like PR review interface locally using [reviewit](https://github.com/yoshiko-pg/reviewit).
+Launch a GitHub-like PR review interface locally using [difit](https://github.com/yoshiko-pg/difit).
 
 ```bash
 phantom review <name> [options]
@@ -290,12 +290,12 @@ phantom review --fzf --base origin/staging
 ```
 
 **Requirements:**
-- [reviewit](https://github.com/yoshiko-pg/reviewit) must be installed separately (`npm install -g reviewit`)
-- Command executes `reviewit HEAD <base-ref>` in the specified worktree
+- [difit](https://github.com/yoshiko-pg/difit) must be installed separately (`npm install -g difit`)
+- Command executes `difit HEAD <base-ref>` in the specified worktree
 
 **Notes:**
 - This is an experimental feature subject to change
-- Credits to [yoshiko-pg/reviewit](https://github.com/yoshiko-pg/reviewit) for the review interface
+- Credits to [yoshiko-pg/difit](https://github.com/yoshiko-pg/difit) for the review interface
 - Uses `defaultBranch` configuration option when `--base` is not specified
 
 ## GitHub Integration

--- a/packages/cli/src/handlers/review.test.js
+++ b/packages/cli/src/handlers/review.test.js
@@ -76,7 +76,7 @@ mock.module("../errors.ts", {
 const { reviewHandler } = await import("./review.ts");
 
 describe("reviewHandler", () => {
-  it("should execute reviewit with default base branch", async () => {
+  it("should execute difit with default base branch", async () => {
     exitMock.mock.resetCalls();
     consoleLogMock.mock.resetCalls();
     getGitRootMock.mock.resetCalls();
@@ -101,7 +101,7 @@ describe("reviewHandler", () => {
     );
     strictEqual(
       consoleLogMock.mock.calls[1].arguments[0],
-      "powered by yoshiko-pg/reviewit (https://github.com/yoshiko-pg/reviewit)",
+      "powered by yoshiko-pg/difit (https://github.com/yoshiko-pg/difit)",
     );
 
     strictEqual(execInWorktreeMock.mock.calls.length, 1);
@@ -109,11 +109,11 @@ describe("reviewHandler", () => {
     strictEqual(execCall.arguments[0], "/repo");
     strictEqual(execCall.arguments[1], "/repo/.git/phantom/worktrees");
     strictEqual(execCall.arguments[2], "feature");
-    strictEqual(execCall.arguments[3].join(" "), "reviewit HEAD origin/main");
+    strictEqual(execCall.arguments[3].join(" "), "difit HEAD origin/main");
     strictEqual(execCall.arguments[4].interactive, true);
   });
 
-  it("should execute reviewit with custom base branch", async () => {
+  it("should execute difit with custom base branch", async () => {
     exitMock.mock.resetCalls();
     consoleLogMock.mock.resetCalls();
     getGitRootMock.mock.resetCalls();
@@ -132,13 +132,10 @@ describe("reviewHandler", () => {
     );
 
     const execCall = execInWorktreeMock.mock.calls[0];
-    strictEqual(
-      execCall.arguments[3].join(" "),
-      "reviewit HEAD origin/develop",
-    );
+    strictEqual(execCall.arguments[3].join(" "), "difit HEAD origin/develop");
   });
 
-  it("should execute reviewit with local branch as base", async () => {
+  it("should execute difit with local branch as base", async () => {
     exitMock.mock.resetCalls();
     consoleLogMock.mock.resetCalls();
     getGitRootMock.mock.resetCalls();
@@ -157,7 +154,7 @@ describe("reviewHandler", () => {
     );
 
     const execCall = execInWorktreeMock.mock.calls[0];
-    strictEqual(execCall.arguments[3].join(" "), "reviewit HEAD main");
+    strictEqual(execCall.arguments[3].join(" "), "difit HEAD main");
   });
 
   it("should use defaultBranch from config when available", async () => {
@@ -203,10 +200,7 @@ describe("reviewHandler", () => {
     );
 
     const execCall = execInWorktreeMock.mock.calls[0];
-    strictEqual(
-      execCall.arguments[3].join(" "),
-      "reviewit HEAD origin/develop",
-    );
+    strictEqual(execCall.arguments[3].join(" "), "difit HEAD origin/develop");
   });
 
   it("should select worktree with fzf when --fzf is used", async () => {

--- a/packages/cli/src/handlers/review.ts
+++ b/packages/cli/src/handlers/review.ts
@@ -84,11 +84,11 @@ export async function reviewHandler(args: string[]): Promise<void> {
 
     output.log(`Opening review for worktree '${worktreeName}'...`);
     output.log(
-      "powered by yoshiko-pg/reviewit (https://github.com/yoshiko-pg/reviewit)",
+      "powered by yoshiko-pg/difit (https://github.com/yoshiko-pg/difit)",
     );
 
-    // Execute reviewit command
-    const command = ["reviewit", "HEAD", baseRef];
+    // Execute difit command
+    const command = ["difit", "HEAD", baseRef];
     const result = await execInWorktree(
       context.gitRoot,
       context.worktreesDirectory,

--- a/packages/cli/src/help/review.ts
+++ b/packages/cli/src/help/review.ts
@@ -42,10 +42,10 @@ export const reviewHelp: CommandHelp = {
   ],
   notes: [
     "⚠️  This is an experimental feature and may change in future versions",
-    "Uses reviewit to provide a GitHub-like PR review interface locally",
+    "Uses difit to provide a GitHub-like PR review interface locally",
     "Default base is origin/<defaultBranch> where defaultBranch is from config or 'main'",
-    "The --base value is passed directly to reviewit as the comparison reference",
-    "Requires reviewit to be installed separately (e.g., npm install -g reviewit)",
-    "powered by yoshiko-pg/reviewit (https://github.com/yoshiko-pg/reviewit)",
+    "The --base value is passed directly to difit as the comparison reference",
+    "Requires difit to be installed separately (e.g., npm install -g difit)",
+    "powered by yoshiko-pg/difit (https://github.com/yoshiko-pg/difit)",
   ],
 };


### PR DESCRIPTION
## Summary
- Updated all references from `reviewit` to `difit` following the tool's renaming
- Changed tool name and GitHub URLs across documentation and code
- Updated command execution to use `difit` instead of `reviewit`

## Changes
- **Documentation**: Updated README files (EN/JA) and command reference docs
- **Source code**: Updated command execution and help text in the review handler
- **Tests**: Updated test descriptions and command assertions

## Context
The `reviewit` tool has been renamed to `difit` as mentioned in this article: https://zenn.dev/yoshiko/articles/difit-from-reviewit

## Test plan
- [x] All tests pass (`pnpm test`)
- [x] Linting and type checking pass (`pnpm ready`)
- [ ] Manual testing of `phantom review` command with `difit` installed

🤖 Generated with [Claude Code](https://claude.ai/code)