### PR TITLE
Align GitHub checkout help and shell completions

### DIFF
--- a/packages/cli/src/completions/phantom-bash.ts
+++ b/packages/cli/src/completions/phantom-bash.ts
@@ -158,7 +158,7 @@ _phantom_completion() {
                             # First argument after checkout should be number
                             return 0
                         else
-                            local opts="--base"
+                            local opts="--base --tmux -t --tmux-vertical --tmux-v --tmux-horizontal --tmux-h"
                             COMPREPLY=( $(compgen -W "\${opts}" -- "\${cur}") )
                             return 0
                         fi

--- a/packages/cli/src/completions/phantom-fish.ts
+++ b/packages/cli/src/completions/phantom-fish.ts
@@ -99,7 +99,17 @@ complete -c phantom -n "__phantom_using_command gh" -a "checkout" -d "Create a w
 
 # github checkout command options
 complete -c phantom -n "__phantom_using_command github checkout" -l base -d "Base branch for new issue branches (issues only)" -x
+complete -c phantom -n "__phantom_using_command github checkout" -l tmux -d "Open worktree in new tmux window (-t)"
+complete -c phantom -n "__phantom_using_command github checkout" -l tmux-vertical -d "Open worktree in vertical split pane"
+complete -c phantom -n "__phantom_using_command github checkout" -l tmux-v -d "Alias for --tmux-vertical"
+complete -c phantom -n "__phantom_using_command github checkout" -l tmux-horizontal -d "Open worktree in horizontal split pane"
+complete -c phantom -n "__phantom_using_command github checkout" -l tmux-h -d "Alias for --tmux-horizontal"
 complete -c phantom -n "__phantom_using_command gh checkout" -l base -d "Base branch for new issue branches (issues only)" -x
+complete -c phantom -n "__phantom_using_command gh checkout" -l tmux -d "Open worktree in new tmux window (-t)"
+complete -c phantom -n "__phantom_using_command gh checkout" -l tmux-vertical -d "Open worktree in vertical split pane"
+complete -c phantom -n "__phantom_using_command gh checkout" -l tmux-v -d "Alias for --tmux-vertical"
+complete -c phantom -n "__phantom_using_command gh checkout" -l tmux-horizontal -d "Open worktree in horizontal split pane"
+complete -c phantom -n "__phantom_using_command gh checkout" -l tmux-h -d "Alias for --tmux-horizontal"
 
 # mcp command options
 complete -c phantom -n "__phantom_using_command mcp" -a "serve" -d "Start MCP server"`;

--- a/packages/cli/src/completions/phantom-zsh.ts
+++ b/packages/cli/src/completions/phantom-zsh.ts
@@ -102,6 +102,11 @@ _phantom() {
                     elif [[ \${line[2]} == "checkout" ]]; then
                         _arguments \
                             '--base[Base branch for new issue branches (issues only)]:branch:' \
+                            '--tmux[Open worktree in new tmux window (-t)]' \
+                            '--tmux-vertical[Open worktree in vertical split pane]' \
+                            '--tmux-v[Alias for --tmux-vertical]' \
+                            '--tmux-horizontal[Open worktree in horizontal split pane]' \
+                            '--tmux-h[Alias for --tmux-horizontal]' \
                             '1:number:'
                     fi
                     ;;

--- a/packages/cli/src/completions/phantom.bash
+++ b/packages/cli/src/completions/phantom.bash
@@ -158,7 +158,7 @@ _phantom_completion() {
                             # First argument after checkout should be number
                             return 0
                         else
-                            local opts="--base"
+                            local opts="--base --tmux -t --tmux-vertical --tmux-v --tmux-horizontal --tmux-h"
                             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                             return 0
                         fi

--- a/packages/cli/src/completions/phantom.fish
+++ b/packages/cli/src/completions/phantom.fish
@@ -99,7 +99,17 @@ complete -c phantom -n "__phantom_using_command gh" -a "checkout" -d "Create a w
 
 # github checkout command options
 complete -c phantom -n "__phantom_using_command github checkout" -l base -d "Base branch for new issue branches (issues only)" -x
+complete -c phantom -n "__phantom_using_command github checkout" -l tmux -d "Open worktree in new tmux window (-t)"
+complete -c phantom -n "__phantom_using_command github checkout" -l tmux-vertical -d "Open worktree in vertical split pane"
+complete -c phantom -n "__phantom_using_command github checkout" -l tmux-v -d "Alias for --tmux-vertical"
+complete -c phantom -n "__phantom_using_command github checkout" -l tmux-horizontal -d "Open worktree in horizontal split pane"
+complete -c phantom -n "__phantom_using_command github checkout" -l tmux-h -d "Alias for --tmux-horizontal"
 complete -c phantom -n "__phantom_using_command gh checkout" -l base -d "Base branch for new issue branches (issues only)" -x
+complete -c phantom -n "__phantom_using_command gh checkout" -l tmux -d "Open worktree in new tmux window (-t)"
+complete -c phantom -n "__phantom_using_command gh checkout" -l tmux-vertical -d "Open worktree in vertical split pane"
+complete -c phantom -n "__phantom_using_command gh checkout" -l tmux-v -d "Alias for --tmux-vertical"
+complete -c phantom -n "__phantom_using_command gh checkout" -l tmux-horizontal -d "Open worktree in horizontal split pane"
+complete -c phantom -n "__phantom_using_command gh checkout" -l tmux-h -d "Alias for --tmux-horizontal"
 
 # mcp command options
 complete -c phantom -n "__phantom_using_command mcp" -a "serve" -d "Start MCP server"

--- a/packages/cli/src/completions/phantom.zsh
+++ b/packages/cli/src/completions/phantom.zsh
@@ -102,6 +102,11 @@ _phantom() {
                     elif [[ ${line[2]} == "checkout" ]]; then
                         _arguments \
                             '--base[Base branch for new issue branches (issues only)]:branch:' \
+                            '--tmux[Open worktree in new tmux window (-t)]' \
+                            '--tmux-vertical[Open worktree in vertical split pane]' \
+                            '--tmux-v[Alias for --tmux-vertical]' \
+                            '--tmux-horizontal[Open worktree in horizontal split pane]' \
+                            '--tmux-h[Alias for --tmux-horizontal]' \
                             '1:number:'
                     fi
                     ;;

--- a/packages/cli/src/help/github.ts
+++ b/packages/cli/src/help/github.ts
@@ -37,6 +37,21 @@ export const githubCheckoutHelp: CommandHelp = {
       description:
         "Base branch for new issue branches (issues only, default: repository HEAD)",
     },
+    {
+      name: "--tmux, -t",
+      type: "boolean",
+      description: "Open worktree in new tmux window",
+    },
+    {
+      name: "--tmux-vertical, --tmux-v",
+      type: "boolean",
+      description: "Open worktree in vertical split pane",
+    },
+    {
+      name: "--tmux-horizontal, --tmux-h",
+      type: "boolean",
+      description: "Open worktree in horizontal split pane",
+    },
   ],
   examples: [
     {
@@ -51,6 +66,10 @@ export const githubCheckoutHelp: CommandHelp = {
       command: "phantom github checkout 789 --base develop",
       description: "Create a worktree for issue #789 based on develop branch",
     },
+    {
+      command: "phantom github checkout 321 --tmux",
+      description: "Create a worktree and open it in a new tmux window",
+    },
   ],
   notes: [
     "For PRs: Creates worktree named 'pulls/{number}' with the PR's branch",
@@ -59,5 +78,7 @@ export const githubCheckoutHelp: CommandHelp = {
     "Requirements:",
     "  - GitHub CLI (gh) must be installed",
     "  - Must be authenticated with 'gh auth login'",
+    "",
+    "Tmux options require being inside a tmux session",
   ],
 };


### PR DESCRIPTION
## Summary
- add tmux flag descriptions to the GitHub checkout help output
- expand GitHub checkout shell completions (github/gh) to include tmux options

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cdc6205c48327af8788f7ece59365)