### PR TITLE
feat!: align PR checkout naming with gh pr checkout

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -400,7 +400,8 @@ phantom gh checkout 123
 - tmux options require being inside a tmux session
 
 **Behavior:**
-- For PRs: Creates worktree named after the PR branch (e.g., `feature/add-logging`)
+- For same-repo PRs: Worktree name matches the PR branch (e.g., `feature/add-logging`)
+- For fork PRs: Worktree name is `{owner}/{branch}` (e.g., `aku11i/feature/add-logging`)
 - For Issues: Creates worktree named `issues/{number}` with a new branch
 
 For detailed information, see the [GitHub Integration Guide](./github.md).

--- a/docs/github.md
+++ b/docs/github.md
@@ -52,7 +52,7 @@ npm test
 ```
 
 **What happens:**
-- Creates a worktree named after the PR branch (e.g., `feature/add-logging`)
+- Creates a worktree named after the PR branch (fork PRs use `{owner}/{branch}`)
 - Checks out the PR's branch
 - You can test the changes without affecting your main working directory
 
@@ -122,23 +122,23 @@ When checking out a pull request, Phantom performs the following steps:
 #### 1. Fetch Remote Branch
 ```bash
 # For PRs from forks:
-git fetch origin pull/{number}/head:{branch-name}
+git fetch origin pull/{number}/head:{owner}/{head-ref}
 
 # For PRs from the same repository:
-git fetch origin {branch-name}:{branch-name}
+git fetch origin {head-ref}:{head-ref}
 ```
 
 The command intelligently detects whether the PR comes from a fork or the same repository:
-- **Fork PRs**: Uses GitHub's special `pull/{number}/head` reference
+- **Fork PRs**: Uses GitHub's special `pull/{number}/head` reference and prefixes the branch with `{owner}/`
 - **Same-repo PRs**: Uses the actual branch name from the PR
 
 #### 2. Set Upstream Tracking
 ```bash
 # For fork PRs:
-git branch --set-upstream-to origin/pull/{number}/head {branch-name}
+git branch --set-upstream-to origin/pull/{number}/head {owner}/{head-ref}
 
 # For same-repo PRs:
-git branch --set-upstream-to origin/{branch-name} {branch-name}
+git branch --set-upstream-to origin/{head-ref} {head-ref}
 ```
 
 This enables easy updates with `git pull` in the worktree.
@@ -172,7 +172,9 @@ The command determines if a PR is from a fork by checking if the PR's head repos
 - The command validates that the GitHub CLI (`gh`) is available before proceeding
 
 #### Naming Conventions
-- Pull request worktrees: `{branch-name}` (PR head ref)
+- Pull request worktrees:
+  - Same-repo PRs: `{head-ref}` (PR head ref)
+  - Fork PRs: `{owner}/{head-ref}`
 - Issue worktrees: `issues/{number}`
 - Local branch names match the worktree names
 

--- a/packages/cli/src/help/github.ts
+++ b/packages/cli/src/help/github.ts
@@ -72,7 +72,8 @@ export const githubCheckoutHelp: CommandHelp = {
     },
   ],
   notes: [
-    "For PRs: Creates worktree named 'pulls/{number}' with the PR's branch",
+    "For same-repo PRs: Worktree name matches the PR branch (e.g., 'feature/add-logging')",
+    "For fork PRs: Worktree name is '{owner}/{branch}' (e.g., 'aku11i/feature/add-logging')",
     "For Issues: Creates worktree named 'issues/{number}' with a new branch",
     "",
     "Requirements:",

--- a/packages/github/src/checkout/pr.test.js
+++ b/packages/github/src/checkout/pr.test.js
@@ -316,7 +316,7 @@ describe("checkoutPullRequest", () => {
     }));
     attachWorktreeCoreMock.mock.mockImplementation(async () => ({
       ok: true,
-      value: "/path/to/repo/.git/phantom/worktrees/fork-feature",
+      value: "/path/to/repo/.git/phantom/worktrees/contributor/fork-feature",
     }));
     setUpstreamBranchMock.mock.mockImplementation(async () => ({
       ok: true,
@@ -333,17 +333,17 @@ describe("checkoutPullRequest", () => {
 
     // Verify it uses the same refspec for forked PRs
     const fetchOptions = fetchMock.mock.calls[0].arguments[0];
-    equal(fetchOptions.refspec, "pull/1234/head:fork-feature");
+    equal(fetchOptions.refspec, "pull/1234/head:contributor/fork-feature");
 
     const [, worktreeDirectory, worktreeName] =
       attachWorktreeCoreMock.mock.calls[0].arguments;
     equal(worktreeDirectory, "/path/to/repo/.git/phantom/worktrees");
-    equal(worktreeName, "fork-feature");
+    equal(worktreeName, "contributor/fork-feature");
 
     // Verify upstream was set correctly for forked PR
     const upstreamArgs = setUpstreamBranchMock.mock.calls[0].arguments;
     equal(upstreamArgs[0], mockGitRoot);
-    equal(upstreamArgs[1], "fork-feature");
+    equal(upstreamArgs[1], "contributor/fork-feature");
     equal(upstreamArgs[2], "origin/pull/1234/head");
   });
 

--- a/packages/github/src/checkout/pr.ts
+++ b/packages/github/src/checkout/pr.ts
@@ -14,13 +14,23 @@ export interface CheckoutResult {
   alreadyExists?: boolean;
 }
 
+function getForkWorktreeName(pullRequest: GitHubPullRequest): string {
+  const [owner] = pullRequest.head.repo.full_name.split("/");
+  if (!owner) {
+    return pullRequest.head.ref;
+  }
+  return `${owner}/${pullRequest.head.ref}`;
+}
+
 export async function checkoutPullRequest(
   pullRequest: GitHubPullRequest,
+  worktreeName = pullRequest.isFromFork
+    ? getForkWorktreeName(pullRequest)
+    : pullRequest.head.ref,
 ): Promise<Result<CheckoutResult>> {
   const gitRoot = await getGitRoot();
   const context = await createContext(gitRoot);
-  const worktreeName = pullRequest.head.ref;
-  const localBranch = pullRequest.head.ref;
+  const localBranch = worktreeName;
 
   // Check if worktree already exists before attempting to fetch
   const existsResult = await validateWorktreeExists(


### PR DESCRIPTION
## Summary
- Align fork PR worktree/branch naming with GitHub CLI (`owner/branch`)
- Update docs/help to reflect the new naming behavior
- Adjust PR checkout tests for forked PR naming

## Breaking Change
- Fork PR worktree names now include the owner prefix (e.g., `aku11i/feature/add-logging`) instead of only the branch name

## Testing
- `pnpm ready` *(Biome warnings: schema version mismatch in `biome.json`, unused parameter in `packages/cli/src/handlers/delete.test.js`, unused import in `packages/process/src/resolve-windows-command-path.windows.test.js`)*
