### PR TITLE
chore: fix tag workflow regex

### DIFF
--- a/.github/workflows/tag-on-merge.yml
+++ b/.github/workflows/tag-on-merge.yml
@@ -20,7 +20,8 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          if [[ "$PR_TITLE" =~ ^chore\(version\):\ v([0-9A-Za-z\.\-\+]+)$ ]]; then
+          # Accept semver-like values including prerelease/build segments (e.g. v2.2.1-rc.0)
+          if [[ "$PR_TITLE" =~ ^chore\(version\):\ v([0-9A-Za-z.+-]+)$ ]]; then
             VERSION="${BASH_REMATCH[1]}"
             echo "version=$VERSION" >> "$GITHUB_OUTPUT"
             echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- accept prerelease/build-like versions in tag-on-merge workflow regex
- document accepted format in extraction step

## Testing
- not run (workflow change only)
