### PR TITLE
fix: bundle Phantom CLI dependencies with tsdown

### DIFF
--- a/packages/cli/tsdown.config.ts
+++ b/packages/cli/tsdown.config.ts
@@ -12,6 +12,9 @@ export default defineConfig({
   sourcemap: true,
   dts: false,
   clean: ["dist/*.js", "dist/*.js.map"],
+  deps: {
+    alwaysBundle: [/.*/],
+  },
   fixedExtension: false,
   hooks: {
     async "build:done"(ctx) {


### PR DESCRIPTION
## Summary
- configure tsdown to fully bundle Phantom CLI runtime dependencies
- preserve the existing CLI distribution shape while avoiding unresolved workspace imports in npm installs
- keep the executable permission hook and existing dist cleanup behavior unchanged

## Verification
- pnpm ready
- Docker: install packed CLI tarball in a temporary `node:22-bookworm` container
- Docker: run `phantom version`
- Docker: run `phantom list`
- Docker: run `phantom create feature/test`
- Docker: run `phantom where feature/test`
- Docker: run `phantom delete feature/test`
- Docker: run `phantom list`