### PR TITLE
fix(process): enable shell execution for Windows compatibility

### DIFF
--- a/packages/process/src/spawn.ts
+++ b/packages/process/src/spawn.ts
@@ -28,7 +28,7 @@ export async function spawnProcess(
     const { command, args = [], options = {} } = config;
 
     const childProcess: ChildProcess = nodeSpawn(command, args, {
-      stdio: "inherit",
+      stdio: "inherit", shell: true,
       ...options,
     });
 


### PR DESCRIPTION
This PR fixes an issue where executing commands that are scripts (like `code.cmd`, `npm.cmd`) fails on Windows with `ENOENT` or `EINVAL`.

By setting `shell: true` in `spawnProcess`, Node.js will spawn the command inside a shell, allowing it to resolve and execute `.cmd` and `.bat` files correctly.

This was discovered when trying to run `phantom exec ... code .` on Windows.

**Automated fix by LLM.**