### PR TITLE
feat: add post-create command and shared runner

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -226,6 +226,12 @@ phantom exec feature-awesome {実行したいコマンド}
 # 例: phantom exec feature-awesome npm run build
 ```
 
+### post-create を再実行
+
+```bash
+phantom post-create feature-awesome
+```
+
 ### 完了したらクリーンアップ
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -230,6 +230,12 @@ phantom exec feature-awesome {command to run}
 # Example: phantom exec feature-awesome npm run build
 ```
 
+### Re-run post-create actions
+
+```bash
+phantom post-create feature-awesome
+```
+
 ### Open your editor in the worktree
 
 ```bash

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -7,6 +7,7 @@ This document provides a comprehensive reference for all Phantom commands and th
 - [Worktree Management](#worktree-management)
   - [create](#create)
   - [attach](#attach)
+  - [post-create](#post-create)
   - [list](#list)
   - [where](#where)
   - [delete](#delete)
@@ -95,6 +96,33 @@ phantom attach feature/existing-branch --exec "npm install"
 # Attach and open in tmux window
 phantom attach feature/existing-branch --tmux
 ```
+
+### post-create
+
+Re-run postCreate file copies and commands for an existing worktree.
+
+```bash
+phantom post-create <name> [options]
+```
+
+**Options:**
+- `--current` - Run post-create actions for the current worktree
+- `--fzf` - Select worktree with fzf
+
+**Examples:**
+```bash
+# Re-run post-create actions in a worktree
+phantom post-create feature-auth
+
+# Re-run post-create actions in the current worktree
+phantom post-create --current
+
+# Select a worktree interactively
+phantom post-create --fzf
+```
+
+**Notes:**
+- Runs `postCreate.copyFiles` and `postCreate.commands` from `phantom.config.json`
 
 ### list
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -119,6 +119,7 @@ An array of file paths to automatically copy from the current worktree to newly 
 - Files must exist in the source worktree
 - Non-existent files are silently skipped
 - Can be overridden with `--copy-file` command line options
+- Re-run with `phantom post-create` to copy files into an existing worktree
 
 ### postCreate.commands
 
@@ -149,6 +150,7 @@ An array of commands to execute after creating a new worktree.
 - Execution stops on the first failed command
 - Commands run in the new worktree's directory
 - Output is displayed in real-time
+- Re-run with `phantom post-create` to execute commands in an existing worktree
 
 ### preDelete.commands
 

--- a/packages/cli/src/bin/phantom.ts
+++ b/packages/cli/src/bin/phantom.ts
@@ -12,6 +12,7 @@ import { githubHandler } from "../handlers/github.ts";
 import { githubCheckoutHandler } from "../handlers/github-checkout.ts";
 import { listHandler } from "../handlers/list.ts";
 import { mcpHandler } from "../handlers/mcp.ts";
+import { postCreateHandler } from "../handlers/post-create.ts";
 import { preferencesHandler } from "../handlers/preferences.ts";
 import { preferencesGetHandler } from "../handlers/preferences-get.ts";
 import { preferencesRemoveHandler } from "../handlers/preferences-remove.ts";
@@ -29,6 +30,7 @@ import { execHelp } from "../help/exec.ts";
 import { githubCheckoutHelp, githubHelp } from "../help/github.ts";
 import { listHelp } from "../help/list.ts";
 import { mcpHelp } from "../help/mcp.ts";
+import { postCreateHelp } from "../help/post-create.ts";
 import {
   preferencesGetHelp,
   preferencesHelp,
@@ -78,6 +80,12 @@ const commands: Command[] = [
     description: "Delete a Git worktree (phantom)",
     handler: deleteHandler,
     help: deleteHelp,
+  },
+  {
+    name: "post-create",
+    description: "Re-run post-create actions for an existing worktree",
+    handler: postCreateHandler,
+    help: postCreateHelp,
   },
   {
     name: "exec",

--- a/packages/cli/src/completions/phantom-bash.ts
+++ b/packages/cli/src/completions/phantom-bash.ts
@@ -72,7 +72,7 @@ _phantom_completion() {
     local cur prev words cword
     _init_completion || return
 
-    local commands="create attach list where delete exec edit ai shell preferences github gh version completion mcp"
+    local commands="create attach list where delete post-create exec edit ai shell preferences github gh version completion mcp"
     local global_opts="--help --version"
 
     if [[ \${cword} -eq 1 ]]; then
@@ -150,6 +150,16 @@ _phantom_completion() {
                 COMPREPLY=( $(compgen -W "\${opts}" -- "\${cur}") )
             else
                 local worktrees=$(_phantom_list_worktrees_no_default)
+                COMPREPLY=( $(compgen -W "\${worktrees}" -- "\${cur}") )
+            fi
+            return 0
+            ;;
+        post-create)
+            if [[ "\${cur}" == -* ]]; then
+                local opts="--current --fzf"
+                COMPREPLY=( $(compgen -W "\${opts}" -- "\${cur}") )
+            else
+                local worktrees=$(_phantom_list_worktrees)
                 COMPREPLY=( $(compgen -W "\${worktrees}" -- "\${cur}") )
             fi
             return 0

--- a/packages/cli/src/completions/phantom-fish.ts
+++ b/packages/cli/src/completions/phantom-fish.ts
@@ -89,6 +89,7 @@ complete -c phantom -n "__phantom_using_command" -a "attach" -d "Attach to an ex
 complete -c phantom -n "__phantom_using_command" -a "list" -d "List all Git worktrees (phantoms)"
 complete -c phantom -n "__phantom_using_command" -a "where" -d "Output the filesystem path of a specific worktree"
 complete -c phantom -n "__phantom_using_command" -a "delete" -d "Delete Git worktrees (phantoms)"
+complete -c phantom -n "__phantom_using_command" -a "post-create" -d "Re-run post-create actions for an existing worktree"
 complete -c phantom -n "__phantom_using_command" -a "exec" -d "Execute a command in a worktree directory"
 complete -c phantom -n "__phantom_using_command" -a "edit" -d "Open a worktree in your configured editor"
 complete -c phantom -n "__phantom_using_command" -a "ai" -d "Launch your configured AI coding assistant in a worktree"
@@ -139,6 +140,11 @@ complete -c phantom -n "__phantom_using_command delete" -l force -d "Force delet
 complete -c phantom -n "__phantom_using_command delete" -l current -d "Delete the current worktree"
 complete -c phantom -n "__phantom_using_command delete" -l fzf -d "Use fzf for interactive selection"
 complete -c phantom -n "__phantom_using_command delete" -a "(__phantom_list_worktrees_no_default)"
+
+# post-create command options
+complete -c phantom -n "__phantom_using_command post-create" -l current -d "Run post-create actions for the current worktree"
+complete -c phantom -n "__phantom_using_command post-create" -l fzf -d "Select a worktree interactively with fzf"
+complete -c phantom -n "__phantom_using_command post-create" -a "(__phantom_list_worktrees)"
 
 # exec command options
 complete -c phantom -n "__phantom_using_command exec; and __phantom_exec_before_command" -l fzf -d "Use fzf for interactive selection"

--- a/packages/cli/src/completions/phantom-zsh.ts
+++ b/packages/cli/src/completions/phantom-zsh.ts
@@ -11,6 +11,7 @@ _phantom() {
         'list:List all Git worktrees (phantoms)'
         'where:Output the filesystem path of a specific worktree'
         'delete:Delete Git worktrees (phantoms)'
+        'post-create:Re-run post-create actions for an existing worktree'
         'exec:Execute a command in a worktree directory'
         'edit:Open a worktree in your configured editor'
         'ai:Launch your configured AI coding assistant in a worktree'
@@ -62,12 +63,19 @@ _phantom() {
                         '--no-default[Exclude the default worktree from the list]' \
                         '--names[Output only phantom names (for scripts and completion)]'
                     ;;
-                where|delete|shell)
+                where|delete|post-create|shell)
                     if [[ \${line[1]} == "where" ]]; then
                         local worktrees
                         worktrees=(\${(f)"$(phantom list --names 2>/dev/null)"})
                         _arguments \
                             '--fzf[Use fzf for interactive selection]' \
+                            '1:worktree:(\${(q)worktrees[@]})'
+                    elif [[ \${line[1]} == "post-create" ]]; then
+                        local worktrees
+                        worktrees=(\${(f)"$(phantom list --names 2>/dev/null)"})
+                        _arguments \
+                            '--current[Run post-create actions for the current worktree]' \
+                            '--fzf[Select worktree with fzf]' \
                             '1:worktree:(\${(q)worktrees[@]})'
                     elif [[ \${line[1]} == "shell" ]]; then
                         local worktrees

--- a/packages/cli/src/handlers/post-create.test.js
+++ b/packages/cli/src/handlers/post-create.test.js
@@ -1,0 +1,222 @@
+import { deepStrictEqual, rejects } from "node:assert";
+import { describe, it, mock } from "node:test";
+import { err, ok } from "@aku11i/phantom-shared";
+
+const exitWithErrorMock = mock.fn((message, code) => {
+  throw new Error(`Exit with code ${code}: ${message}`);
+});
+const exitWithSuccessMock = mock.fn(() => {
+  throw new Error("Exit with success");
+});
+const outputLogMock = mock.fn();
+const outputWarnMock = mock.fn();
+const getGitRootMock = mock.fn();
+const getCurrentWorktreeMock = mock.fn();
+const createContextMock = mock.fn();
+const validateWorktreeExistsMock = mock.fn();
+const runPostCreateMock = mock.fn();
+const selectWorktreeWithFzfMock = mock.fn();
+
+class WorktreeNotFoundError extends Error {}
+
+mock.module("../errors.ts", {
+  namedExports: {
+    exitWithError: exitWithErrorMock,
+    exitWithSuccess: exitWithSuccessMock,
+    exitCodes: {
+      validationError: 3,
+      generalError: 1,
+      notFound: 2,
+      success: 0,
+    },
+  },
+});
+
+mock.module("../output.ts", {
+  namedExports: {
+    output: { log: outputLogMock, warn: outputWarnMock },
+  },
+});
+
+mock.module("@aku11i/phantom-git", {
+  namedExports: {
+    getGitRoot: getGitRootMock,
+    getCurrentWorktree: getCurrentWorktreeMock,
+  },
+});
+
+mock.module("@aku11i/phantom-core", {
+  namedExports: {
+    createContext: createContextMock,
+    runPostCreate: runPostCreateMock,
+    selectWorktreeWithFzf: selectWorktreeWithFzfMock,
+    validateWorktreeExists: validateWorktreeExistsMock,
+    WorktreeNotFoundError,
+  },
+});
+
+const { postCreateHandler } = await import("./post-create.ts");
+
+describe("postCreateHandler", () => {
+  it("runs post-create actions for a named worktree", async () => {
+    exitWithErrorMock.mock.resetCalls();
+    exitWithSuccessMock.mock.resetCalls();
+    outputLogMock.mock.resetCalls();
+    outputWarnMock.mock.resetCalls();
+    getGitRootMock.mock.resetCalls();
+    createContextMock.mock.resetCalls();
+    validateWorktreeExistsMock.mock.resetCalls();
+    runPostCreateMock.mock.resetCalls();
+
+    getGitRootMock.mock.mockImplementation(() => Promise.resolve("/repo"));
+    createContextMock.mock.mockImplementation(() =>
+      Promise.resolve({
+        gitRoot: "/repo",
+        worktreesDirectory: "/repo/.git/phantom/worktrees",
+        config: {
+          postCreate: {
+            copyFiles: [".env"],
+            commands: ["pnpm install"],
+          },
+        },
+      }),
+    );
+    validateWorktreeExistsMock.mock.mockImplementation(() =>
+      Promise.resolve(ok({ path: "/repo/.git/phantom/worktrees/feature" })),
+    );
+    runPostCreateMock.mock.mockImplementation(() =>
+      Promise.resolve(ok({ copyError: undefined, executedCommands: [] })),
+    );
+
+    await rejects(
+      async () => await postCreateHandler(["feature"]),
+      /Exit with success/,
+    );
+
+    deepStrictEqual(runPostCreateMock.mock.calls.length, 1);
+    deepStrictEqual(runPostCreateMock.mock.calls[0].arguments[0], {
+      gitRoot: "/repo",
+      worktreesDirectory: "/repo/.git/phantom/worktrees",
+      worktreeName: "feature",
+      copyFiles: [".env"],
+      commands: ["pnpm install"],
+    });
+  });
+
+  it("uses the current worktree when --current is set", async () => {
+    exitWithErrorMock.mock.resetCalls();
+    exitWithSuccessMock.mock.resetCalls();
+    getGitRootMock.mock.resetCalls();
+    getCurrentWorktreeMock.mock.resetCalls();
+    createContextMock.mock.resetCalls();
+    validateWorktreeExistsMock.mock.resetCalls();
+    runPostCreateMock.mock.resetCalls();
+
+    getGitRootMock.mock.mockImplementation(() => Promise.resolve("/repo"));
+    getCurrentWorktreeMock.mock.mockImplementation(() =>
+      Promise.resolve("current-branch"),
+    );
+    createContextMock.mock.mockImplementation(() =>
+      Promise.resolve({
+        gitRoot: "/repo",
+        worktreesDirectory: "/repo/.git/phantom/worktrees",
+        config: {
+          postCreate: {
+            commands: ["pnpm install"],
+          },
+        },
+      }),
+    );
+    validateWorktreeExistsMock.mock.mockImplementation(() =>
+      Promise.resolve(
+        ok({ path: "/repo/.git/phantom/worktrees/current-branch" }),
+      ),
+    );
+    runPostCreateMock.mock.mockImplementation(() =>
+      Promise.resolve(ok({ copyError: undefined, executedCommands: [] })),
+    );
+
+    await rejects(
+      async () => await postCreateHandler(["--current"]),
+      /Exit with success/,
+    );
+
+    deepStrictEqual(runPostCreateMock.mock.calls.length, 1);
+    deepStrictEqual(
+      runPostCreateMock.mock.calls[0].arguments[0].worktreeName,
+      "current-branch",
+    );
+  });
+
+  it("warns and exits when no post-create actions are configured", async () => {
+    exitWithErrorMock.mock.resetCalls();
+    exitWithSuccessMock.mock.resetCalls();
+    outputWarnMock.mock.resetCalls();
+    getGitRootMock.mock.resetCalls();
+    createContextMock.mock.resetCalls();
+    validateWorktreeExistsMock.mock.resetCalls();
+    runPostCreateMock.mock.resetCalls();
+
+    getGitRootMock.mock.mockImplementation(() => Promise.resolve("/repo"));
+    createContextMock.mock.mockImplementation(() =>
+      Promise.resolve({
+        gitRoot: "/repo",
+        worktreesDirectory: "/repo/.git/phantom/worktrees",
+        config: null,
+      }),
+    );
+    validateWorktreeExistsMock.mock.mockImplementation(() =>
+      Promise.resolve(ok({ path: "/repo/.git/phantom/worktrees/feature" })),
+    );
+
+    await rejects(
+      async () => await postCreateHandler(["feature"]),
+      /Exit with success/,
+    );
+
+    deepStrictEqual(outputWarnMock.mock.calls.length, 1);
+    deepStrictEqual(
+      outputWarnMock.mock.calls[0].arguments[0],
+      "No post-create actions configured in phantom.config.json.",
+    );
+    deepStrictEqual(runPostCreateMock.mock.calls.length, 0);
+  });
+
+  it("fails when no target is provided", async () => {
+    exitWithErrorMock.mock.resetCalls();
+
+    await rejects(async () => await postCreateHandler([]), /Exit with code 3/);
+  });
+
+  it("surfaces post-create command errors", async () => {
+    exitWithErrorMock.mock.resetCalls();
+    getGitRootMock.mock.resetCalls();
+    createContextMock.mock.resetCalls();
+    validateWorktreeExistsMock.mock.resetCalls();
+    runPostCreateMock.mock.resetCalls();
+
+    getGitRootMock.mock.mockImplementation(() => Promise.resolve("/repo"));
+    createContextMock.mock.mockImplementation(() =>
+      Promise.resolve({
+        gitRoot: "/repo",
+        worktreesDirectory: "/repo/.git/phantom/worktrees",
+        config: {
+          postCreate: {
+            commands: ["pnpm install"],
+          },
+        },
+      }),
+    );
+    validateWorktreeExistsMock.mock.mockImplementation(() =>
+      Promise.resolve(ok({ path: "/repo/.git/phantom/worktrees/feature" })),
+    );
+    runPostCreateMock.mock.mockImplementation(() =>
+      Promise.resolve(err(new Error("Post-create command failed"))),
+    );
+
+    await rejects(
+      async () => await postCreateHandler(["feature"]),
+      /Exit with code 1/,
+    );
+  });
+});

--- a/packages/cli/src/handlers/post-create.ts
+++ b/packages/cli/src/handlers/post-create.ts
@@ -1,0 +1,136 @@
+import { parseArgs } from "node:util";
+import {
+  createContext,
+  runPostCreate,
+  selectWorktreeWithFzf,
+  validateWorktreeExists,
+  WorktreeNotFoundError,
+} from "@aku11i/phantom-core";
+import { getCurrentWorktree, getGitRoot } from "@aku11i/phantom-git";
+import { isErr } from "@aku11i/phantom-shared";
+import { exitCodes, exitWithError, exitWithSuccess } from "../errors.ts";
+import { output } from "../output.ts";
+
+export async function postCreateHandler(args: string[]): Promise<void> {
+  const { positionals, values } = parseArgs({
+    args,
+    options: {
+      current: {
+        type: "boolean",
+      },
+      fzf: {
+        type: "boolean",
+        default: false,
+      },
+    },
+    strict: true,
+    allowPositionals: true,
+  });
+
+  const useCurrent = values.current ?? false;
+  const useFzf = values.fzf ?? false;
+
+  if (positionals.length === 0 && !useCurrent && !useFzf) {
+    exitWithError(
+      "Please provide a worktree name, use --current to target the current worktree, or use --fzf for interactive selection",
+      exitCodes.validationError,
+    );
+  }
+
+  if ((positionals.length > 0 || useFzf) && useCurrent) {
+    exitWithError(
+      "Cannot specify --current with a worktree name or --fzf option",
+      exitCodes.validationError,
+    );
+  }
+
+  if (positionals.length > 0 && useFzf) {
+    exitWithError(
+      "Cannot specify both a worktree name and --fzf option",
+      exitCodes.validationError,
+    );
+  }
+
+  if (positionals.length > 1) {
+    exitWithError(
+      "Please provide only one worktree name",
+      exitCodes.validationError,
+    );
+  }
+
+  try {
+    const gitRoot = await getGitRoot();
+    const context = await createContext(gitRoot);
+
+    let worktreeName: string;
+
+    if (useCurrent) {
+      const currentWorktree = await getCurrentWorktree(gitRoot);
+      if (!currentWorktree) {
+        exitWithError(
+          "Not in a worktree directory. The --current option can only be used from within a worktree.",
+          exitCodes.validationError,
+        );
+      }
+      worktreeName = currentWorktree;
+    } else if (useFzf) {
+      const selectResult = await selectWorktreeWithFzf(context.gitRoot);
+      if (isErr(selectResult)) {
+        exitWithError(selectResult.error.message, exitCodes.generalError);
+      }
+      if (!selectResult.value) {
+        exitWithSuccess();
+      }
+      worktreeName = selectResult.value.name;
+    } else {
+      worktreeName = positionals[0];
+    }
+
+    const validation = await validateWorktreeExists(
+      context.gitRoot,
+      context.worktreesDirectory,
+      worktreeName,
+    );
+    if (isErr(validation)) {
+      const exitCode =
+        validation.error instanceof WorktreeNotFoundError
+          ? exitCodes.notFound
+          : exitCodes.generalError;
+      exitWithError(validation.error.message, exitCode);
+    }
+
+    const postCreateCopyFiles = context.config?.postCreate?.copyFiles;
+    const postCreateCommands = context.config?.postCreate?.commands;
+
+    if (!postCreateCopyFiles?.length && !postCreateCommands?.length) {
+      output.warn("No post-create actions configured in phantom.config.json.");
+      exitWithSuccess();
+    }
+
+    const postCreateResult = await runPostCreate({
+      gitRoot: context.gitRoot,
+      worktreesDirectory: context.worktreesDirectory,
+      worktreeName,
+      copyFiles: postCreateCopyFiles,
+      commands: postCreateCommands,
+    });
+
+    if (isErr(postCreateResult)) {
+      exitWithError(postCreateResult.error.message, exitCodes.generalError);
+    }
+
+    if (postCreateResult.value.copyError) {
+      output.warn(
+        `Warning: Failed to copy some files: ${postCreateResult.value.copyError}`,
+      );
+    }
+
+    output.log(`Re-ran post-create actions in '${worktreeName}'.`);
+    exitWithSuccess();
+  } catch (error) {
+    exitWithError(
+      error instanceof Error ? error.message : String(error),
+      exitCodes.generalError,
+    );
+  }
+}

--- a/packages/cli/src/help/create.ts
+++ b/packages/cli/src/help/create.ts
@@ -89,5 +89,6 @@ export const createHelp: CommandHelp = {
     "The worktree name will be used as the branch name",
     "Only one of --shell, --exec, or --tmux options can be used at a time",
     "File copying can also be configured in phantom.config.json",
+    "Re-run post-create actions with phantom post-create",
   ],
 };

--- a/packages/cli/src/help/post-create.ts
+++ b/packages/cli/src/help/post-create.ts
@@ -1,0 +1,37 @@
+import type { CommandHelp } from "../help.ts";
+
+export const postCreateHelp: CommandHelp = {
+  name: "post-create",
+  description:
+    "Re-run postCreate file copies and commands for an existing worktree",
+  usage: "phantom post-create <worktree-name> [options]",
+  options: [
+    {
+      name: "current",
+      type: "boolean",
+      description: "Run post-create actions for the current worktree",
+    },
+    {
+      name: "fzf",
+      type: "boolean",
+      description: "Select a worktree interactively with fzf",
+    },
+  ],
+  examples: [
+    {
+      description: "Re-run post-create actions for a worktree",
+      command: "phantom post-create feature-auth",
+    },
+    {
+      description: "Re-run post-create actions for the current worktree",
+      command: "phantom post-create --current",
+    },
+    {
+      description: "Pick a worktree interactively",
+      command: "phantom post-create --fzf",
+    },
+  ],
+  notes: [
+    "Runs phantom.config.json postCreate.copyFiles and postCreate.commands",
+  ],
+};


### PR DESCRIPTION
### Motivation

- Allow re-running configured `postCreate` file copies and commands for existing worktrees without duplicating logic. 
- Share post-create execution logic between `create` and `attach` flows to centralize behavior and error handling.

### Description

- Add a shared runner `runPostCreate` and related types to `packages/core/src/worktree/post-create.ts` and keep `executePostCreateCommands` for command execution. 
- Reuse `runPostCreate` in `create` and `attach` flows to perform copy and command steps and to surface errors consistently. 
- Add a new CLI command `post-create` with handler, help, and shell completions (bash/zsh/fish) plus docs/README updates and a `post-create` help file. 
- Add unit tests for the CLI handler at `packages/cli/src/handlers/post-create.test.js` and wire the command into the CLI command list.

### Testing

- Ran `pnpm ready` (runs lint fixes, `pnpm typecheck`, and `pnpm test`); the run completed successfully though Biome emitted a schema version/info warning and existing lint suggestions. 
- All automated tests (including the new `post-create` handler tests) were executed as part of `pnpm test` and passed. 
- `pnpm typecheck` completed successfully across workspace packages.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69645dd10b088327a24bb42715c7b2e7)