### PR TITLE
Add fish shell completion tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,3 +81,19 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y zsh
       - name: Run shell tests
         run: pnpm test:shell:zsh
+
+  test-shell-fish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: "pnpm"
+      - name: Install dependencies
+        run: pnpm install
+      - name: Install fish
+        run: sudo apt-get update && sudo apt-get install -y fish
+      - name: Run shell tests
+        run: pnpm test:shell:fish

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test": "pnpm -r test",
     "test:shell": "pnpm --filter @aku11i/phantom-cli run test:shell",
     "test:shell:bash": "pnpm --filter @aku11i/phantom-cli run test:shell:bash",
+    "test:shell:fish": "pnpm --filter @aku11i/phantom-cli run test:shell:fish",
     "test:shell:zsh": "pnpm --filter @aku11i/phantom-cli run test:shell:zsh",
     "lint": "biome check .",
     "fix": "biome check --write .",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,8 +8,9 @@
     "prebuild": "git clean -fdx dist",
     "build": "node build.ts",
     "typecheck": "tsc --noEmit",
-    "test:shell": "pnpm run test:shell:bash && pnpm run test:shell:zsh",
+    "test:shell": "pnpm run test:shell:bash && pnpm run test:shell:zsh && pnpm run test:shell:fish",
     "test:shell:bash": "node --test --experimental-strip-types --experimental-test-module-mocks src/completions/phantom.bash.test.shell.js",
+    "test:shell:fish": "node --test --experimental-strip-types --experimental-test-module-mocks src/completions/phantom.fish.test.shell.js",
     "test:shell:zsh": "node --test --experimental-strip-types --experimental-test-module-mocks src/completions/phantom.zsh.test.shell.js",
     "test": "node --test --experimental-strip-types --experimental-test-module-mocks \"src/**/*.test.js\"",
     "prepublishOnly": "pnpm build"

--- a/packages/cli/src/completions/phantom.fish.test.shell.js
+++ b/packages/cli/src/completions/phantom.fish.test.shell.js
@@ -1,0 +1,25 @@
+import { ok, strictEqual } from "node:assert";
+import { dirname, join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+import { runFishCompletion } from "../test-utils/run-fish-completion.ts";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const completionScriptPath = join(__dirname, "phantom.fish");
+
+describe("phantom.fish completion", () => {
+  it("completes version when typing phantom v", () => {
+    const { completions, result } = runFishCompletion(completionScriptPath, [
+      "phantom",
+      "v",
+    ]);
+
+    strictEqual(result.status, 0, result.stderr);
+
+    ok(
+      completions.includes("version"),
+      `Expected version to be offered, got: ${completions.join(", ")}`,
+    );
+  });
+});

--- a/packages/cli/src/test-utils/run-fish-completion.ts
+++ b/packages/cli/src/test-utils/run-fish-completion.ts
@@ -1,0 +1,28 @@
+import { type SpawnSyncReturns, spawnSync } from "node:child_process";
+
+export type FishCompletionResult = {
+  completions: string[];
+  result: SpawnSyncReturns<string>;
+};
+
+export const runFishCompletion = (
+  completionScriptPath: string,
+  words: string[],
+): FishCompletionResult => {
+  const buffer = words.join(" ");
+
+  const command = `
+source ${JSON.stringify(completionScriptPath)}
+complete -C${JSON.stringify(buffer)}
+`;
+
+  const result = spawnSync("fish", ["-c", command], { encoding: "utf8" });
+
+  const completions = result.stdout
+    .trim()
+    .split("\n")
+    .map((line) => line.split("\t")[0])
+    .filter((value) => value.length > 0);
+
+  return { completions, result };
+};


### PR DESCRIPTION
## Summary
- add fish completion test utility and shell test to cover version completion
- expose pnpm scripts for running fish completion tests and include them in CI

## Testing
- pnpm run test:shell:fish


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69250678d5e8832792cb1af808f71c63)