### PR TITLE
build(deps): bump pnpm from 10.8.1 to 10.33.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@phantompane/monorepo",
   "version": "6.2.0",
-  "packageManager": "pnpm@10.8.1",
+  "packageManager": "pnpm@10.33.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,5 @@ packages:
   - "e2e"
   - "packages/*"
   - "packages/cli/dist"
+
+minimumReleaseAge: 20160


### PR DESCRIPTION
## Summary

- Bump the project package manager pin from `pnpm@10.8.1` to `pnpm@10.33.2`.
- Configure `minimumReleaseAge: 20160` in `pnpm-workspace.yaml` so dependency versions must be at least 14 days old before pnpm installs them.

## Verification

- `corepack pnpm --version` -> `10.33.2`
- `corepack pnpm config get minimumReleaseAge` -> `20160`
- `corepack pnpm install --lockfile-only`
- `corepack pnpm typecheck`
- `corepack pnpm test`

## Notes

- `corepack pnpm ready` was attempted, but the e2e suite failed because this local worktree does not have the `phantom` executable or `packages/cli/dist/phantom.js` available for the e2e tests to invoke. The non-e2e typecheck and test suites pass.