### PR TITLE
fix: branchExists always returning true, breaking worktree name generation

### DIFF
--- a/packages/git/src/libs/branch-exists.ts
+++ b/packages/git/src/libs/branch-exists.ts
@@ -6,18 +6,11 @@ export async function branchExists(
   branchName: string,
 ): Promise<Result<boolean, Error>> {
   try {
-    await executeGitCommand(
-      ["show-ref", "--verify", "--quiet", `refs/heads/${branchName}`],
-      { cwd: gitRoot },
-    );
-    return ok(true);
+    const result = await executeGitCommand(["branch", "--list", branchName], {
+      cwd: gitRoot,
+    });
+    return ok(result.stdout.trim() !== "");
   } catch (error) {
-    if (error && typeof error === "object" && "code" in error) {
-      const execError = error as { code?: number; message?: string };
-      if (execError.code === 1) {
-        return ok(false);
-      }
-    }
     return err(
       new Error(
         `Failed to check branch existence: ${


### PR DESCRIPTION
## Summary
- `branchExists` always returned `ok(true)` because `executeGitCommand` silently swallows non-zero exit codes when stderr is empty
- `git show-ref --verify --quiet` exits with code 1 and empty stderr when a branch doesn't exist, which `executeGitCommand` treated as success
- This caused `generateUniqueName` to think every generated name was already taken, failing after 10 retries with "Failed to generate a unique worktree name after maximum retries"
- Switched to `git branch --list <name>` which always exits 0 and returns the branch name on stdout if it exists

## Test plan
- [x] `pnpm ready` passes (lint, typecheck, tests)
- [x] `pnpm phantom create` successfully creates a worktree with an auto-generated name

🤖 Generated with [Claude Code](https://claude.com/claude-code)