### PR TITLE
feat: add worktreesDirectory preference

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -76,7 +76,9 @@ your-project/    # Gitリポジトリ
 └── ...
 ```
 
-`phantom.config.json`の`worktreesDirectory`設定オプションを使用してワークツリーの場所をカスタマイズすることもできます。これにより、お好みの場所にワークツリーを保存できます。
+ユーザーごとに `phantom preferences set worktreesDirectory <path>` でワークツリーの場所をカスタマイズできます。**Gitリポジトリのルートからの相対パス**を指定してください。デフォルトは `.git/phantom/worktrees/` です。
+
+`phantom.config.json` の `worktreesDirectory` オプションはDeprecatedで、次のバージョンで削除されます。
 
 このルールにより、worktreeの場所を覚える必要がなくなり、ブランチ名だけで簡単にワークツリーの操作ができます。
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Phantom is a powerful CLI tool that dramatically boosts your development product
 - 🪟 **Built-in tmux integration** - Open worktrees in new panes or windows
 - 🔍 **Interactive selection with fzf** - Use built-in fzf option for worktree selection
 - 🎮 **Shell completion** - Full autocomplete support for Fish, Zsh, and Bash
-- 🧭 **Configurable defaults** - Set editor and AI commands once via `phantom preferences` (stored in global git config)
+- 🧭 **Configurable defaults** - Set editor, AI command, and worktreesDirectory once via `phantom preferences` (stored in global git config)
 - 🐙 **GitHub Integration** - Create worktrees directly from GitHub PRs and issues
 - 🤖 **MCP Integration** - AI autonomously manages worktrees for parallel development
 - ⚡ **Fast and lightweight** - Minimal external dependencies
@@ -77,7 +77,9 @@ your-project/    # Git repository
 └── ...
 ```
 
-You can also customize the worktree location using the `worktreesDirectory` configuration option in `phantom.config.json`. This allows you to store worktrees in any location you prefer.
+You can also customize the worktree location per user with `phantom preferences set worktreesDirectory <path>`. Specify a path **relative to the Git repository root**; the default is `.git/phantom/worktrees/`.
+
+The `worktreesDirectory` option in `phantom.config.json` is deprecated and will be removed in the next version.
 
 This convention means you never need to remember worktree paths - just use the branch name for easy worktree operations.
 
@@ -166,14 +168,17 @@ Store your defaults in global git config and manage them with `phantom preferenc
 # Inspect current defaults
 phantom preferences get editor
 phantom preferences get ai
+phantom preferences get worktreesDirectory
 
 # Update them
 phantom preferences set editor "code --reuse-window"
 phantom preferences set ai claude
+phantom preferences set worktreesDirectory ../phantom-worktrees
 
 # Remove to fall back to $EDITOR or reconfigure AI
 phantom preferences remove editor
 phantom preferences remove ai
+phantom preferences remove worktreesDirectory
 ```
 
 #### fzf Integration

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -309,6 +309,9 @@ phantom ai feature-auth
 Configure defaults for Phantom commands using global git config. Preferences are stored under the `phantom.<key>` namespace and currently support:
 - `editor` - preferred editor command for `phantom edit`
 - `ai` - assistant command for `phantom ai`
+- `worktreesDirectory` - base directory for Phantom worktrees
+
+For `worktreesDirectory`, specify a path **relative to the Git repository root**. The default is `.git/phantom/worktrees/`.
 
 Set them once to avoid exporting environment variables each time.
 
@@ -319,6 +322,7 @@ Show a preference value.
 ```bash
 phantom preferences get editor
 phantom preferences get ai
+phantom preferences get worktreesDirectory
 ```
 
 ### preferences set
@@ -331,6 +335,9 @@ phantom preferences set editor "code --reuse-window"
 
 # Configure your AI assistant command
 phantom preferences set ai "codex --full-auto"
+
+# Store worktrees outside the repo (relative to repo root)
+phantom preferences set worktreesDirectory ../phantom-worktrees
 ```
 
 ### preferences remove
@@ -340,11 +347,13 @@ Remove a preference value.
 ```bash
 phantom preferences remove editor
 phantom preferences remove ai
+phantom preferences remove worktreesDirectory
 ```
 
 **Notes:**
 - `phantom edit` prefers `phantom.editor` and falls back to `$EDITOR` if unset
 - `phantom ai` requires `phantom.ai` to be configured
+- `phantom create/attach` use `phantom.worktreesDirectory` when set, otherwise `.git/phantom/worktrees/`
 
 ## GitHub Integration
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,7 +4,7 @@
 
 - [Configuration File](#configuration-file)
 - [Configuration Options](#configuration-options)
-  - [worktreesDirectory](#worktreebasedirectory)
+  - [worktreesDirectory](#worktreesdirectory-deprecated)
   - [postCreate.copyFiles](#postcreatecopyfiles)
   - [postCreate.commands](#postcreatecommands)
   - [preDelete.commands](#predeletecommands)
@@ -17,7 +17,6 @@ Create a `phantom.config.json` file in your repository root:
 
 ```json
 {
-  "worktreesDirectory": "../phantom-worktrees",
   "postCreate": {
     "copyFiles": [
       ".env",
@@ -39,9 +38,11 @@ Create a `phantom.config.json` file in your repository root:
 
 ## Configuration Options
 
-### worktreesDirectory
+### worktreesDirectory (Deprecated)
 
-A custom base directory where Phantom worktrees will be created. By default, Phantom creates all worktrees in `.git/phantom/worktrees/`, but you can customize this location using the `worktreesDirectory` option.
+A custom base directory where Phantom worktrees will be created.
+
+**Deprecated:** Configure this per user via `phantom preferences set worktreesDirectory <path>` instead. Specify a path relative to the Git repository root; the default is `.git/phantom/worktrees/`. This config option will be removed in the next version.
 
 **Use Cases:**
 - Store worktrees outside the main repository directory
@@ -175,4 +176,3 @@ An array of commands to execute in a worktree **before** it is deleted. Use this
 - Commands are executed in order and halt on the first failure
 - If a command fails, the worktree is **not** removed
 - Output is displayed in real-time
-

--- a/packages/cli/src/completions/phantom-bash.ts
+++ b/packages/cli/src/completions/phantom-bash.ts
@@ -268,19 +268,19 @@ _phantom_completion() {
                 return 0
             elif [[ \${words[2]} == "get" ]]; then
                 if [[ \${cword} -eq 3 ]]; then
-                    local keys="editor ai"
+                    local keys="editor ai worktreesDirectory"
                     COMPREPLY=( $(compgen -W "\${keys}" -- "\${cur}") )
                     return 0
                 fi
             elif [[ \${words[2]} == "set" ]]; then
                 if [[ \${cword} -eq 3 ]]; then
-                    local keys="editor ai"
+                    local keys="editor ai worktreesDirectory"
                     COMPREPLY=( $(compgen -W "\${keys}" -- "\${cur}") )
                     return 0
                 fi
             elif [[ \${words[2]} == "remove" ]]; then
                 if [[ \${cword} -eq 3 ]]; then
-                    local keys="editor ai"
+                    local keys="editor ai worktreesDirectory"
                     COMPREPLY=( $(compgen -W "\${keys}" -- "\${cur}") )
                     return 0
                 fi

--- a/packages/cli/src/completions/phantom-zsh.ts
+++ b/packages/cli/src/completions/phantom-zsh.ts
@@ -110,7 +110,7 @@ _phantom() {
                 preferences)
                     _arguments \
                         '1:subcommand:(get set remove)' \
-                        '2:key:(editor ai)'
+                        '2:key:(editor ai worktreesDirectory)'
                     ;;
                 completion)
                     _arguments \

--- a/packages/cli/src/completions/phantom.bash
+++ b/packages/cli/src/completions/phantom.bash
@@ -268,19 +268,19 @@ _phantom_completion() {
                 return 0
             elif [[ ${words[2]} == "get" ]]; then
                 if [[ ${cword} -eq 3 ]]; then
-                    local keys="editor ai"
+                    local keys="editor ai worktreesDirectory"
                     COMPREPLY=( $(compgen -W "${keys}" -- "${cur}") )
                     return 0
                 fi
             elif [[ ${words[2]} == "set" ]]; then
                 if [[ ${cword} -eq 3 ]]; then
-                    local keys="editor ai"
+                    local keys="editor ai worktreesDirectory"
                     COMPREPLY=( $(compgen -W "${keys}" -- "${cur}") )
                     return 0
                 fi
             elif [[ ${words[2]} == "remove" ]]; then
                 if [[ ${cword} -eq 3 ]]; then
-                    local keys="editor ai"
+                    local keys="editor ai worktreesDirectory"
                     COMPREPLY=( $(compgen -W "${keys}" -- "${cur}") )
                     return 0
                 fi

--- a/packages/cli/src/completions/phantom.fish
+++ b/packages/cli/src/completions/phantom.fish
@@ -155,9 +155,9 @@ complete -c phantom -n "__phantom_using_command ai" -a "(__phantom_list_worktree
 
 # preferences command
 complete -c phantom -n "__phantom_using_command preferences" -a "get set remove" -d "Manage preferences"
-complete -c phantom -n "__phantom_using_command preferences get" -a "editor ai" -d "Preference key"
-complete -c phantom -n "__phantom_using_command preferences set" -a "editor ai" -d "Preference key"
-complete -c phantom -n "__phantom_using_command preferences remove" -a "editor ai" -d "Preference key"
+complete -c phantom -n "__phantom_using_command preferences get" -a "editor ai worktreesDirectory" -d "Preference key"
+complete -c phantom -n "__phantom_using_command preferences set" -a "editor ai worktreesDirectory" -d "Preference key"
+complete -c phantom -n "__phantom_using_command preferences remove" -a "editor ai worktreesDirectory" -d "Preference key"
 
 # shell command options
 complete -c phantom -n "__phantom_using_command shell" -l fzf -d "Use fzf for interactive selection"

--- a/packages/cli/src/completions/phantom.zsh
+++ b/packages/cli/src/completions/phantom.zsh
@@ -110,7 +110,7 @@ _phantom() {
                 preferences)
                     _arguments \
                         '1:subcommand:(get set remove)' \
-                        '2:key:(editor ai)'
+                        '2:key:(editor ai worktreesDirectory)'
                     ;;
                 completion)
                     _arguments \

--- a/packages/cli/src/handlers/preferences-get.test.js
+++ b/packages/cli/src/handlers/preferences-get.test.js
@@ -77,7 +77,7 @@ describe("preferencesGetHandler", () => {
 
     await rejects(
       async () => await preferencesGetHandler(["unknown"]),
-      /Exit with code 3: Unknown preference 'unknown'\. Supported keys: editor, ai/,
+      /Exit with code 3: Unknown preference 'unknown'\. Supported keys: editor, ai, worktreesDirectory/,
     );
 
     strictEqual(exitMock.mock.calls[0].arguments[0], 3);
@@ -113,6 +113,24 @@ describe("preferencesGetHandler", () => {
     strictEqual(exitMock.mock.calls[0].arguments[0], 0);
   });
 
+  it("prints worktreesDirectory preference when set", async () => {
+    resetMocks();
+    loadPreferencesMock.mock.mockImplementation(async () => ({
+      worktreesDirectory: "../phantom-worktrees",
+    }));
+
+    await rejects(
+      async () => await preferencesGetHandler(["worktreesDirectory"]),
+      /Process exit with code 0/,
+    );
+
+    strictEqual(
+      consoleLogMock.mock.calls[0].arguments[0],
+      "../phantom-worktrees",
+    );
+    strictEqual(exitMock.mock.calls[0].arguments[0], 0);
+  });
+
   it("warns when preference is unset", async () => {
     resetMocks();
     loadPreferencesMock.mock.mockImplementation(async () => ({}));
@@ -140,6 +158,21 @@ describe("preferencesGetHandler", () => {
     strictEqual(
       consoleLogMock.mock.calls[0].arguments[0],
       "Preference 'ai' is not set (git config --global phantom.ai)",
+    );
+  });
+
+  it("warns when worktreesDirectory preference is unset", async () => {
+    resetMocks();
+    loadPreferencesMock.mock.mockImplementation(async () => ({}));
+
+    await rejects(
+      async () => await preferencesGetHandler(["worktreesDirectory"]),
+      /Process exit with code 0/,
+    );
+
+    strictEqual(
+      consoleLogMock.mock.calls[0].arguments[0],
+      "Preference 'worktreesDirectory' is not set (git config --global phantom.worktreesDirectory)",
     );
   });
 });

--- a/packages/cli/src/handlers/preferences-get.ts
+++ b/packages/cli/src/handlers/preferences-get.ts
@@ -3,7 +3,7 @@ import { loadPreferences } from "@aku11i/phantom-core";
 import { exitCodes, exitWithError, exitWithSuccess } from "../errors.ts";
 import { output } from "../output.ts";
 
-const supportedKeys = ["editor", "ai"] as const;
+const supportedKeys = ["editor", "ai", "worktreesDirectory"] as const;
 
 export async function preferencesGetHandler(args: string[]): Promise<void> {
   const { positionals } = parseArgs({
@@ -36,7 +36,9 @@ export async function preferencesGetHandler(args: string[]): Promise<void> {
         ? preferences.editor
         : inputKey === "ai"
           ? preferences.ai
-          : undefined;
+          : inputKey === "worktreesDirectory"
+            ? preferences.worktreesDirectory
+            : undefined;
 
     if (value === undefined) {
       output.log(

--- a/packages/cli/src/handlers/preferences-remove.test.js
+++ b/packages/cli/src/handlers/preferences-remove.test.js
@@ -73,7 +73,7 @@ describe("preferencesRemoveHandler", () => {
 
     await rejects(
       async () => await preferencesRemoveHandler(["unknown"]),
-      /Exit with code 3: Unknown preference 'unknown'\. Supported keys: editor, ai/,
+      /Exit with code 3: Unknown preference 'unknown'\. Supported keys: editor, ai, worktreesDirectory/,
     );
 
     strictEqual(exitMock.mock.calls[0].arguments[0], 3);
@@ -123,6 +123,29 @@ describe("preferencesRemoveHandler", () => {
     strictEqual(
       consoleLogMock.mock.calls[0].arguments[0],
       "Removed phantom.ai from global git config",
+    );
+    strictEqual(exitMock.mock.calls[0].arguments[0], 0);
+  });
+
+  it("unsets worktreesDirectory preference via git config --global", async () => {
+    resetMocks();
+    executeGitCommandMock.mock.mockImplementation(async () => ({
+      stdout: "",
+      stderr: "",
+    }));
+
+    await rejects(
+      async () => await preferencesRemoveHandler(["worktreesDirectory"]),
+      /Process exit with code 0/,
+    );
+
+    strictEqual(
+      executeGitCommandMock.mock.calls[0].arguments[0][3],
+      "phantom.worktreesDirectory",
+    );
+    strictEqual(
+      consoleLogMock.mock.calls[0].arguments[0],
+      "Removed phantom.worktreesDirectory from global git config",
     );
     strictEqual(exitMock.mock.calls[0].arguments[0], 0);
   });

--- a/packages/cli/src/handlers/preferences-remove.ts
+++ b/packages/cli/src/handlers/preferences-remove.ts
@@ -3,7 +3,7 @@ import { executeGitCommand } from "@aku11i/phantom-git";
 import { exitCodes, exitWithError, exitWithSuccess } from "../errors.ts";
 import { output } from "../output.ts";
 
-const supportedKeys = ["editor", "ai"] as const;
+const supportedKeys = ["editor", "ai", "worktreesDirectory"] as const;
 
 export async function preferencesRemoveHandler(args: string[]): Promise<void> {
   const { positionals } = parseArgs({

--- a/packages/cli/src/handlers/preferences-set.test.js
+++ b/packages/cli/src/handlers/preferences-set.test.js
@@ -73,7 +73,7 @@ describe("preferencesSetHandler", () => {
 
     await rejects(
       async () => await preferencesSetHandler(["unknown", "value"]),
-      /Exit with code 3: Unknown preference 'unknown'\. Supported keys: editor, ai/,
+      /Exit with code 3: Unknown preference 'unknown'\. Supported keys: editor, ai, worktreesDirectory/,
     );
 
     strictEqual(exitMock.mock.calls[0].arguments[0], 3);
@@ -154,6 +154,37 @@ describe("preferencesSetHandler", () => {
     strictEqual(
       consoleLogMock.mock.calls[0].arguments[0],
       "Set phantom.ai (global) to 'claude'",
+    );
+    strictEqual(exitMock.mock.calls[0].arguments[0], 0);
+  });
+
+  it("sets worktreesDirectory preference via git config --global", async () => {
+    resetMocks();
+    executeGitCommandMock.mock.mockImplementation(async () => ({
+      stdout: "",
+      stderr: "",
+    }));
+
+    await rejects(
+      async () =>
+        await preferencesSetHandler([
+          "worktreesDirectory",
+          "../phantom-worktrees",
+        ]),
+      /Process exit with code 0/,
+    );
+
+    strictEqual(
+      executeGitCommandMock.mock.calls[0].arguments[0][2],
+      "phantom.worktreesDirectory",
+    );
+    strictEqual(
+      executeGitCommandMock.mock.calls[0].arguments[0][3],
+      "../phantom-worktrees",
+    );
+    strictEqual(
+      consoleLogMock.mock.calls[0].arguments[0],
+      "Set phantom.worktreesDirectory (global) to '../phantom-worktrees'",
     );
     strictEqual(exitMock.mock.calls[0].arguments[0], 0);
   });

--- a/packages/cli/src/handlers/preferences-set.ts
+++ b/packages/cli/src/handlers/preferences-set.ts
@@ -2,7 +2,7 @@ import { executeGitCommand } from "@aku11i/phantom-git";
 import { exitCodes, exitWithError, exitWithSuccess } from "../errors.ts";
 import { output } from "../output.ts";
 
-const supportedKeys = ["editor", "ai"] as const;
+const supportedKeys = ["editor", "ai", "worktreesDirectory"] as const;
 
 export async function preferencesSetHandler(args: string[]): Promise<void> {
   if (args.length < 2) {

--- a/packages/cli/src/help/preferences.ts
+++ b/packages/cli/src/help/preferences.ts
@@ -20,6 +20,12 @@ export const preferencesHelp: CommandHelp = {
         "Set the AI assistant preference (stored as phantom.ai in git config --global)",
     },
     {
+      command:
+        "phantom preferences set worktreesDirectory ../phantom-worktrees",
+      description:
+        "Set a custom worktrees directory (stored as phantom.worktreesDirectory in git config --global)",
+    },
+    {
       command: "phantom preferences remove editor",
       description: "Remove the editor preference (fallback to env/default)",
     },
@@ -31,7 +37,8 @@ export const preferencesHelp: CommandHelp = {
     "  remove <key> Remove a preference value",
     "",
     "Preferences are saved in git config with the 'phantom.' prefix (global scope).",
-    "Supported keys: editor (used by 'phantom edit', preferred over $EDITOR) and ai (used by 'phantom ai').",
+    "Supported keys: editor (used by 'phantom edit', preferred over $EDITOR), ai (used by 'phantom ai'), and worktreesDirectory (base directory for worktrees).",
+    "For worktreesDirectory, specify a path relative to the Git repository root. Default: .git/phantom/worktrees.",
   ],
 };
 
@@ -49,8 +56,12 @@ export const preferencesGetHelp: CommandHelp = {
       command: "phantom preferences get ai",
       description: "Show the AI assistant preference",
     },
+    {
+      command: "phantom preferences get worktreesDirectory",
+      description: "Show the worktrees directory preference",
+    },
   ],
-  notes: ["Supported keys: editor, ai"],
+  notes: ["Supported keys: editor, ai, worktreesDirectory"],
 };
 
 export const preferencesSetHelp: CommandHelp = {
@@ -67,8 +78,16 @@ export const preferencesSetHelp: CommandHelp = {
       command: "phantom preferences set ai claude",
       description: "Configure the AI assistant command",
     },
+    {
+      command:
+        "phantom preferences set worktreesDirectory ../phantom-worktrees",
+      description: "Set a custom base directory for worktrees",
+    },
   ],
-  notes: ["Supported keys: editor, ai"],
+  notes: [
+    "Supported keys: editor, ai, worktreesDirectory",
+    "worktreesDirectory should be a path relative to the repository root. Default: .git/phantom/worktrees.",
+  ],
 };
 
 export const preferencesRemoveHelp: CommandHelp = {
@@ -85,6 +104,10 @@ export const preferencesRemoveHelp: CommandHelp = {
       command: "phantom preferences remove ai",
       description: "Unset the AI assistant preference",
     },
+    {
+      command: "phantom preferences remove worktreesDirectory",
+      description: "Unset the worktrees directory preference",
+    },
   ],
-  notes: ["Supported keys: editor, ai"],
+  notes: ["Supported keys: editor, ai, worktreesDirectory"],
 };

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -13,8 +13,18 @@ export interface Context {
 export async function createContext(gitRoot: string): Promise<Context> {
   const configResult = await loadConfig(gitRoot);
   const config = isOk(configResult) ? configResult.value : null;
-  const worktreesDirectory = config?.worktreesDirectory;
   const preferences = await loadPreferences();
+  const deprecatedWorktreesDirectory = config?.worktreesDirectory;
+  const preferredWorktreesDirectory = preferences.worktreesDirectory;
+
+  if (deprecatedWorktreesDirectory && !preferredWorktreesDirectory) {
+    console.warn(
+      "Warning: 'worktreesDirectory' in phantom.config.json is deprecated and will be removed in the next version. Set it via 'phantom preferences set worktreesDirectory <path>' instead.",
+    );
+  }
+
+  const worktreesDirectory =
+    preferredWorktreesDirectory ?? deprecatedWorktreesDirectory;
 
   return {
     gitRoot,

--- a/packages/core/src/preferences/loader.test.js
+++ b/packages/core/src/preferences/loader.test.js
@@ -19,13 +19,18 @@ describe("loadPreferences", () => {
   it("returns editor and ai preferences from git config", async () => {
     resetMocks();
     executeGitCommandMock.mock.mockImplementation(async () => ({
-      stdout: "phantom.editor\ncode\u0000phantom.ai\nclaude\u0000",
+      stdout:
+        "phantom.editor\ncode\u0000phantom.ai\nclaude\u0000phantom.worktreesDirectory\n../phantom-worktrees\u0000",
       stderr: "",
     }));
 
     const preferences = await loadPreferences();
 
-    deepStrictEqual(preferences, { editor: "code", ai: "claude" });
+    deepStrictEqual(preferences, {
+      editor: "code",
+      ai: "claude",
+      worktreesDirectory: "../phantom-worktrees",
+    });
     deepStrictEqual(executeGitCommandMock.mock.calls[0].arguments[0], [
       "config",
       "--global",
@@ -39,13 +44,17 @@ describe("loadPreferences", () => {
     resetMocks();
     executeGitCommandMock.mock.mockImplementation(async () => ({
       stdout:
-        "phantom.unknown\nvalue\u0000phantom.editor\nvim\u0000phantom.ai\ncodex\u0000",
+        "phantom.unknown\nvalue\u0000phantom.editor\nvim\u0000phantom.ai\ncodex\u0000phantom.worktreesDirectory\ncustom/worktrees\u0000",
       stderr: "",
     }));
 
     const preferences = await loadPreferences();
 
-    deepStrictEqual(preferences, { editor: "vim", ai: "codex" });
+    deepStrictEqual(preferences, {
+      editor: "vim",
+      ai: "codex",
+      worktreesDirectory: "custom/worktrees",
+    });
   });
 
   it("returns empty preferences when no config entries exist", async () => {
@@ -64,7 +73,7 @@ describe("loadPreferences", () => {
     resetMocks();
     executeGitCommandMock.mock.mockImplementation(async () => ({
       stdout:
-        "phantom.editor\nvim\u0000phantom.editor\ncode\u0000phantom.ai\nclaude\u0000phantom.ai\ncursor\u0000",
+        "phantom.editor\nvim\u0000phantom.editor\ncode\u0000phantom.ai\nclaude\u0000phantom.ai\ncursor\u0000phantom.worktreesDirectory\none\u0000phantom.worktreesDirectory\ntwo\u0000",
       stderr: "",
     }));
 
@@ -72,5 +81,6 @@ describe("loadPreferences", () => {
 
     equal(preferences.editor, "code");
     equal(preferences.ai, "cursor");
+    equal(preferences.worktreesDirectory, "two");
   });
 });

--- a/packages/core/src/preferences/loader.ts
+++ b/packages/core/src/preferences/loader.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 export interface Preferences {
   editor?: string;
   ai?: string;
+  worktreesDirectory?: string;
 }
 
 export class PreferencesValidationError extends Error {
@@ -17,6 +18,7 @@ const preferencesSchema = z
   .object({
     editor: z.string().optional(),
     ai: z.string().optional(),
+    worktreesDirectory: z.string().optional(),
   })
   .passthrough();
 
@@ -52,6 +54,8 @@ function parsePreferences(output: string): Preferences {
       preferences.editor = value;
     } else if (strippedKey === "ai") {
       preferences.ai = value;
+    } else if (strippedKey === "worktreesDirectory") {
+      preferences.worktreesDirectory = value;
     }
   }
 


### PR DESCRIPTION
## Summary
- Added `phantom.worktreesDirectory` user preference (global git config) and prefer it when resolving the worktree base directory.
- Deprecated `worktreesDirectory` in `phantom.config.json`; prints a warning when it is used and no preference is set.
- Updated CLI help/completions and docs to emphasize "relative to repo root" and the default `.git/phantom/worktrees/`.

## Verification
- pnpm ready