### PR TITLE
Add shell test job to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,15 @@ jobs:
         run: pnpm install
       - name: Run tests
         run: pnpm test
+
+  test-shell:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: "pnpm"
+      - name: Run shell tests
+        run: pnpm test:shell


### PR DESCRIPTION
## Summary
- move shell tests into a dedicated CI job
- run shell tests on the default Node version without a matrix or extra install step

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923f8a9f69483278d9b3bf4c0e8aa54)