### PR TITLE
Support pre* release bumps and tag prereleases as next

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -38,7 +38,11 @@ jobs:
       - name: Determine npm dist-tag
         id: dist_tag
         run: |
-          if [[ "${{ github.event.release.prerelease }}" == "true" ]]; then
+          release_tag="${{ github.event.release.tag_name }}"
+          release_tag="${release_tag:-${GITHUB_REF##*/}}"
+          version="${release_tag#v}"
+
+          if [[ "${{ github.event.release.prerelease }}" == "true" || "$version" == *"-"* ]]; then
             echo "npm_tag=next" >>"$GITHUB_OUTPUT"
           else
             echo "npm_tag=latest" >>"$GITHUB_OUTPUT"

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -12,6 +12,9 @@ on:
           - patch
           - minor
           - major
+          - prepatch
+          - preminor
+          - premajor
           - prerelease
 
 permissions:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,12 +134,11 @@ To release a new version of Phantom:
 1. **Bump version**
    ```bash
    # Trigger the automated version bump workflow via GitHub CLI
-   # release_type: patch | minor | major
-   # preid: "" for stable, "rc" for prerelease
-   gh workflow run version-bump.yml -f release_type=patch -f preid=""
+   # release_type: patch | minor | major | prepatch | preminor | premajor | prerelease
+   gh workflow run version-bump.yml -f release_type=patch
 
-   # Example: start an rc prerelease minor bump
-   gh workflow run version-bump.yml -f release_type=minor -f preid=rc
+   # Example: start a prerelease minor bump
+   gh workflow run version-bump.yml -f release_type=preminor
 
    # Wait for the workflow to finish and create the PR for you
    gh run watch --exit-status --workflow=version-bump.yml
@@ -164,7 +163,7 @@ To release a new version of Phantom:
       --target main
     ```
 
-    Publishing to npm is handled by `.github/workflows/npm-publish.yml` when the release is published. Monitor the workflow run in GitHub Actions to ensure it completes successfully.
+   Publishing to npm is handled by `.github/workflows/npm-publish.yml` when the release is published. Releases from `pre*` bumps are published with the `next` dist-tag; all other releases use `latest`. Monitor the workflow run in GitHub Actions to ensure it completes successfully.
 
 4. **Update release notes for clarity**
    - Review the auto-generated release notes using `gh release view v<version>`

--- a/scripts/bump-version.ts
+++ b/scripts/bump-version.ts
@@ -10,7 +10,15 @@ const { values } = parseArgs({
 });
 
 const releaseType = values["release-type"]?.trim() ?? "patch";
-const allowedReleaseTypes = new Set(["patch", "minor", "major", "prerelease"]);
+const allowedReleaseTypes = new Set([
+  "patch",
+  "minor",
+  "major",
+  "prepatch",
+  "preminor",
+  "premajor",
+  "prerelease",
+]);
 
 if (!allowedReleaseTypes.has(releaseType)) {
   throw new Error(


### PR DESCRIPTION
## Summary
- add prepatch, preminor, and premajor as version-bump release types
- publish any hyphenated prerelease version with the next dist-tag, otherwise latest
- update contributing docs with new release examples and tagging notes

## Testing
- not run (no code paths exercised)