### PR TITLE
Trigger npm publish from releases

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           node-version-file: .node-version
           registry-url: https://registry.npmjs.org
+          cache: pnpm
 
       - name: Determine npm dist-tag
         id: dist_tag


### PR DESCRIPTION
## Summary
- run npm publishing when GitHub Releases are published and check out the release tag
- load Node.js version from .node-version while retaining pnpm 10.8.1 setup
- set npm dist-tag to `next` when the Release is marked as prerelease, otherwise `latest`

## Testing
- not run (workflow definition only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69215c5114e4832788be13ab836f370c)