### PR TITLE
chore: add devenv-based devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,17 @@
+{
+  "name": "phantom-worktrees",
+  "image": "mcr.microsoft.com/devcontainers/base:bookworm",
+  "mounts": [
+    "source=nix-store-${devcontainerId},target=/nix,type=volume",
+    "source=devenv-${devcontainerId},target=${containerWorkspaceFolder}/.devenv,type=volume"
+  ],
+  "features": {
+    "ghcr.io/devcontainers/features/nix:1": {
+      "packages": "devenv",
+      "extraNixConfig": "experimental-features = nix-command flakes"
+    }
+  },
+  "postCreateCommand": "bash .devcontainer/postCreateCommand.sh",
+  "remoteUser": "vscode",
+  "updateRemoteUserUID": true
+}

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+sudo chown -R vscode:vscode ./.devenv
+
+if ! command -v devenv >/dev/null 2>&1; then
+  nix profile add nixpkgs#devenv
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ Thumbs.db
 # Dependencies
 node_modules
 .worktrees
+.devenv*
+devenv.local.nix
+devenv.local.yaml

--- a/devenv.lock
+++ b/devenv.lock
@@ -1,0 +1,65 @@
+{
+  "nodes": {
+    "devenv": {
+      "locked": {
+        "dir": "src/modules",
+        "lastModified": 1773498739,
+        "narHash": "sha256-DXLtdpj5CPtBGYB7nCcjFDgqFwOrRD3/Jd9VR+EngwA=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "1da1b4180d50d67d547b1839ba161420dd2f74e2",
+        "type": "github"
+      },
+      "original": {
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "inputs": {
+        "nixpkgs-src": "nixpkgs-src"
+      },
+      "locked": {
+        "lastModified": 1772749504,
+        "narHash": "sha256-eqtQIz0alxkQPym+Zh/33gdDjkkch9o6eHnMPnXFXN0=",
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "08543693199362c1fddb8f52126030d0d374ba2e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1772173633,
+        "narHash": "sha256-MOH58F4AIbCkh6qlQcwMycyk5SWvsqnS/TCfnqDlpj4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c0f3d81a7ddbc2b1332be0d8481a672b4f6004d6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,0 +1,23 @@
+{ pkgs, ... }:
+
+{
+  languages.javascript = {
+    enable = true;
+    package = pkgs.nodejs_24;
+    pnpm = {
+      enable = true;
+      install.enable = true;
+    };
+  };
+
+  packages = with pkgs; [
+    bash-completion
+    bashInteractive
+    fish
+    fzf
+    gh
+    git
+    tmux
+    zsh
+  ];
+}

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,0 +1,3 @@
+inputs:
+  nixpkgs:
+    url: github:cachix/devenv-nixpkgs/rolling


### PR DESCRIPTION
## Summary
- add a devcontainer configuration based on the Nix feature and devenv
- define the development environment with `devenv.nix` and `devenv.yaml`
- initialize `.devenv` ownership and install `devenv` in `postCreateCommand` when needed

## Verification
- rebuilt the devcontainer with `@devcontainers/cli`
- ran `devenv shell -- pnpm ready` inside the rebuilt container (passed)
- existing Biome warnings remain, but `pnpm ready` exited with code 0