### PR TITLE
Add --keep-branch flag and deleteBranch preference for worktree deletion

### DIFF
--- a/packages/cli/src/handlers/delete.ts
+++ b/packages/cli/src/handlers/delete.ts
@@ -26,6 +26,9 @@ export async function deleteHandler(args: string[]): Promise<void> {
         type: "boolean",
         default: false,
       },
+      "keep-branch": {
+        type: "boolean",
+      },
     },
     strict: true,
     allowPositionals: true,
@@ -56,10 +59,16 @@ export async function deleteHandler(args: string[]): Promise<void> {
   }
 
   const forceDelete = values.force ?? false;
+  const keepBranch = values["keep-branch"] ?? false;
 
   try {
     const gitRoot = await getGitRoot();
     const context = await createContext(gitRoot);
+
+    // --keep-branch flag takes priority, then preference, default is true (delete branch)
+    const shouldDeleteBranch = keepBranch
+      ? false
+      : (context.preferences.deleteBranch ?? true);
 
     const worktreeNames: string[] = [];
     if (deleteCurrent) {
@@ -91,6 +100,7 @@ export async function deleteHandler(args: string[]): Promise<void> {
         worktreeName,
         {
           force: forceDelete,
+          deleteBranch: shouldDeleteBranch,
         },
         context.config?.preDelete?.commands,
       );

--- a/packages/cli/src/handlers/preferences-get.ts
+++ b/packages/cli/src/handlers/preferences-get.ts
@@ -3,7 +3,12 @@ import { loadPreferences } from "@aku11i/phantom-core";
 import { exitCodes, exitWithError, exitWithSuccess } from "../errors.ts";
 import { output } from "../output.ts";
 
-const supportedKeys = ["editor", "ai", "worktreesDirectory"] as const;
+const supportedKeys = [
+  "editor",
+  "ai",
+  "worktreesDirectory",
+  "deleteBranch",
+] as const;
 
 export async function preferencesGetHandler(args: string[]): Promise<void> {
   const { positionals } = parseArgs({
@@ -38,14 +43,16 @@ export async function preferencesGetHandler(args: string[]): Promise<void> {
           ? preferences.ai
           : inputKey === "worktreesDirectory"
             ? preferences.worktreesDirectory
-            : undefined;
+            : inputKey === "deleteBranch"
+              ? preferences.deleteBranch
+              : undefined;
 
     if (value === undefined) {
       output.log(
         `Preference '${inputKey}' is not set (git config --global phantom.${inputKey})`,
       );
     } else {
-      output.log(value);
+      output.log(String(value));
     }
 
     exitWithSuccess();

--- a/packages/cli/src/handlers/preferences-remove.ts
+++ b/packages/cli/src/handlers/preferences-remove.ts
@@ -3,7 +3,12 @@ import { executeGitCommand } from "@aku11i/phantom-git";
 import { exitCodes, exitWithError, exitWithSuccess } from "../errors.ts";
 import { output } from "../output.ts";
 
-const supportedKeys = ["editor", "ai", "worktreesDirectory"] as const;
+const supportedKeys = [
+  "editor",
+  "ai",
+  "worktreesDirectory",
+  "deleteBranch",
+] as const;
 
 export async function preferencesRemoveHandler(args: string[]): Promise<void> {
   const { positionals } = parseArgs({

--- a/packages/cli/src/handlers/preferences-set.ts
+++ b/packages/cli/src/handlers/preferences-set.ts
@@ -2,7 +2,12 @@ import { executeGitCommand } from "@aku11i/phantom-git";
 import { exitCodes, exitWithError, exitWithSuccess } from "../errors.ts";
 import { output } from "../output.ts";
 
-const supportedKeys = ["editor", "ai", "worktreesDirectory"] as const;
+const supportedKeys = [
+  "editor",
+  "ai",
+  "worktreesDirectory",
+  "deleteBranch",
+] as const;
 
 export async function preferencesSetHandler(args: string[]): Promise<void> {
   if (args.length < 2) {
@@ -26,6 +31,13 @@ export async function preferencesSetHandler(args: string[]): Promise<void> {
   if (!value) {
     exitWithError(
       `Preference '${inputKey}' requires a value`,
+      exitCodes.validationError,
+    );
+  }
+
+  if (inputKey === "deleteBranch" && value !== "true" && value !== "false") {
+    exitWithError(
+      `Preference 'deleteBranch' must be 'true' or 'false'`,
       exitCodes.validationError,
     );
   }

--- a/packages/cli/src/help/delete.ts
+++ b/packages/cli/src/help/delete.ts
@@ -22,6 +22,12 @@ export const deleteHelp: CommandHelp = {
       type: "boolean",
       description: "Use fzf for interactive selection",
     },
+    {
+      name: "--keep-branch",
+      type: "boolean",
+      description:
+        "Keep the associated branch after deleting the worktree (overrides deleteBranch preference)",
+    },
   ],
   examples: [
     {
@@ -44,11 +50,15 @@ export const deleteHelp: CommandHelp = {
       description: "Delete a worktree with interactive fzf selection",
       command: "phantom delete --fzf",
     },
+    {
+      description: "Delete a worktree but keep its branch",
+      command: "phantom delete feature-auth --keep-branch",
+    },
   ],
   notes: [
     "By default, deletion will fail if the worktree has uncommitted changes",
     "You can pass multiple worktree names to delete them at once",
-    "The associated branch will also be deleted if it's not checked out elsewhere",
+    "The associated branch will also be deleted unless --keep-branch is specified or the deleteBranch preference is set to false",
     "With --fzf, you can interactively select the worktree to delete",
   ],
 };

--- a/packages/cli/src/help/preferences.ts
+++ b/packages/cli/src/help/preferences.ts
@@ -29,6 +29,10 @@ export const preferencesHelp: CommandHelp = {
       command: "phantom preferences remove editor",
       description: "Remove the editor preference (fallback to env/default)",
     },
+    {
+      command: "phantom preferences set deleteBranch false",
+      description: "Disable automatic branch deletion when deleting worktrees",
+    },
   ],
   notes: [
     "Subcommands:",
@@ -41,6 +45,7 @@ export const preferencesHelp: CommandHelp = {
     "  editor - used by 'phantom edit', preferred over $EDITOR",
     "  ai - used by 'phantom ai'",
     "  worktreesDirectory - path relative to the Git repo root for storing worktrees (defaults to .git/phantom/worktrees)",
+    "  deleteBranch - whether to delete the branch when deleting a worktree (true or false, defaults to true)",
   ],
 };
 
@@ -63,8 +68,12 @@ export const preferencesGetHelp: CommandHelp = {
       description:
         "Show the preferred worktrees directory (relative to repo root)",
     },
+    {
+      command: "phantom preferences get deleteBranch",
+      description: "Show whether branches are deleted when deleting worktrees",
+    },
   ],
-  notes: ["Supported keys: editor, ai, worktreesDirectory"],
+  notes: ["Supported keys: editor, ai, worktreesDirectory, deleteBranch"],
 };
 
 export const preferencesSetHelp: CommandHelp = {
@@ -87,10 +96,15 @@ export const preferencesSetHelp: CommandHelp = {
       description:
         "Store worktrees in ../phantom-worktrees relative to the Git repository root",
     },
+    {
+      command: "phantom preferences set deleteBranch false",
+      description: "Disable automatic branch deletion when deleting worktrees",
+    },
   ],
   notes: [
-    "Supported keys: editor, ai, worktreesDirectory",
+    "Supported keys: editor, ai, worktreesDirectory, deleteBranch",
     "For worktreesDirectory, provide a path relative to the Git repository root; defaults to .git/phantom/worktrees when unset",
+    "For deleteBranch, use 'true' or 'false'; defaults to true when unset",
   ],
 };
 
@@ -112,6 +126,11 @@ export const preferencesRemoveHelp: CommandHelp = {
       command: "phantom preferences remove worktreesDirectory",
       description: "Unset the custom worktrees directory preference",
     },
+    {
+      command: "phantom preferences remove deleteBranch",
+      description:
+        "Unset the deleteBranch preference (reverts to default: true)",
+    },
   ],
-  notes: ["Supported keys: editor, ai, worktreesDirectory"],
+  notes: ["Supported keys: editor, ai, worktreesDirectory, deleteBranch"],
 };

--- a/packages/core/src/preferences/loader.test.js
+++ b/packages/core/src/preferences/loader.test.js
@@ -98,4 +98,28 @@ describe("loadPreferences", () => {
     equal(preferences.ai, "claude");
     equal(preferences.worktreesDirectory, "../phantom-wt");
   });
+
+  it("parses deleteBranch preference as boolean", async () => {
+    resetMocks();
+    executeGitCommandMock.mock.mockImplementation(async () => ({
+      stdout: "phantom.deletebranch\nfalse\u0000",
+      stderr: "",
+    }));
+
+    const preferences = await loadPreferences();
+
+    equal(preferences.deleteBranch, false);
+  });
+
+  it("parses deleteBranch preference as true", async () => {
+    resetMocks();
+    executeGitCommandMock.mock.mockImplementation(async () => ({
+      stdout: "phantom.deletebranch\ntrue\u0000",
+      stderr: "",
+    }));
+
+    const preferences = await loadPreferences();
+
+    equal(preferences.deleteBranch, true);
+  });
 });

--- a/packages/core/src/preferences/loader.ts
+++ b/packages/core/src/preferences/loader.ts
@@ -5,6 +5,7 @@ export interface Preferences {
   editor?: string;
   ai?: string;
   worktreesDirectory?: string;
+  deleteBranch?: boolean;
 }
 
 export class PreferencesValidationError extends Error {
@@ -19,6 +20,7 @@ const preferencesSchema = z
     editor: z.string().optional(),
     ai: z.string().optional(),
     worktreesDirectory: z.string().optional(),
+    deleteBranch: z.boolean().optional(),
   })
   .passthrough();
 
@@ -56,6 +58,8 @@ function parsePreferences(output: string): Preferences {
       preferences.ai = value;
     } else if (strippedKey === "worktreesdirectory") {
       preferences.worktreesDirectory = value;
+    } else if (strippedKey === "deletebranch") {
+      preferences.deleteBranch = value === "true";
     }
   }
 

--- a/packages/mcp/src/tools/delete-worktree.test.js
+++ b/packages/mcp/src/tools/delete-worktree.test.js
@@ -68,6 +68,7 @@ describe("deleteWorktreeTool", () => {
         gitRoot,
         worktreesDirectory: "/path/to/repo/.git/phantom/worktrees",
         config: null,
+        preferences: {},
       }),
     );
     deleteWorktreeMock.mock.mockImplementation(() =>
@@ -82,7 +83,7 @@ describe("deleteWorktreeTool", () => {
       gitRoot,
       "/path/to/repo/.git/phantom/worktrees",
       "feature-1",
-      { force: undefined },
+      { force: undefined, deleteBranch: true },
       undefined,
     ]);
 
@@ -106,6 +107,7 @@ describe("deleteWorktreeTool", () => {
         gitRoot,
         worktreesDirectory: "/path/to/repo/.git/phantom/worktrees",
         config: null,
+        preferences: {},
       }),
     );
     deleteWorktreeMock.mock.mockImplementation(() =>
@@ -122,7 +124,7 @@ describe("deleteWorktreeTool", () => {
       gitRoot,
       "/path/to/repo/.git/phantom/worktrees",
       "feature-2",
-      { force: true },
+      { force: true, deleteBranch: true },
       undefined,
     ]);
 
@@ -132,6 +134,35 @@ describe("deleteWorktreeTool", () => {
       parsedContent.message,
       "Worktree 'feature-2' deleted successfully",
     );
+  });
+
+  it("should respect deleteBranch preference from context", async () => {
+    resetMocks();
+    const gitRoot = "/path/to/repo";
+
+    getGitRootMock.mock.mockImplementation(() => Promise.resolve(gitRoot));
+    createContextMock.mock.mockImplementation(() =>
+      Promise.resolve({
+        gitRoot,
+        worktreesDirectory: "/path/to/repo/.git/phantom/worktrees",
+        config: null,
+        preferences: { deleteBranch: false },
+      }),
+    );
+    deleteWorktreeMock.mock.mockImplementation(() =>
+      Promise.resolve(okMock({})),
+    );
+
+    await deleteWorktreeTool.handler({ name: "feature-3" });
+
+    strictEqual(deleteWorktreeMock.mock.calls.length, 1);
+    deepStrictEqual(deleteWorktreeMock.mock.calls[0].arguments, [
+      gitRoot,
+      "/path/to/repo/.git/phantom/worktrees",
+      "feature-3",
+      { force: undefined, deleteBranch: false },
+      undefined,
+    ]);
   });
 
   it("should throw error when deleteWorktree fails", async () => {
@@ -146,6 +177,7 @@ describe("deleteWorktreeTool", () => {
         gitRoot,
         worktreesDirectory: "/path/to/repo/.git/phantom/worktrees",
         config: null,
+        preferences: {},
       }),
     );
     deleteWorktreeMock.mock.mockImplementation(() =>

--- a/packages/mcp/src/tools/delete-worktree.ts
+++ b/packages/mcp/src/tools/delete-worktree.ts
@@ -19,12 +19,14 @@ export const deleteWorktreeTool: Tool<typeof schema> = {
   handler: async ({ name, force }) => {
     const gitRoot = await getGitRoot();
     const context = await createContext(gitRoot);
+    const shouldDeleteBranch = context.preferences.deleteBranch ?? true;
     const result = await deleteWorktree(
       context.gitRoot,
       context.worktreesDirectory,
       name,
       {
         force,
+        deleteBranch: shouldDeleteBranch,
       },
       context.config?.preDelete?.commands,
     );


### PR DESCRIPTION
## Summary
This PR adds support for controlling whether branches are deleted when removing worktrees. Users can now either use the `--keep-branch` CLI flag or set a `deleteBranch` preference to control this behavior globally.

## Key Changes

- **New `--keep-branch` flag**: Added to the `delete` command to keep the associated branch when deleting a worktree. This flag takes priority over the preference setting.

- **New `deleteBranch` preference**: Added support for a new preference that controls whether branches are automatically deleted when removing worktrees. Defaults to `true` (delete branches) to maintain backward compatibility.

- **Preference management**: Extended the preferences system to support getting, setting, and removing the `deleteBranch` preference via CLI commands.

- **Core deletion logic**: Updated `deleteWorktree` function to accept a `deleteBranch` option and skip branch deletion when set to `false`.

- **MCP tool integration**: Updated the MCP delete-worktree tool to respect the `deleteBranch` preference from context.

- **Help documentation**: Updated help text for the `delete` command and all preference-related commands with examples and notes about the new feature.

## Implementation Details

- The `--keep-branch` flag takes priority over the `deleteBranch` preference
- When `deleteBranch` is `false`, the worktree is deleted but the branch is preserved with a message: "Deleted worktree 'X' (branch 'Y' kept)"
- The preference value is stored as a boolean in git config (`phantom.deleteBranch`)
- All preference handlers (get, set, remove) now support the `deleteBranch` key with validation to ensure only "true" or "false" values are accepted

https://claude.ai/code/session_0126B5cc5NbbSdfCj8Yfqece