### PR TITLE
chore: remove @aku11i/phantom backward compatibility publish step

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -60,13 +60,3 @@ jobs:
           NPM_CONFIG_REGISTRY: https://registry.npmjs.org
           NPM_CONFIG_ALWAYS_AUTH: true
         run: pnpm -r publish --access public --provenance --no-git-checks --tag ${{ steps.dist_tag.outputs.npm_tag }}
-
-      - name: Publish @aku11i/phantom (backward compatibility)
-        env:
-          NPM_CONFIG_PROVENANCE: true
-          NPM_CONFIG_REGISTRY: https://registry.npmjs.org
-          NPM_CONFIG_ALWAYS_AUTH: true
-        run: |
-          cd packages/cli/dist
-          sed -i 's/"name": "@phantompane\/cli"/"name": "@aku11i\/phantom"/' package.json
-          npm publish --access public --provenance --tag ${{ steps.dist_tag.outputs.npm_tag }}


### PR DESCRIPTION
## Summary
- Remove the backward compatibility publish step for `@aku11i/phantom` from the npm-publish workflow
- The package scope has been fully migrated to `@phantompane/*` as of v6.0.0, so the legacy publish is no longer needed

## Test plan
- [ ] Verify the npm-publish workflow YAML is valid
- [ ] Confirm next release publishes only `@phantompane/cli`

🤖 Generated with [Claude Code](https://claude.com/claude-code)