### PR TITLE
chore: add .envrc for devenv direnv integration

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+eval "$(devenv direnvrc)"
+use devenv

--- a/devenv.lock
+++ b/devenv.lock
@@ -17,6 +17,62 @@
         "type": "github"
       }
     },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "git-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1772893680,
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "8baab586afc9c9b57645a734c820e4ac0a604af9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "git-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1762808025,
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "cb5e3fdca1de58ccbc3ef53de65bd372b48f567c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "inputs": {
         "nixpkgs-src": "nixpkgs-src"
@@ -56,7 +112,11 @@
     "root": {
       "inputs": {
         "devenv": "devenv",
-        "nixpkgs": "nixpkgs"
+        "git-hooks": "git-hooks",
+        "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": [
+          "git-hooks"
+        ]
       }
     }
   },

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,6 +1,8 @@
 { pkgs, ... }:
 
 {
+  cachix.enable = false;
+
   languages.javascript = {
     enable = true;
     package = pkgs.nodejs_24;

--- a/phantom.config.json
+++ b/phantom.config.json
@@ -1,6 +1,6 @@
 {
   "postCreate": {
     "copyFiles": [".claude/settings.local.json"],
-    "commands": ["pnpm install"]
+    "commands": ["direnv allow"]
   }
 }


### PR DESCRIPTION
## Summary
- Add `.envrc` with `devenv direnvrc` eval for automatic environment setup via direnv
- Disable cachix in `devenv.nix`
- Change `postCreate` command from `pnpm install` to `direnv allow` so worktree setup uses direnv

## Test plan
- [ ] Run `direnv allow` in the project root and verify the devenv environment loads
- [ ] Create a new worktree with `phantom create` and verify `direnv allow` runs as postCreate command

🤖 Generated with [Claude Code](https://claude.com/claude-code)