### PR TITLE
chore: update remaining aku11i/phantom URLs to phantompane/phantom

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Thank you for your interest in contributing to Phantom! This guide will help you
 
 ```bash
 # Clone and setup
-git clone https://github.com/aku11i/phantom.git
+git clone https://github.com/phantompane/phantom.git
 cd phantom
 pnpm install
 
@@ -214,7 +214,7 @@ To release a new version of Phantom:
    brew upgrade phantom
    ```
    
-   **Full Changelog**: https://github.com/aku11i/phantom/compare/v<previous>...v<version>
+   **Full Changelog**: https://github.com/phantompane/phantom/compare/v<previous>...v<version>
    EOF
    )"
    ```

--- a/README.ja.md
+++ b/README.ja.md
@@ -7,7 +7,7 @@
 [![npm version](https://img.shields.io/npm/v/@phantompane/cli.svg)](https://www.npmjs.com/package/@phantompane/cli)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node.js Version](https://img.shields.io/node/v/@phantompane/cli.svg)](https://nodejs.org)
-[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/aku11i/phantom)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/phantompane/phantom)
 
 [English](./README.md) • [インストール](#-インストール) • [なぜPhantom？](#-なぜphantom) • [基本的な使い方](#-基本的な使い方) • [ドキュメント](#-ドキュメント)
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![npm version](https://img.shields.io/npm/v/@phantompane/cli.svg)](https://www.npmjs.com/package/@phantompane/cli)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node.js Version](https://img.shields.io/node/v/@phantompane/cli.svg)](https://nodejs.org)
-[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/aku11i/phantom)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/phantompane/phantom)
 
 [日本語](./README.ja.md) • [Installation](#-installation) • [Why Phantom?](#-why-phantom) • [Basic Usage](#-basic-usage) • [Documentation](#-documentation)
 

--- a/packages/cli/dist/README.md
+++ b/packages/cli/dist/README.md
@@ -14,7 +14,7 @@ npm install -g @phantompane/cli
 
 For detailed documentation, examples, and advanced usage, please visit:
 
-https://github.com/aku11i/phantom
+https://github.com/phantompane/phantom
 
 ## License
 

--- a/packages/cli/dist/package.json
+++ b/packages/cli/dist/package.json
@@ -12,13 +12,13 @@
     "parallel",
     "mcp"
   ],
-  "homepage": "https://github.com/aku11i/phantom#readme",
+  "homepage": "https://github.com/phantompane/phantom#readme",
   "bugs": {
-    "url": "https://github.com/aku11i/phantom/issues"
+    "url": "https://github.com/phantompane/phantom/issues"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/aku11i/phantom.git"
+    "url": "git+https://github.com/phantompane/phantom.git"
   },
   "license": "MIT",
   "author": "aku11i",


### PR DESCRIPTION
## Summary
- Update GitHub URLs from `aku11i/phantom` to `phantompane/phantom` in README, README.ja, CONTRIBUTING, and `packages/cli/dist/` (README + package.json)
- Author references (`@aku11i`) and the backward-compatibility npm publish step are intentionally unchanged

## Test plan
- [ ] Verify DeepWiki badge links resolve correctly
- [ ] Verify clone URL in CONTRIBUTING.md is correct
- [ ] Verify homepage/bugs/repository in `packages/cli/dist/package.json` point to new org

🤖 Generated with [Claude Code](https://claude.com/claude-code)