### PR TITLE
Update npm installation in publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -32,6 +32,9 @@ jobs:
           registry-url: https://registry.npmjs.org
           cache: pnpm
 
+      - name: Install latest npm
+        run: npm install -g npm@latest
+
       - name: Determine npm dist-tag
         id: dist_tag
         run: |


### PR DESCRIPTION
## Summary
- install the latest npm after Node.js setup in the npm publish workflow
- ensure the publication process uses the most recent npm release

## Testing
- not run (not needed for workflow change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692188540bf48327a8f042e8fc900612)