### PR TITLE
feat: use branch names for worktree selection

### DIFF
--- a/packages/cli/src/handlers/list.test.js
+++ b/packages/cli/src/handlers/list.test.js
@@ -80,6 +80,7 @@ describe("listHandler", () => {
 
   it("should list worktrees in default format", async () => {
     resetMocks();
+    const cwdMock = mock.method(process, "cwd", () => "/test/repo");
     getGitRootMock.mock.mockImplementation(() => Promise.resolve("/test/repo"));
     loadConfigMock.mock.mockImplementation(() =>
       Promise.resolve(err(new Error("Config not found"))),
@@ -90,14 +91,12 @@ describe("listHandler", () => {
           worktrees: [
             {
               name: "feature-1",
-              relativePath: ".git/phantom/worktrees/feature-1",
               path: "/test/repo/.git/phantom/worktrees/feature-1",
               branch: "feature-1",
               isClean: true,
             },
             {
               name: "feature-2",
-              relativePath: ".git/phantom/worktrees/feature-2",
               path: "/test/repo/.git/phantom/worktrees/feature-2",
               branch: "feature-2",
               isClean: false,
@@ -126,6 +125,7 @@ describe("listHandler", () => {
       "feature-2  [.git/phantom/worktrees/feature-2] [dirty]",
     );
     strictEqual(exitMock.mock.calls[0].arguments[0], 0);
+    cwdMock.mock.restore();
   });
 
   it("should list only worktree names with --names option", async () => {
@@ -137,21 +137,18 @@ describe("listHandler", () => {
           worktrees: [
             {
               name: "feature-1",
-              relativePath: ".git/phantom/worktrees/feature-1",
               path: "/test/repo/.git/phantom/worktrees/feature-1",
               branch: "feature-1",
               isClean: true,
             },
             {
               name: "feature-2",
-              relativePath: ".git/phantom/worktrees/feature-2",
               path: "/test/repo/.git/phantom/worktrees/feature-2",
               branch: "feature-2",
               isClean: false,
             },
             {
               name: "bugfix-3",
-              relativePath: ".git/phantom/worktrees/bugfix-3",
               path: "/test/repo/.git/phantom/worktrees/bugfix-3",
               branch: "bugfix-3",
               isClean: true,

--- a/packages/cli/src/handlers/list.ts
+++ b/packages/cli/src/handlers/list.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { parseArgs } from "node:util";
 import {
   createContext,
@@ -66,12 +67,19 @@ export async function listHandler(args: string[] = []): Promise<void> {
           output.log(worktree.name);
         }
       } else {
-        const maxNameLength = Math.max(...worktrees.map((wt) => wt.name.length));
+        const worktreesWithRelativePaths = worktrees.map((worktree) => ({
+          ...worktree,
+          relativePath: path.relative(process.cwd(), worktree.path) || ".",
+        }));
+
+        const maxNameLength = Math.max(
+          ...worktreesWithRelativePaths.map((wt) => wt.name.length),
+        );
         const maxDirectoryLength = Math.max(
-          ...worktrees.map((wt) => wt.relativePath.length),
+          ...worktreesWithRelativePaths.map((wt) => wt.relativePath.length),
         );
 
-        for (const worktree of worktrees) {
+        for (const worktree of worktreesWithRelativePaths) {
           const paddedName = worktree.name.padEnd(maxNameLength);
           const paddedDirectory = worktree.relativePath.padEnd(
             maxDirectoryLength,

--- a/packages/core/src/worktree/select.ts
+++ b/packages/core/src/worktree/select.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { selectWithFzf } from "@aku11i/phantom-process";
 import { isErr, type Result } from "@aku11i/phantom-shared";
 import { listWorktrees } from "./list.ts";
@@ -28,7 +29,8 @@ export async function selectWorktreeWithFzf(
   }
 
   const list = worktrees.map((wt) => {
-    const directoryInfo = wt.relativePath ? `[${wt.relativePath}]` : "";
+    const relativePath = path.relative(process.cwd(), wt.path) || ".";
+    const directoryInfo = relativePath ? `[${relativePath}]` : "";
     const status = !wt.isClean ? " [dirty]" : "";
     return `${wt.name} ${directoryInfo}${status}`.trim();
   });

--- a/packages/core/src/worktree/validate.test.js
+++ b/packages/core/src/worktree/validate.test.js
@@ -68,7 +68,6 @@ describe("validateWorktreeExists", () => {
         worktrees: [
           {
             name: "my-feature-branch",
-            relativePath: "my-feature",
             path: "/test/repo/.git/phantom/worktrees/my-feature",
           },
         ],
@@ -173,7 +172,6 @@ describe("validateWorktreeDoesNotExist", () => {
         worktrees: [
           {
             name: "existing-feature",
-            relativePath: "existing-feature",
             path: "/test/repo/.git/phantom/worktrees/existing-feature",
           },
         ],

--- a/packages/mcp/src/tools/list-worktrees.test.js
+++ b/packages/mcp/src/tools/list-worktrees.test.js
@@ -61,7 +61,6 @@ describe("listWorktreesTool", () => {
     const mockWorktrees = [
       {
         name: "main",
-        relativePath: ".",
         path: "/path/to/repo",
         branch: "main",
         isClean: true,
@@ -69,7 +68,6 @@ describe("listWorktreesTool", () => {
       },
       {
         name: "feature-1",
-        relativePath: ".git/phantom/worktrees/feature-1",
         path: "/path/to/repo/.git/phantom/worktrees/feature-1",
         branch: "feature-1",
         isClean: false,
@@ -77,7 +75,6 @@ describe("listWorktreesTool", () => {
       },
       {
         name: "hotfix-1",
-        relativePath: ".git/phantom/worktrees/hotfix-1",
         path: "/path/to/repo/.git/phantom/worktrees/hotfix-1",
         branch: "hotfix-1",
         isClean: true,


### PR DESCRIPTION
## Summary
- show branch names as the primary identifiers when listing worktrees and include directory names as supplemental context
- resolve worktree lookups by branch or directory name so interactive commands target branch-named worktrees
- update validation and tooling/tests to align with the branch-based naming and display

## Testing
- CI=1 FORCE_COLOR=0 pnpm test --filter @aku11i/phantom-core


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ae6d4d5a08327b1eff3c3148690b9)