### PR TITLE
docs: require pnpm ready after implementation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@
 - Lint/format: `pnpm lint` (check) or `pnpm fix` (apply Biome fixes).
 - Tests: `pnpm test` (native `node --test` across packages).
 - Pre-flight: `pnpm ready` (fix + typecheck + test) or `pnpm ready:check` (lint + typecheck + test).
+- After finishing an implementation, run `pnpm ready` to execute lint, typecheck, and tests before shipping changes.
 - Scope work: `pnpm --filter <pkg> <cmd>` (e.g., `pnpm --filter @aku11i/phantom-github test`).
 
 ## Coding Style & Naming Conventions


### PR DESCRIPTION
## Summary
- document the expectation to run `pnpm ready` after finishing an implementation

## Testing
- pnpm ready


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925108465288327a14461dce0ddbc07)