### PR TITLE
Add latest Node to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node-version: ['22', '24']
+        node-version: ['22', '24', 'latest']
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061


### PR DESCRIPTION
## Summary
- add Node latest to CI test matrix alongside 22 and 24

## Testing
- not run (workflow change only)
