### PR TITLE
feat: Add --tmux option to phantom github checkout command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -311,6 +311,9 @@ phantom gh checkout <number> [options]  # alias
 
 **Options:**
 - `--base <branch>` - Base branch for new issue branches (issues only, default: repository default branch)
+- `--tmux` / `-t` - Open the worktree in a new tmux window after checkout
+- `--tmux-vertical` / `--tmux-v` - Open the worktree in a vertical tmux split
+- `--tmux-horizontal` / `--tmux-h` - Open the worktree in a horizontal tmux split
 
 **Examples:**
 ```bash
@@ -323,6 +326,12 @@ phantom github checkout 456
 # Create worktree for issue #789 based on develop branch
 phantom github checkout 789 --base develop
 
+# Create and open PR #321 in a new tmux window
+phantom github checkout 321 --tmux
+
+# Create and open issue #654 in a vertical split
+phantom github checkout 654 --tmux-v
+
 # Using the alias
 phantom gh checkout 123
 ```
@@ -330,6 +339,7 @@ phantom gh checkout 123
 **Requirements:**
 - GitHub CLI (gh) must be installed
 - Must be authenticated with `gh auth login`
+- tmux options require being inside a tmux session
 
 **Behavior:**
 - For PRs: Creates worktree named `pulls/{number}` with the PR's branch

--- a/docs/github.md
+++ b/docs/github.md
@@ -30,6 +30,9 @@ phantom gh checkout <number> [options]
 
 **Options:**
 - `--base <branch>`: Base branch for new issue branches (issues only, default: repository default branch)
+- `--tmux` / `-t`: Open the worktree in a new tmux window (requires tmux)
+- `--tmux-vertical` / `--tmux-v`: Open the worktree in a vertical tmux split
+- `--tmux-horizontal` / `--tmux-h`: Open the worktree in a horizontal tmux split
 
 ## Use Cases
 
@@ -84,6 +87,23 @@ phantom github checkout 789 --base develop
 phantom shell issues/789
 # Your worktree is now based on the 'develop' branch
 ```
+
+### 4. Opening in tmux
+
+When using tmux, you can open the worktree directly after checkout:
+
+```bash
+# Create and open PR #321 in a new tmux window
+phantom github checkout 321 --tmux
+
+# Create and open issue #654 in a vertical split
+phantom github checkout 654 --tmux-v
+
+# Create and open in a horizontal split
+phantom github checkout 987 --tmux-h
+```
+
+**Note:** The `--tmux` options require you to be inside a tmux session.
 
 ## Internal Behavior
 

--- a/packages/cli/src/handlers/github-checkout.test.js
+++ b/packages/cli/src/handlers/github-checkout.test.js
@@ -1,7 +1,50 @@
 import { equal } from "node:assert/strict";
 import { describe, it, mock } from "node:test";
 import { exitCodes } from "../errors.ts";
-import { githubCheckoutHandler } from "./github-checkout.ts";
+
+// Use the same mocking pattern as github-checkout-postcreate.test.js
+const exitWithErrorMock = mock.fn((message, code) => {
+  throw new Error(`Exit with code ${code}: ${message}`);
+});
+
+const outputLogMock = mock.fn();
+const outputErrorMock = mock.fn();
+const githubCheckoutMock = mock.fn();
+const isInsideTmuxMock = mock.fn();
+const executeTmuxCommandMock = mock.fn();
+const getPhantomEnvMock = mock.fn();
+
+mock.module("../errors.ts", {
+  namedExports: {
+    exitWithError: exitWithErrorMock,
+    exitCodes: {
+      validationError: 3,
+      generalError: 1,
+    },
+  },
+});
+
+mock.module("../output.ts", {
+  namedExports: {
+    output: { log: outputLogMock, error: outputErrorMock },
+  },
+});
+
+mock.module("@aku11i/phantom-github", {
+  namedExports: {
+    githubCheckout: githubCheckoutMock,
+  },
+});
+
+mock.module("@aku11i/phantom-process", {
+  namedExports: {
+    isInsideTmux: isInsideTmuxMock,
+    executeTmuxCommand: executeTmuxCommandMock,
+    getPhantomEnv: getPhantomEnvMock,
+  },
+});
+
+const { githubCheckoutHandler } = await import("./github-checkout.ts");
 
 describe("githubCheckoutHandler", () => {
   it("should export githubCheckoutHandler function", () => {
@@ -14,9 +57,7 @@ describe("githubCheckoutHandler", () => {
   });
 
   it("should exit with error when number is not provided", async () => {
-    const mockExit = mock.method(process, "exit", () => {
-      throw new Error("Process exited");
-    });
+    exitWithErrorMock.mock.resetCalls();
 
     try {
       await githubCheckoutHandler([]);
@@ -24,15 +65,19 @@ describe("githubCheckoutHandler", () => {
       // Expected to throw due to mocked process.exit
     }
 
-    equal(mockExit.mock.calls.length, 1);
-    equal(mockExit.mock.calls[0].arguments[0], exitCodes.validationError);
-    mockExit.mock.restore();
+    equal(exitWithErrorMock.mock.calls.length, 1);
+    equal(
+      exitWithErrorMock.mock.calls[0].arguments[0],
+      "Please specify a PR or issue number",
+    );
+    equal(
+      exitWithErrorMock.mock.calls[0].arguments[1],
+      exitCodes.validationError,
+    );
   });
 
   it("should exit with error when only base option is provided", async () => {
-    const mockExit = mock.method(process, "exit", () => {
-      throw new Error("Process exited");
-    });
+    exitWithErrorMock.mock.resetCalls();
 
     try {
       await githubCheckoutHandler(["--base", "develop"]);
@@ -40,8 +85,74 @@ describe("githubCheckoutHandler", () => {
       // Expected to throw due to mocked process.exit
     }
 
-    equal(mockExit.mock.calls.length, 1);
-    equal(mockExit.mock.calls[0].arguments[0], exitCodes.validationError);
-    mockExit.mock.restore();
+    equal(exitWithErrorMock.mock.calls.length, 1);
+    equal(
+      exitWithErrorMock.mock.calls[0].arguments[0],
+      "Please specify a PR or issue number",
+    );
+    equal(
+      exitWithErrorMock.mock.calls[0].arguments[1],
+      exitCodes.validationError,
+    );
+  });
+
+  it("should exit with error when tmux option is used outside tmux", async () => {
+    exitWithErrorMock.mock.resetCalls();
+    isInsideTmuxMock.mock.resetCalls();
+    githubCheckoutMock.mock.resetCalls();
+
+    // Mock not being inside tmux
+    isInsideTmuxMock.mock.mockImplementation(() => Promise.resolve(false));
+
+    try {
+      await githubCheckoutHandler(["123", "--tmux"]);
+    } catch {
+      // Expected to throw due to mocked process.exit
+    }
+
+    equal(exitWithErrorMock.mock.calls.length, 1);
+    equal(
+      exitWithErrorMock.mock.calls[0].arguments[0],
+      "The --tmux option can only be used inside a tmux session",
+    );
+    equal(
+      exitWithErrorMock.mock.calls[0].arguments[1],
+      exitCodes.validationError,
+    );
+  });
+
+  it("should parse tmux options correctly", async () => {
+    exitWithErrorMock.mock.resetCalls();
+    isInsideTmuxMock.mock.resetCalls();
+
+    // Mock not being inside tmux
+    isInsideTmuxMock.mock.mockImplementation(() => Promise.resolve(false));
+
+    const tmuxOptions = [
+      ["--tmux"],
+      ["-t"],
+      ["--tmux-vertical"],
+      ["--tmux-v"],
+      ["--tmux-horizontal"],
+      ["--tmux-h"],
+    ];
+
+    for (const option of tmuxOptions) {
+      try {
+        await githubCheckoutHandler(["123", ...option]);
+      } catch {
+        // Expected to throw due to mocked process.exit
+      }
+    }
+
+    // All should fail due to not being in tmux
+    equal(exitWithErrorMock.mock.calls.length, tmuxOptions.length);
+    for (const call of exitWithErrorMock.mock.calls) {
+      equal(
+        call.arguments[0],
+        "The --tmux option can only be used inside a tmux session",
+      );
+      equal(call.arguments[1], exitCodes.validationError);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Add `--tmux` option to `phantom github checkout` command for seamless tmux integration
- Automatically open worktrees in tmux windows/panes after checkout
- Support for new window, vertical split, and horizontal split options

## Changes
- **CLI Handler**: Added tmux options parsing and execution logic to `github-checkout.ts`
- **Tests**: Added comprehensive tests for tmux option validation
- **Documentation**: Updated command reference and GitHub integration guide

## Usage
```bash
# Open PR in new tmux window
phantom github checkout 123 --tmux

# Open issue in vertical split
phantom github checkout 456 --tmux-v

# Open in horizontal split  
phantom github checkout 789 --tmux-h
```

## Test Plan
- [x] Unit tests pass for tmux option validation
- [x] All existing tests continue to pass
- [x] `pnpm ready` passes without errors
- [ ] Manual testing in tmux environment
- [ ] Manual testing outside tmux (should show error)

🤖 Generated with [Claude Code](https://claude.ai/code)