### PR TITLE
build: add devenv pre-commit hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ node_modules
 .turbo
 .worktrees
 .devenv*
+.pre-commit-config.yaml
 devenv.local.nix
 devenv.local.yaml

--- a/devenv.nix
+++ b/devenv.nix
@@ -12,6 +12,32 @@
     };
   };
 
+  git-hooks.hooks = {
+    fix = {
+      enable = true;
+      name = "fix";
+      entry = "pnpm exec turbo run fix";
+      pass_filenames = false;
+      always_run = true;
+    };
+
+    typecheck = {
+      enable = true;
+      name = "typecheck";
+      entry = "pnpm exec turbo run typecheck";
+      pass_filenames = false;
+      always_run = true;
+    };
+
+    test = {
+      enable = true;
+      name = "test";
+      entry = "pnpm exec turbo run test";
+      pass_filenames = false;
+      always_run = true;
+    };
+  };
+
   packages = with pkgs; [
     bash-completion
     bashInteractive


### PR DESCRIPTION
## Summary
- add devenv-managed pre-commit hooks for `fix`, `typecheck`, and `test`
- run the hooks through `turbo run` with `pass_filenames = false`
- ignore the generated `.pre-commit-config.yaml`

## Verification
- `pnpm exec turbo run fix typecheck test`
- `devenv shell -- true`