### PR TITLE
Add phantom gh checkout --tmux* shell completion

### DIFF
--- a/packages/cli/src/handlers/completion.ts
+++ b/packages/cli/src/handlers/completion.ts
@@ -104,7 +104,13 @@ complete -c phantom -n "__phantom_using_command gh" -a "checkout" -d "Create a w
 
 # github checkout command options
 complete -c phantom -n "__phantom_using_command github checkout" -l base -d "Base branch for new issue branches (issues only)" -x
+complete -c phantom -n "__phantom_using_command github checkout" -l tmux -d "Open the worktree in a new tmux window (-t)"
+complete -c phantom -n "__phantom_using_command github checkout" -l tmux-vertical -d "Open the worktree in a vertical tmux pane"
+complete -c phantom -n "__phantom_using_command github checkout" -l tmux-horizontal -d "Open the worktree in a horizontal tmux pane"
 complete -c phantom -n "__phantom_using_command gh checkout" -l base -d "Base branch for new issue branches (issues only)" -x
+complete -c phantom -n "__phantom_using_command gh checkout" -l tmux -d "Open the worktree in a new tmux window (-t)"
+complete -c phantom -n "__phantom_using_command gh checkout" -l tmux-vertical -d "Open the worktree in a vertical tmux pane"
+complete -c phantom -n "__phantom_using_command gh checkout" -l tmux-horizontal -d "Open the worktree in a horizontal tmux pane"
 
 # mcp command options
 complete -c phantom -n "__phantom_using_command mcp" -a "serve" -d "Start MCP server"`;
@@ -215,6 +221,9 @@ _phantom() {
                     elif [[ \${line[2]} == "checkout" ]]; then
                         _arguments \\
                             '--base[Base branch for new issue branches (issues only)]:branch:' \\
+                            '--tmux[Open the worktree in a new tmux window (-t)]' \\
+                            '--tmux-vertical[Open the worktree in a vertical tmux pane]' \\
+                            '--tmux-horizontal[Open the worktree in a horizontal tmux pane]' \\
                             '1:number:'
                     fi
                     ;;
@@ -406,9 +415,9 @@ _phantom_completion() {
                             # First argument after checkout should be number
                             return 0
                         else
-                            local opts="--base"
-                            COMPREPLY=( \$(compgen -W "\${opts}" -- "\${cur}") )
-                            return 0
+                            local opts="--base --tmux --tmux-vertical --tmux-horizontal"
+                             COMPREPLY=( \$(compgen -W "\${opts}" -- "\${cur}") )
+                             return 0
                         fi
                         ;;
                 esac

--- a/packages/cli/src/help/github.ts
+++ b/packages/cli/src/help/github.ts
@@ -37,6 +37,21 @@ export const githubCheckoutHelp: CommandHelp = {
       description:
         "Base branch for new issue branches (issues only, default: repository HEAD)",
     },
+    {
+      name: "--tmux, -t",
+      type: "boolean",
+      description: "Open the worktree in a new tmux window",
+    },
+    {
+      name: "--tmux-vertical, --tmux-v",
+      type: "boolean",
+      description: "Open the worktree in a vertical tmux pane",
+    },
+    {
+      name: "--tmux-horizontal, --tmux-h",
+      type: "boolean",
+      description: "Open the worktree in a horizontal tmux pane",
+    },
   ],
   examples: [
     {
@@ -50,6 +65,18 @@ export const githubCheckoutHelp: CommandHelp = {
     {
       command: "phantom github checkout 789 --base develop",
       description: "Create a worktree for issue #789 based on develop branch",
+    },
+    {
+      command: "phantom gh checkout 123 --tmux",
+      description: "Create a worktree and open it in a new tmux window",
+    },
+    {
+      command: "phantom gh checkout 123 --tmux-v",
+      description: "Create a worktree and open it in a vertical tmux pane",
+    },
+    {
+      command: "phantom gh checkout 123 --tmux-h",
+      description: "Create a worktree and open it in a horizontal tmux pane",
     },
   ],
   notes: [


### PR DESCRIPTION
Add `--tmux*` options to `phantom gh checkout` shell completion and help documentation.

---
<a href="https://cursor.com/background-agent?bcId=bc-606f8c09-6081-417a-8e55-4be900e50df3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-606f8c09-6081-417a-8e55-4be900e50df3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

