### PR TITLE
Add --local flag support to preferences commands

### DIFF
--- a/packages/cli/src/handlers/preferences-get.ts
+++ b/packages/cli/src/handlers/preferences-get.ts
@@ -6,16 +6,21 @@ import { output } from "../output.ts";
 const supportedKeys = ["editor", "ai", "worktreesDirectory"] as const;
 
 export async function preferencesGetHandler(args: string[]): Promise<void> {
-  const { positionals } = parseArgs({
+  const { positionals, values } = parseArgs({
     args,
-    options: {},
+    options: {
+      local: { type: "boolean" },
+    },
     strict: true,
     allowPositionals: true,
   });
 
+  const isLocal = values.local ?? false;
+  const scope = isLocal ? "local" : "global";
+
   if (positionals.length !== 1) {
     exitWithError(
-      "Usage: phantom preferences get <key>",
+      "Usage: phantom preferences get [--local] <key>",
       exitCodes.validationError,
     );
   }
@@ -30,7 +35,7 @@ export async function preferencesGetHandler(args: string[]): Promise<void> {
   }
 
   try {
-    const preferences = await loadPreferences();
+    const preferences = await loadPreferences({ scope });
     const value =
       inputKey === "editor"
         ? preferences.editor
@@ -42,7 +47,7 @@ export async function preferencesGetHandler(args: string[]): Promise<void> {
 
     if (value === undefined) {
       output.log(
-        `Preference '${inputKey}' is not set (git config --global phantom.${inputKey})`,
+        `Preference '${inputKey}' is not set (git config --${scope} phantom.${inputKey})`,
       );
     } else {
       output.log(value);

--- a/packages/cli/src/handlers/preferences-remove.test.js
+++ b/packages/cli/src/handlers/preferences-remove.test.js
@@ -1,4 +1,4 @@
-import { rejects, strictEqual } from "node:assert";
+import { deepStrictEqual, rejects, strictEqual } from "node:assert";
 import { describe, it, mock } from "node:test";
 
 const exitMock = mock.fn();
@@ -62,7 +62,7 @@ describe("preferencesRemoveHandler", () => {
 
     await rejects(
       async () => await preferencesRemoveHandler([]),
-      /Exit with code 3: Usage: phantom preferences remove <key>/,
+      /Exit with code 3: Usage: phantom preferences remove \[--local\] <key>/,
     );
 
     strictEqual(exitMock.mock.calls[0].arguments[0], 3);
@@ -146,6 +146,31 @@ describe("preferencesRemoveHandler", () => {
     strictEqual(
       consoleLogMock.mock.calls[0].arguments[0],
       "Removed phantom.worktreesDirectory from global git config",
+    );
+    strictEqual(exitMock.mock.calls[0].arguments[0], 0);
+  });
+
+  it("unsets preference via git config --local when --local is passed", async () => {
+    resetMocks();
+    executeGitCommandMock.mock.mockImplementation(async () => ({
+      stdout: "",
+      stderr: "",
+    }));
+
+    await rejects(
+      async () => await preferencesRemoveHandler(["--local", "editor"]),
+      /Process exit with code 0/,
+    );
+
+    deepStrictEqual(executeGitCommandMock.mock.calls[0].arguments[0], [
+      "config",
+      "--local",
+      "--unset",
+      "phantom.editor",
+    ]);
+    strictEqual(
+      consoleLogMock.mock.calls[0].arguments[0],
+      "Removed phantom.editor from local git config",
     );
     strictEqual(exitMock.mock.calls[0].arguments[0], 0);
   });

--- a/packages/cli/src/handlers/preferences-remove.ts
+++ b/packages/cli/src/handlers/preferences-remove.ts
@@ -6,16 +6,21 @@ import { output } from "../output.ts";
 const supportedKeys = ["editor", "ai", "worktreesDirectory"] as const;
 
 export async function preferencesRemoveHandler(args: string[]): Promise<void> {
-  const { positionals } = parseArgs({
+  const { positionals, values } = parseArgs({
     args,
-    options: {},
+    options: {
+      local: { type: "boolean" },
+    },
     strict: true,
     allowPositionals: true,
   });
 
+  const isLocal = values.local ?? false;
+  const scope = isLocal ? "local" : "global";
+
   if (positionals.length !== 1) {
     exitWithError(
-      "Usage: phantom preferences remove <key>",
+      "Usage: phantom preferences remove [--local] <key>",
       exitCodes.validationError,
     );
   }
@@ -32,12 +37,12 @@ export async function preferencesRemoveHandler(args: string[]): Promise<void> {
   try {
     await executeGitCommand([
       "config",
-      "--global",
+      `--${scope}`,
       "--unset",
       `phantom.${inputKey}`,
     ]);
 
-    output.log(`Removed phantom.${inputKey} from global git config`);
+    output.log(`Removed phantom.${inputKey} from ${scope} git config`);
     exitWithSuccess();
   } catch (error) {
     exitWithError(

--- a/packages/cli/src/handlers/preferences-set.test.js
+++ b/packages/cli/src/handlers/preferences-set.test.js
@@ -1,4 +1,4 @@
-import { rejects, strictEqual } from "node:assert";
+import { deepStrictEqual, rejects, strictEqual } from "node:assert";
 import { describe, it, mock } from "node:test";
 
 const exitMock = mock.fn();
@@ -62,7 +62,7 @@ describe("preferencesSetHandler", () => {
 
     await rejects(
       async () => await preferencesSetHandler(["editor"]),
-      /Exit with code 3: Usage: phantom preferences set <key> <value>/,
+      /Exit with code 3: Usage: phantom preferences set \[--local\] <key> <value>/,
     );
 
     strictEqual(exitMock.mock.calls[0].arguments[0], 3);
@@ -185,6 +185,31 @@ describe("preferencesSetHandler", () => {
     strictEqual(
       consoleLogMock.mock.calls[0].arguments[0],
       "Set phantom.worktreesDirectory (global) to '../phantom/worktrees'",
+    );
+    strictEqual(exitMock.mock.calls[0].arguments[0], 0);
+  });
+
+  it("sets preference via git config --local when --local is passed", async () => {
+    resetMocks();
+    executeGitCommandMock.mock.mockImplementation(async () => ({
+      stdout: "",
+      stderr: "",
+    }));
+
+    await rejects(
+      async () => await preferencesSetHandler(["--local", "editor", "vim"]),
+      /Process exit with code 0/,
+    );
+
+    deepStrictEqual(executeGitCommandMock.mock.calls[0].arguments[0], [
+      "config",
+      "--local",
+      "phantom.editor",
+      "vim",
+    ]);
+    strictEqual(
+      consoleLogMock.mock.calls[0].arguments[0],
+      "Set phantom.editor (local) to 'vim'",
     );
     strictEqual(exitMock.mock.calls[0].arguments[0], 0);
   });

--- a/packages/cli/src/help/preferences.ts
+++ b/packages/cli/src/help/preferences.ts
@@ -3,16 +3,22 @@ import type { CommandHelp } from "../help.ts";
 export const preferencesHelp: CommandHelp = {
   name: "preferences",
   usage: "phantom preferences <subcommand>",
-  description: "Manage phantom user preferences stored in git config (global)",
+  description:
+    "Manage phantom user preferences stored in git config (global or local)",
   examples: [
     {
       command: "phantom preferences get editor",
-      description: "Show the configured editor preference",
+      description: "Show the configured editor preference (global)",
     },
     {
       command: "phantom preferences set editor code",
       description:
         "Set the editor preference (stored as phantom.editor in git config --global)",
+    },
+    {
+      command: "phantom preferences set --local editor vim",
+      description:
+        "Set the editor preference for the current repository only (git config --local)",
     },
     {
       command: 'phantom preferences set ai "codex --full-auto"',
@@ -36,7 +42,12 @@ export const preferencesHelp: CommandHelp = {
     "  set <key>    Set a preference value",
     "  remove <key> Remove a preference value",
     "",
-    "Preferences are saved in git config with the 'phantom.' prefix (global scope).",
+    "Options:",
+    "  --local  Target the repository-local git config instead of global",
+    "",
+    "Preferences are saved in git config with the 'phantom.' prefix.",
+    "By default, preferences use global scope. Pass --local to use per-repository scope.",
+    "Local preferences take precedence over global ones at runtime.",
     "Supported keys:",
     "  editor - used by 'phantom edit', preferred over $EDITOR",
     "  ai - used by 'phantom ai'",
@@ -46,13 +57,23 @@ export const preferencesHelp: CommandHelp = {
 
 export const preferencesGetHelp: CommandHelp = {
   name: "preferences get",
-  usage: "phantom preferences get <key>",
-  description:
-    "Show a preference value (reads git config --global phantom.<key>)",
+  usage: "phantom preferences get [--local] <key>",
+  description: "Show a preference value (reads git config phantom.<key>)",
+  options: [
+    {
+      name: "local",
+      type: "boolean",
+      description: "Read from repository-local git config instead of global",
+    },
+  ],
   examples: [
     {
       command: "phantom preferences get editor",
-      description: "Show the editor preference",
+      description: "Show the editor preference (global)",
+    },
+    {
+      command: "phantom preferences get --local editor",
+      description: "Show the editor preference (local to this repository)",
     },
     {
       command: "phantom preferences get ai",
@@ -69,13 +90,23 @@ export const preferencesGetHelp: CommandHelp = {
 
 export const preferencesSetHelp: CommandHelp = {
   name: "preferences set",
-  usage: "phantom preferences set <key> <value>",
-  description:
-    "Set a preference value (writes git config --global phantom.<key>)",
+  usage: "phantom preferences set [--local] <key> <value>",
+  description: "Set a preference value (writes git config phantom.<key>)",
+  options: [
+    {
+      name: "local",
+      type: "boolean",
+      description: "Write to repository-local git config instead of global",
+    },
+  ],
   examples: [
     {
       command: "phantom preferences set editor code",
-      description: "Set VS Code as the editor",
+      description: "Set VS Code as the editor (global)",
+    },
+    {
+      command: "phantom preferences set --local editor vim",
+      description: "Set vim as the editor for this repository only",
     },
     {
       command: "phantom preferences set ai claude",
@@ -96,13 +127,23 @@ export const preferencesSetHelp: CommandHelp = {
 
 export const preferencesRemoveHelp: CommandHelp = {
   name: "preferences remove",
-  usage: "phantom preferences remove <key>",
-  description:
-    "Remove a preference value (git config --global --unset phantom.<key>)",
+  usage: "phantom preferences remove [--local] <key>",
+  description: "Remove a preference value (git config --unset phantom.<key>)",
+  options: [
+    {
+      name: "local",
+      type: "boolean",
+      description: "Remove from repository-local git config instead of global",
+    },
+  ],
   examples: [
     {
       command: "phantom preferences remove editor",
-      description: "Unset the editor preference",
+      description: "Unset the editor preference (global)",
+    },
+    {
+      command: "phantom preferences remove --local editor",
+      description: "Unset the editor preference (local to this repository)",
     },
     {
       command: "phantom preferences remove ai",

--- a/packages/core/src/preferences/loader.test.js
+++ b/packages/core/src/preferences/loader.test.js
@@ -16,7 +16,7 @@ describe("loadPreferences", () => {
     executeGitCommandMock.mock.resetCalls();
   };
 
-  it("returns editor and ai preferences from git config", async () => {
+  it("returns editor and ai preferences from git config (no scope)", async () => {
     resetMocks();
     executeGitCommandMock.mock.mockImplementation(async () => ({
       stdout:
@@ -33,7 +33,44 @@ describe("loadPreferences", () => {
     });
     deepStrictEqual(executeGitCommandMock.mock.calls[0].arguments[0], [
       "config",
+      "--null",
+      "--get-regexp",
+      "^phantom\\.",
+    ]);
+  });
+
+  it("passes --global flag when scope is global", async () => {
+    resetMocks();
+    executeGitCommandMock.mock.mockImplementation(async () => ({
+      stdout: "phantom.editor\ncode\u0000",
+      stderr: "",
+    }));
+
+    const preferences = await loadPreferences({ scope: "global" });
+
+    deepStrictEqual(preferences, { editor: "code" });
+    deepStrictEqual(executeGitCommandMock.mock.calls[0].arguments[0], [
+      "config",
       "--global",
+      "--null",
+      "--get-regexp",
+      "^phantom\\.",
+    ]);
+  });
+
+  it("passes --local flag when scope is local", async () => {
+    resetMocks();
+    executeGitCommandMock.mock.mockImplementation(async () => ({
+      stdout: "phantom.editor\nvim\u0000",
+      stderr: "",
+    }));
+
+    const preferences = await loadPreferences({ scope: "local" });
+
+    deepStrictEqual(preferences, { editor: "vim" });
+    deepStrictEqual(executeGitCommandMock.mock.calls[0].arguments[0], [
+      "config",
+      "--local",
       "--null",
       "--get-regexp",
       "^phantom\\.",

--- a/packages/core/src/preferences/loader.ts
+++ b/packages/core/src/preferences/loader.ts
@@ -70,14 +70,24 @@ function parsePreferences(output: string): Preferences {
   return parsed.data;
 }
 
-export async function loadPreferences(): Promise<Preferences> {
-  const { stdout } = await executeGitCommand([
-    "config",
-    "--global",
-    "--null",
-    "--get-regexp",
-    "^phantom\\.",
-  ]);
+export interface LoadPreferencesOptions {
+  scope?: "global" | "local";
+}
+
+export async function loadPreferences(
+  options?: LoadPreferencesOptions,
+): Promise<Preferences> {
+  const args = ["config"];
+
+  if (options?.scope === "global") {
+    args.push("--global");
+  } else if (options?.scope === "local") {
+    args.push("--local");
+  }
+
+  args.push("--null", "--get-regexp", "^phantom\\.");
+
+  const { stdout } = await executeGitCommand(args);
 
   return parsePreferences(stdout);
 }


### PR DESCRIPTION
## Summary
Add support for repository-local git config preferences via a new `--local` flag across all preferences subcommands (get, set, remove). This allows users to override global preferences on a per-repository basis.

## Key Changes
- **preferences-get**: Added `--local` flag to read preferences from local git config instead of global
- **preferences-set**: Added `--local` flag to write preferences to local git config instead of global
- **preferences-remove**: Added `--local` flag to remove preferences from local git config instead of global
- **loadPreferences**: Updated to accept optional `LoadPreferencesOptions` with `scope` parameter ("global" or "local")
- **Help documentation**: Updated all help text to document the new `--local` flag and clarify scope behavior
- **Tests**: Added comprehensive test coverage for local scope functionality across all handlers and the loader

## Implementation Details
- The `--local` flag is optional and defaults to global scope for backward compatibility
- Local preferences take precedence over global ones at runtime (as documented in help)
- Usage strings updated from `<key>` to `[--local] <key>` format
- Git config commands now dynamically use `--global` or `--local` based on the flag
- All error messages and output now reflect the appropriate scope (e.g., "git config --local phantom.editor")

https://claude.ai/code/session_01UCo6wySfe9kmoKt475JKSw