### PR TITLE
docs: add mcp command reference

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -16,6 +16,7 @@ This document provides a comprehensive reference for all Phantom commands and th
 - [GitHub Integration](#github-integration)
   - [github checkout](#github-checkout)
 - [Other Commands](#other-commands)
+  - [mcp](#mcp)
   - [version](#version)
   - [completion](#completion)
 
@@ -309,6 +310,26 @@ phantom gh checkout 123
 For detailed information, see the [GitHub Integration Guide](./github.md).
 
 ## Other Commands
+
+### mcp
+
+Start and manage the Phantom MCP server for AI assistant integrations. See the [MCP Integration Guide](./mcp.md) for full setup instructions.
+
+```bash
+phantom mcp <subcommand> [options]
+```
+
+**Subcommands:**
+- `serve` - Start the MCP server (stdio transport)
+
+**Examples:**
+```bash
+# Start the MCP server with stdio transport
+phantom mcp serve
+
+# Show MCP help
+phantom mcp --help
+```
 
 ### version
 


### PR DESCRIPTION
## Summary
- add an MCP section to the commands reference near Other Commands
- describe the `phantom mcp` usage, `serve` subcommand, and link to the integration guide
- update the table of contents so users can find the MCP server command

## Testing
- not run (docs only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69295d6dd9ac8327be0c7d7277397033)