### PR TITLE
feat: redesign Phantom Serve UI

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,667 @@
+# Phantom Design System
+
+This document defines the visual and interaction principles for Phantom's user-facing interfaces, especially Phantom Serve and future developer tooling surfaces.
+
+Phantom is a developer productivity tool for managing Git worktrees and AI-assisted parallel development. Its UI should stay quiet, dense, and practical: the worktree, chat, command output, state, and result should be more prominent than the application chrome.
+
+## Design Philosophy
+
+### Concept
+
+Phantom's interface is a low-saturation, high-density workspace for developers. It is optimized for:
+
+- Project and worktree navigation
+- Agent chat and execution logs
+- Status and approval flows
+- Command input and output
+- Git and worktree context
+- Future diff or review surfaces
+
+The interface should reduce cognitive load and keep attention on the user's current task. Avoid decorative visuals, large marketing-style sections, and brand-heavy color usage inside the product UI.
+
+### Design Keywords
+
+- Soft neutral workspace
+- Low-contrast productivity UI
+- Muted semantic highlight
+- Developer workflow focus
+- Quiet hierarchy
+- Dense but calm
+- Functional surface design
+- Native-app restraint, web accessibility
+
+### Principles
+
+1. Make information the subject.
+   Use color, emphasis, and motion only where they communicate state, selection, change, warning, or action.
+
+2. Build hierarchy with surfaces.
+   Prefer background tone, spacing, border subtlety, radius, and text weight over heavy shadows or saturated color blocks.
+
+3. Do not turn layout regions into cards.
+   Sidebar bodies, main work areas, top summaries, and page sections should be unframed bands or plain surfaces. Use cards only for repeated content items, dialogs, popovers, and genuinely bounded tools.
+
+4. Use muted semantic colors.
+   Success, warning, danger, info, added, and removed states should avoid primary red/green. Use gray-mixed colors that remain comfortable during long work sessions.
+
+5. Keep controls compact and predictable.
+   Phantom is a repeated-use developer tool. Favor compact controls, familiar icons, clear labels, and stable layouts.
+
+6. Preserve accessibility.
+   Keyboard operation, visible focus rings, accessible names for icon buttons, and non-color state indicators are required.
+
+## Tokens
+
+Token names should describe purpose, not incidental appearance.
+
+```text
+--category-role-state
+```
+
+Examples:
+
+```css
+--surface-panel
+--text-secondary
+--diff-added-bg
+--button-primary-bg
+--state-hover-bg
+```
+
+Recommended prefixes:
+
+| Category                  | Prefix                              |
+| ------------------------- | ----------------------------------- |
+| Color primitives          | `--color-*`                         |
+| Surfaces                  | `--surface-*`                       |
+| Text                      | `--text-*`                          |
+| Borders                   | `--border-*`                        |
+| Semantic states           | `--semantic-*`                      |
+| Diff states               | `--diff-*`                          |
+| Interaction states        | `--state-*`                         |
+| Spacing                   | `--space-*`                         |
+| Radius                    | `--radius-*`                        |
+| Shadow                    | `--shadow-*`                        |
+| Typography                | `--font-*`                          |
+| Component-specific values | `--component-*` or component prefix |
+
+## Color System
+
+Primitive colors should not be used directly in components. Map them through semantic tokens or Tailwind theme variables.
+
+```css
+:root {
+  --color-white: #fdfdfd;
+
+  --color-gray-50: #f7f8fa;
+  --color-gray-75: #f3f4f7;
+  --color-gray-100: #f0f1f5;
+  --color-gray-150: #edeef0;
+  --color-gray-200: #e5e7ec;
+  --color-gray-250: #dadde5;
+  --color-gray-300: #c9ccd6;
+  --color-gray-400: #aeb1bb;
+  --color-gray-500: #8d909b;
+  --color-gray-600: #747783;
+  --color-gray-700: #565a66;
+  --color-gray-800: #343844;
+  --color-gray-900: #1f2330;
+
+  --color-green-50: #e7f0ea;
+  --color-green-100: #dde7df;
+  --color-green-500: #2f7a4e;
+
+  --color-rose-50: #f0e1e7;
+  --color-rose-100: #e8d7df;
+  --color-rose-500: #9b3f5a;
+
+  --color-yellow-50: #f3ead2;
+  --color-yellow-100: #eadcad;
+  --color-yellow-600: #8a6a1d;
+
+  --color-blue-50: #e4e9f7;
+  --color-blue-100: #d8e0f3;
+  --color-blue-600: #4d5f9e;
+}
+```
+
+### Surface Tokens
+
+```css
+:root {
+  --surface-window: #f0f1f5;
+  --surface-sidebar: #edeef0;
+  --surface-panel: #f3f4f7;
+  --surface-card: #f7f8fa;
+  --surface-code: #f1f2f6;
+  --surface-input: #f3f4f7;
+  --surface-floating: rgba(255, 255, 255, 0.72);
+  --surface-overlay: rgba(31, 35, 48, 0.36);
+}
+```
+
+| Token                | Use                                      |
+| -------------------- | ---------------------------------------- |
+| `--surface-window`   | Base app background                      |
+| `--surface-sidebar`  | Sidebar and secondary navigation         |
+| `--surface-panel`    | Main work area                           |
+| `--surface-card`     | Repeated items, messages, bounded tools  |
+| `--surface-code`     | Code, logs, diffs                        |
+| `--surface-input`    | Inputs, search fields, command textareas |
+| `--surface-floating` | Popovers, floating bars                  |
+| `--surface-overlay`  | Dialog backdrop                          |
+
+### Text Tokens
+
+```css
+:root {
+  --text-primary: #2c303a;
+  --text-secondary: #5f636f;
+  --text-tertiary: #8a8e99;
+  --text-muted: #a9adb6;
+  --text-disabled: #c4c7cf;
+
+  --text-link: #4d5f9e;
+  --text-success: #2f7a4e;
+  --text-danger: #9b3f5a;
+  --text-warning: #8a6a1d;
+}
+```
+
+Use `--text-primary` for project names, chat titles, command text, and key output. Use secondary and tertiary text for paths, metadata, branch names, timestamps, and supporting copy.
+
+### Border Tokens
+
+```css
+:root {
+  --border-subtle: #e0e2e8;
+  --border-default: #d5d8e0;
+  --border-strong: #c4c8d2;
+  --border-focus: #aeb7d8;
+  --border-divider: rgba(31, 35, 48, 0.08);
+}
+```
+
+Border rules:
+
+- Keep borders thin and low-saturation.
+- Do not use borders where surface contrast is enough.
+- Reserve stronger borders for focus, drag, resize, and selected states.
+
+### Semantic Tokens
+
+```css
+:root {
+  --semantic-success-bg: #e7f0ea;
+  --semantic-success-fg: #2f7a4e;
+  --semantic-success-border: #8ec7a2;
+
+  --semantic-danger-bg: #f0e1e7;
+  --semantic-danger-fg: #9b3f5a;
+  --semantic-danger-border: #d18ba0;
+
+  --semantic-warning-bg: #f3ead2;
+  --semantic-warning-fg: #8a6a1d;
+  --semantic-warning-border: #d7bc73;
+
+  --semantic-info-bg: #e4e9f7;
+  --semantic-info-fg: #4d5f9e;
+  --semantic-info-border: #a8b7e0;
+}
+```
+
+Use semantic tones for execution state, approval prompts, errors, completion, and warnings. Do not use them as general decoration.
+
+### Diff Tokens
+
+These are reserved for future Git diff, preview, or change summary surfaces.
+
+```css
+:root {
+  --diff-added-bg: #dde7df;
+  --diff-added-bg-soft: #e7f0ea;
+  --diff-added-fg: #2f7a4e;
+  --diff-added-border: #8ec7a2;
+
+  --diff-removed-bg: #e8d7df;
+  --diff-removed-bg-soft: #f0e1e7;
+  --diff-removed-fg: #9b3f5a;
+  --diff-removed-border: #d18ba0;
+
+  --diff-hunk-bg: #e9e7f5;
+  --diff-hunk-fg: #6b61a8;
+  --diff-hunk-border: #c8c2ea;
+}
+```
+
+Diff color rules:
+
+| Type         | Treatment                                |
+| ------------ | ---------------------------------------- |
+| Added        | Muted green, also usable for completion  |
+| Removed      | Rose gray, not aggressive red            |
+| Context      | Lavender gray for supporting information |
+| Line numbers | Tinted with the related state color      |
+
+## Typography
+
+```css
+:root {
+  --font-sans:
+    -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue",
+    sans-serif;
+  --font-mono:
+    "SF Mono", "Menlo", "Monaco", "Consolas", "Liberation Mono", monospace;
+
+  --font-size-2xs: 10px;
+  --font-size-xs: 11px;
+  --font-size-sm: 12px;
+  --font-size-md: 13px;
+  --font-size-lg: 14px;
+  --font-size-xl: 16px;
+  --font-size-2xl: 20px;
+
+  --line-height-tight: 1.25;
+  --line-height-normal: 1.45;
+  --line-height-relaxed: 1.6;
+
+  --font-weight-regular: 400;
+  --font-weight-medium: 500;
+  --font-weight-semibold: 600;
+  --font-weight-bold: 700;
+}
+```
+
+| Token             | Size | Use                                  |
+| ----------------- | ---: | ------------------------------------ |
+| `--font-size-2xs` | 10px | Very small metadata                  |
+| `--font-size-xs`  | 11px | Badges, timestamps, counts           |
+| `--font-size-sm`  | 12px | Sidebar, buttons, tabs               |
+| `--font-size-md`  | 13px | Body text, forms, lists              |
+| `--font-size-lg`  | 14px | Section headings and emphasized body |
+| `--font-size-xl`  | 16px | Page and chat titles                 |
+| `--font-size-2xl` | 20px | Major headings when needed           |
+
+Use monospace for code, command output, paths when full precision matters, and logs. Do not scale font size with viewport width.
+
+## Spacing, Radius, and Elevation
+
+### Spacing
+
+```css
+:root {
+  --space-0: 0;
+  --space-0_5: 2px;
+  --space-1: 4px;
+  --space-1_5: 6px;
+  --space-2: 8px;
+  --space-2_5: 10px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-10: 40px;
+  --space-12: 48px;
+}
+```
+
+| Use                             | Recommended value |
+| ------------------------------- | ----------------: |
+| Icon and text gap               |               6px |
+| Small button padding            |               8px |
+| Sidebar item horizontal padding |       8px to 12px |
+| Item and message padding        |      12px to 16px |
+| Main panel padding              |              16px |
+| Section gap                     |      24px to 32px |
+
+### Radius
+
+```css
+:root {
+  --radius-xs: 4px;
+  --radius-sm: 6px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-xl: 16px;
+  --radius-pill: 9999px;
+}
+```
+
+Use 6px to 8px for compact controls and list items. Use 12px for dialogs, repeated items, and bounded tool surfaces. Avoid oversized rounding on dense tool surfaces.
+
+Do not add radius to large app regions such as the whole sidebar, whole main area, page sections, or summary bands. Radius belongs on local controls, selected rows, messages, dialogs, and bounded tool surfaces.
+
+### Shadow
+
+```css
+:root {
+  --shadow-xs: 0 1px 2px rgba(31, 35, 48, 0.06);
+  --shadow-sm: 0 2px 6px rgba(31, 35, 48, 0.08);
+  --shadow-md: 0 8px 24px rgba(31, 35, 48, 0.12);
+  --shadow-lg: 0 16px 48px rgba(31, 35, 48, 0.16);
+}
+```
+
+Use shadows sparingly. Most app structure should come from surface contrast and dividers. Do not use shadows around the whole sidebar, main area, top summaries, or normal page sections. Reserve `--shadow-lg` for modal dialogs.
+
+## Motion and Interaction States
+
+```css
+:root {
+  --motion-duration-fast: 120ms;
+  --motion-duration-normal: 180ms;
+  --motion-duration-slow: 240ms;
+
+  --motion-ease-standard: cubic-bezier(0.2, 0, 0, 1);
+  --motion-ease-out: cubic-bezier(0, 0, 0.2, 1);
+  --motion-ease-in: cubic-bezier(0.4, 0, 1, 1);
+
+  --state-hover-bg: rgba(31, 35, 48, 0.05);
+  --state-pressed-bg: rgba(31, 35, 48, 0.09);
+  --state-selected-bg: rgba(31, 35, 48, 0.07);
+  --state-focus-ring: 0 0 0 3px rgba(104, 116, 180, 0.22);
+
+  --opacity-disabled: 0.42;
+  --opacity-muted: 0.64;
+}
+```
+
+Motion rules:
+
+- Avoid large decorative animation.
+- Use transitions for hover, focus, selection, and open/close states only.
+- Prefer 120ms to 180ms. Dialogs and panels may use up to 240ms.
+- Loading should use state text where possible; use spinners only when useful.
+
+State rules:
+
+| State    | Treatment                                    |
+| -------- | -------------------------------------------- |
+| Hover    | Add a subtle background overlay              |
+| Pressed  | Slightly stronger overlay than hover         |
+| Selected | Maintain a muted surface state               |
+| Focus    | Always visible focus ring                    |
+| Disabled | Pair opacity with disabled behavior and ARIA |
+
+## Layout System
+
+### Phantom Serve Shell
+
+Phantom Serve should use an app-shell layout:
+
+```text
++-------------------------------------------------------------+
+| Sidebar: projects and worktrees | Main: chat, status, logs  |
+|                                |                            |
+|                                |                            |
+|                                |                            |
++-------------------------------------------------------------+
+| Optional command composer within the main panel             |
++-------------------------------------------------------------+
+```
+
+Recommended layout tokens:
+
+```css
+:root {
+  --layout-sidebar-width: 320px;
+  --layout-topbar-height: 56px;
+  --layout-panel-min-width: 320px;
+  --layout-max-content-width: 1200px;
+}
+```
+
+Responsive rules:
+
+| Breakpoint          | Rule                                                              |
+| ------------------- | ----------------------------------------------------------------- |
+| `< 640px`           | One column; sidebar becomes a drawer                              |
+| `640px-1023px`      | Sidebar plus main content where space allows                      |
+| `1024px+`           | Sidebar plus main content                                         |
+| Future wide screens | Add optional detail or diff panel only when the workflow needs it |
+
+## Component Guidelines
+
+### Surface and Card Usage
+
+Cards are not the default layout primitive in Phantom.
+
+Rules:
+
+- Do not wrap major regions in cards: sidebar content, main content, top summaries, page sections, and composer areas should not have enclosing border + radius + shadow treatments.
+- Prefer unframed surfaces, horizontal dividers, selected row backgrounds, and subtle density changes for hierarchy.
+- Use cards only for repeated content items, message bubbles, dialogs, popovers, and explicitly bounded tool surfaces.
+- Avoid card grids and persistent bands for summary information. Keep current context in the top bar unless an action-specific state requires a temporary banner.
+- Do not nest cards inside cards.
+
+### Button
+
+Use buttons for primary actions, secondary actions, destructive actions, and icon-only controls.
+
+Rules:
+
+- Use a single primary action per local context.
+- Use ghost buttons in sidebars and toolbars.
+- Icon buttons must use `aria-label` and `title` when helpful.
+- Prefer lucide-react icons for actions.
+
+### Input and Textarea
+
+Use inputs for paths, settings, and short names. Use textarea for chat or command composition.
+
+Rules:
+
+- Placeholder text should be useful but not required for understanding.
+- Preserve visible labels in dialogs and settings forms.
+- Keep command/chat input stable in height; dynamic content should not shift the layout unexpectedly.
+
+### Sidebar
+
+The sidebar is for project and worktree navigation.
+
+Rules:
+
+- Project items should be simple and scan-friendly.
+- Sidebar items should be single-line by default.
+- Show project and worktree names as primary text; avoid counts, status descriptions, branch names, or full paths unless the user needs disambiguation.
+- Nest worktree/chat items under their project.
+- Project creation belongs in the Projects group action.
+- Worktree/chat creation belongs near the related project item.
+- Collapsing the sidebar should fully hide it instead of leaving an icon rail, so the main panel can use the recovered space.
+- Keep the top-bar sidebar trigger accessible for reopening the sidebar.
+
+### Agent Chat Panel
+
+The main panel is for user instructions, assistant responses, approvals, and errors. Internal execution events may exist in the data model, but they are not primary user-facing chat content.
+
+Rules:
+
+- User messages may use the strongest surface.
+- Assistant output should be calmer and easy to scan.
+- Message bubbles should contain only the message body. Do not show speaker labels, avatars, timestamps, message IDs, item IDs, or raw transport identifiers in the primary chat timeline.
+- Do not show internal lifecycle or debug records such as `item/started`, `item/completed`, and `turn/completed` in the main chat timeline by default.
+- Put raw logs and event streams in a dedicated diagnostics surface only when the workflow explicitly needs them.
+- Error and approval states should use semantic tones and clear labels.
+- Do not rely on color alone to communicate status.
+
+### Dialog
+
+Use dialogs for project creation, settings, approvals requiring structured input, and destructive confirmations.
+
+Rules:
+
+- Dialogs must have a title.
+- Keep body text brief and task-specific.
+- Primary action goes on the right.
+- Destructive actions require clear labeling and semantic danger styling.
+
+### Badge and Status
+
+Use badges for concise state: ready, running, waiting for approval, failed, archived, count, or branch metadata.
+
+Rules:
+
+- Keep badge text short.
+- Use semantic tones only when the state needs attention.
+- Do not use badges as decoration.
+
+### Diff and Code Surfaces
+
+Future diff or preview views should use the diff tokens above.
+
+Rules:
+
+- Use monospace text.
+- Use symbols, labels, or line prefixes in addition to color.
+- Allow horizontal scrolling for code.
+- Keep line height compact but readable.
+
+## Iconography
+
+```css
+:root {
+  --icon-size-xs: 12px;
+  --icon-size-sm: 14px;
+  --icon-size-md: 16px;
+  --icon-size-lg: 20px;
+
+  --icon-color-default: #747783;
+  --icon-color-muted: #a9adb6;
+  --icon-color-active: #343844;
+}
+```
+
+Icon rules:
+
+- Use lucide-react where possible.
+- Keep stroke icons small and light.
+- Do not depend on icons alone when the action is unfamiliar.
+- Icon buttons require accessible names.
+- Avoid custom SVG icons unless the icon library lacks the concept.
+
+## Accessibility
+
+Requirements:
+
+- Every interactive element must be reachable by keyboard.
+- Focus rings must be visible.
+- Icon buttons require accessible names.
+- Do not communicate status with color alone.
+- Use `aria-live` or `role="status"` for important asynchronous state changes.
+- Dialogs must expose title and close behavior.
+- Disabled controls must use native `disabled` where possible.
+
+ARIA examples:
+
+```html
+<button aria-label="Create worktree">
+  <svg aria-hidden="true"></svg>
+</button>
+
+<nav aria-label="Projects and worktrees">
+  <button aria-current="page">feature-auth</button>
+</nav>
+
+<div role="status" aria-live="polite">Running command</div>
+```
+
+## Theming
+
+Light theme is the default. It should use neutral gray surfaces and muted text hierarchy.
+
+Dark theme, when implemented, should not be a pure inversion. Preserve the same low-saturation hierarchy and avoid high-contrast neon accents.
+
+## Implementation Notes
+
+Phantom's app package currently uses Tailwind CSS and local shadcn-style components under `packages/app/src/components/ui`.
+
+Implementation rules:
+
+- Prefer existing local UI components before adding new ones.
+- Map design tokens into `packages/app/src/styles.css` and Tailwind theme variables.
+- Keep tokens centralized; do not hard-code one-off colors across components.
+- Use lucide-react icons for buttons and sidebar actions.
+- Keep UI text in English.
+- Keep file paths visible only when they are needed for task context or disambiguation.
+
+## Usage Guidelines
+
+### Do
+
+- Use pale gray backgrounds instead of pure white.
+- Use unframed bands and dividers for app layout.
+- Keep secondary actions low contrast.
+- Use semantic color only for meaningful states.
+- Keep dense layouts readable with consistent line height and spacing.
+- Always show focus states.
+- Use monospace for code, command output, and path-heavy details.
+- Pair color with symbols or labels for diff and status views.
+
+### Do Not
+
+- Spread brand color across the product UI.
+- Use card shells around major app regions.
+- Use card grids for routine summaries.
+- Add persistent summary bands above the chat when the top bar already carries the active context.
+- Expose debug lifecycle events in the primary chat timeline.
+- Use heavy shadows for normal panels.
+- Use primary red or green over large areas.
+- Over-emphasize every button.
+- Remove focus styles.
+- Add decorative gradients or abstract background elements.
+- Show long filesystem paths in navigation unless they are necessary.
+
+## Governance
+
+Before adding a token, check whether an existing token expresses the same purpose.
+
+Add a token only when:
+
+- The value is reused across multiple components.
+- The purpose is independently meaningful.
+- The value needs theme-specific replacement.
+- The token names a stable component dimension or state.
+
+Do not add a token when:
+
+- It is used once.
+- It renames an existing token without adding meaning.
+- It only supports a one-off visual tweak.
+- Its name does not explain usage.
+
+When adding a component, document:
+
+- Purpose
+- Anatomy
+- Variants
+- States
+- Accessibility
+- Tokens
+- Examples
+- Do and do not rules
+
+## Review Checklist
+
+- [ ] Semantic color is limited to meaningful states.
+- [ ] Major app regions are not enclosed in card shells.
+- [ ] Cards are limited to repeated items, dialogs, popovers, or bounded tools.
+- [ ] Text hierarchy uses primary, secondary, tertiary, and muted levels.
+- [ ] Spacing follows the spacing scale.
+- [ ] Radius follows the radius scale.
+- [ ] Focus states are visible.
+- [ ] Keyboard interaction works.
+- [ ] Status is not communicated by color alone.
+- [ ] Sidebar navigation remains scannable.
+- [ ] Mobile and narrow layouts do not overlap.
+- [ ] Dark theme, if touched, preserves the same hierarchy.
+
+## Summary
+
+Phantom's design system is a quiet, dense, developer-focused UI foundation.
+
+The central rule is:
+
+> Use a pale neutral workspace, and reserve muted semantic color for state, change, and execution results.
+
+This keeps Phantom useful for long-running worktree management, AI agent workflows, command execution, and future Git review surfaces without making the interface itself compete for attention.

--- a/packages/app/src/components/ui/badge.tsx
+++ b/packages/app/src/components/ui/badge.tsx
@@ -1,0 +1,36 @@
+import type { ComponentProps } from "react";
+import { cn } from "../../lib/utils";
+
+const variants = {
+  default: "border-transparent bg-primary text-primary-foreground",
+  danger:
+    "border-[var(--semantic-danger-border)] bg-[var(--semantic-danger-bg)] text-[var(--semantic-danger-fg)]",
+  info: "border-[var(--semantic-info-border)] bg-[var(--semantic-info-bg)] text-[var(--semantic-info-fg)]",
+  outline: "border-border bg-transparent text-foreground",
+  secondary: "border-transparent bg-secondary text-secondary-foreground",
+  success:
+    "border-[var(--semantic-success-border)] bg-[var(--semantic-success-bg)] text-[var(--semantic-success-fg)]",
+  warning:
+    "border-[var(--semantic-warning-border)] bg-[var(--semantic-warning-bg)] text-[var(--semantic-warning-fg)]",
+} as const;
+
+export interface BadgeProps extends ComponentProps<"span"> {
+  variant?: keyof typeof variants;
+}
+
+export function Badge({
+  className,
+  variant = "default",
+  ...props
+}: BadgeProps) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-[var(--radius-xs)] border px-2 py-0.5 text-[length:var(--font-size-xs)] font-medium whitespace-nowrap transition-colors",
+        variants[variant],
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/packages/app/src/components/ui/button.tsx
+++ b/packages/app/src/components/ui/button.tsx
@@ -1,0 +1,44 @@
+import type { ComponentProps } from "react";
+import { cn } from "../../lib/utils";
+
+const variants = {
+  default:
+    "bg-primary text-primary-foreground shadow-[var(--shadow-xs)] hover:bg-[var(--color-gray-800)]",
+  destructive:
+    "bg-destructive text-destructive-foreground shadow-[var(--shadow-xs)] hover:bg-[var(--color-rose-500)] focus-visible:ring-[var(--semantic-danger-border)]/40",
+  ghost: "hover:bg-accent hover:text-accent-foreground",
+  outline:
+    "border border-input bg-[var(--surface-card)] shadow-[var(--shadow-xs)] hover:bg-accent hover:text-accent-foreground",
+  secondary:
+    "bg-secondary text-secondary-foreground shadow-[var(--shadow-xs)] hover:bg-[var(--color-gray-150)]",
+} as const;
+
+const sizes = {
+  default: "h-9 px-4 py-2",
+  icon: "size-8",
+  sm: "h-8 gap-1.5 px-3",
+} as const;
+
+export interface ButtonProps extends ComponentProps<"button"> {
+  size?: keyof typeof sizes;
+  variant?: keyof typeof variants;
+}
+
+export function Button({
+  className,
+  size = "default",
+  variant = "default",
+  ...props
+}: ButtonProps) {
+  return (
+    <button
+      className={cn(
+        "inline-flex shrink-0 items-center justify-center gap-2 whitespace-nowrap rounded-[var(--radius-sm)] text-[length:var(--font-size-sm)] font-medium outline-none transition-colors duration-[var(--motion-duration-fast)] ease-[var(--motion-ease-standard)] focus-visible:border-ring focus-visible:shadow-[var(--state-focus-ring)] disabled:pointer-events-none disabled:opacity-[var(--opacity-disabled)] [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+        variants[variant],
+        sizes[size],
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/packages/app/src/components/ui/dialog.tsx
+++ b/packages/app/src/components/ui/dialog.tsx
@@ -1,5 +1,15 @@
-import type { ComponentProps, ReactNode } from "react";
+import { useEffect, useRef } from "react";
+import type { ComponentProps, KeyboardEvent, ReactNode } from "react";
 import { cn } from "../../lib/utils";
+
+const focusableSelector = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  "[tabindex]:not([tabindex='-1'])",
+].join(",");
 
 export function Dialog({
   children,
@@ -10,19 +20,77 @@ export function Dialog({
   onOpenChange: (open: boolean) => void;
   open: boolean;
 }) {
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    const previousActiveElement = document.activeElement;
+    const focusableElements = getFocusableElements(contentRef.current);
+    focusableElements[0]?.focus();
+
+    return () => {
+      if (previousActiveElement instanceof HTMLElement) {
+        previousActiveElement.focus();
+      }
+    };
+  }, [open]);
+
+  function handleKeyDown(event: KeyboardEvent<HTMLDivElement>) {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      onOpenChange(false);
+      return;
+    }
+
+    if (event.key !== "Tab") {
+      return;
+    }
+
+    const focusableElements = getFocusableElements(contentRef.current);
+    if (focusableElements.length === 0) {
+      event.preventDefault();
+      return;
+    }
+
+    const firstElement = focusableElements[0];
+    const lastElement = focusableElements[focusableElements.length - 1];
+    if (!firstElement || !lastElement) {
+      return;
+    }
+
+    if (event.shiftKey && document.activeElement === firstElement) {
+      event.preventDefault();
+      lastElement.focus();
+    }
+
+    if (!event.shiftKey && document.activeElement === lastElement) {
+      event.preventDefault();
+      firstElement.focus();
+    }
+  }
+
   if (!open) {
     return null;
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      onKeyDown={handleKeyDown}
+    >
       <button
         aria-label="Close dialog"
         className="absolute inset-0 bg-[var(--surface-overlay)]"
         onClick={() => onOpenChange(false)}
+        tabIndex={-1}
         type="button"
       />
-      {children}
+      <div ref={contentRef} className="contents">
+        {children}
+      </div>
     </div>
   );
 }
@@ -34,6 +102,7 @@ export function DialogContent({ className, ...props }: ComponentProps<"div">) {
         "relative z-10 grid w-full max-w-md gap-4 rounded-[var(--radius-lg)] border border-border bg-card p-5 text-card-foreground shadow-[var(--shadow-lg)]",
         className,
       )}
+      aria-modal="true"
       role="dialog"
       {...props}
     />
@@ -73,4 +142,18 @@ export function DialogDescription({
 
 export function DialogFooter({ className, ...props }: ComponentProps<"div">) {
   return <div className={cn("flex justify-end gap-2", className)} {...props} />;
+}
+
+function getFocusableElements(root: HTMLElement | null) {
+  if (!root) {
+    return [];
+  }
+
+  return Array.from(
+    root.querySelectorAll<HTMLElement>(focusableSelector),
+  ).filter(
+    (element) =>
+      !element.hasAttribute("disabled") &&
+      element.getAttribute("aria-hidden") !== "true",
+  );
 }

--- a/packages/app/src/components/ui/dialog.tsx
+++ b/packages/app/src/components/ui/dialog.tsx
@@ -1,0 +1,76 @@
+import type { ComponentProps, ReactNode } from "react";
+import { cn } from "../../lib/utils";
+
+export function Dialog({
+  children,
+  onOpenChange,
+  open,
+}: {
+  children: ReactNode;
+  onOpenChange: (open: boolean) => void;
+  open: boolean;
+}) {
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <button
+        aria-label="Close dialog"
+        className="absolute inset-0 bg-[var(--surface-overlay)]"
+        onClick={() => onOpenChange(false)}
+        type="button"
+      />
+      {children}
+    </div>
+  );
+}
+
+export function DialogContent({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <div
+      className={cn(
+        "relative z-10 grid w-full max-w-md gap-4 rounded-[var(--radius-lg)] border border-border bg-card p-5 text-card-foreground shadow-[var(--shadow-lg)]",
+        className,
+      )}
+      role="dialog"
+      {...props}
+    />
+  );
+}
+
+export function DialogHeader({ className, ...props }: ComponentProps<"div">) {
+  return <div className={cn("grid gap-1.5", className)} {...props} />;
+}
+
+export function DialogTitle({ className, ...props }: ComponentProps<"h2">) {
+  return (
+    <h2
+      className={cn(
+        "text-[length:var(--font-size-xl)] font-semibold leading-none",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function DialogDescription({
+  className,
+  ...props
+}: ComponentProps<"p">) {
+  return (
+    <p
+      className={cn(
+        "text-[length:var(--font-size-md)] text-muted-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function DialogFooter({ className, ...props }: ComponentProps<"div">) {
+  return <div className={cn("flex justify-end gap-2", className)} {...props} />;
+}

--- a/packages/app/src/components/ui/input.tsx
+++ b/packages/app/src/components/ui/input.tsx
@@ -1,0 +1,14 @@
+import type { ComponentProps } from "react";
+import { cn } from "../../lib/utils";
+
+export function Input({ className, ...props }: ComponentProps<"input">) {
+  return (
+    <input
+      className={cn(
+        "flex h-9 w-full min-w-0 rounded-[var(--radius-sm)] border border-input bg-[var(--surface-input)] px-3 py-1 text-[length:var(--font-size-md)] shadow-[var(--shadow-xs)] outline-none transition-[border-color,box-shadow] duration-[var(--motion-duration-fast)] placeholder:text-[var(--text-tertiary)] focus-visible:border-ring focus-visible:shadow-[var(--state-focus-ring)] disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-[var(--opacity-disabled)]",
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/packages/app/src/components/ui/label.tsx
+++ b/packages/app/src/components/ui/label.tsx
@@ -1,0 +1,14 @@
+import type { ComponentProps } from "react";
+import { cn } from "../../lib/utils";
+
+export function Label({ className, ...props }: ComponentProps<"label">) {
+  return (
+    <label
+      className={cn(
+        "text-[length:var(--font-size-sm)] font-medium leading-none text-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/packages/app/src/components/ui/sidebar.tsx
+++ b/packages/app/src/components/ui/sidebar.tsx
@@ -116,35 +116,44 @@ export function Sidebar({
   collapsible?: "none" | "offcanvas";
   variant?: "inset" | "sidebar";
 }) {
-  const { state } = useSidebar();
+  const { setOpen, state } = useSidebar();
   const isOffcanvasCollapsed =
     state === "collapsed" && collapsible === "offcanvas";
   return (
-    <aside
-      data-collapsible={state === "collapsed" ? collapsible : ""}
-      data-state={state}
-      data-variant={variant}
-      className={cn(
-        "group/sidebar relative hidden h-svh shrink-0 flex-col overflow-hidden text-sidebar-foreground transition-[width] duration-[var(--motion-duration-normal)] ease-[var(--motion-ease-standard)] md:flex",
-        isOffcanvasCollapsed && "w-0 border-r-0",
-        (state === "expanded" || collapsible === "none") &&
-          "w-[--sidebar-width]",
-        !isOffcanvasCollapsed &&
-          variant === "sidebar" &&
-          "border-r border-sidebar-border bg-sidebar",
-        !isOffcanvasCollapsed &&
-          variant === "inset" &&
-          "border-r border-sidebar-border bg-sidebar",
-        className,
+    <>
+      {!isOffcanvasCollapsed && collapsible === "offcanvas" && (
+        <button
+          aria-label="Close sidebar"
+          className="fixed inset-0 z-30 bg-[var(--surface-overlay)] md:hidden"
+          onClick={() => setOpen(false)}
+          type="button"
+        />
       )}
-      {...props}
-    >
-      {!isOffcanvasCollapsed && (
-        <div className="flex h-full min-h-0 flex-col bg-sidebar">
-          {children}
-        </div>
-      )}
-    </aside>
+      <aside
+        data-collapsible={state === "collapsed" ? collapsible : ""}
+        data-state={state}
+        data-variant={variant}
+        className={cn(
+          "group/sidebar fixed inset-y-0 left-0 z-40 flex h-svh w-[var(--sidebar-width)] shrink-0 flex-col overflow-hidden text-sidebar-foreground transition-transform duration-[var(--motion-duration-normal)] ease-[var(--motion-ease-standard)] md:relative md:z-auto",
+          isOffcanvasCollapsed && "hidden",
+          !isOffcanvasCollapsed && "translate-x-0",
+          !isOffcanvasCollapsed &&
+            variant === "sidebar" &&
+            "border-r border-sidebar-border bg-sidebar",
+          !isOffcanvasCollapsed &&
+            variant === "inset" &&
+            "border-r border-sidebar-border bg-sidebar",
+          className,
+        )}
+        {...props}
+      >
+        {!isOffcanvasCollapsed && (
+          <div className="flex h-full min-h-0 flex-col bg-sidebar">
+            {children}
+          </div>
+        )}
+      </aside>
+    </>
   );
 }
 

--- a/packages/app/src/components/ui/sidebar.tsx
+++ b/packages/app/src/components/ui/sidebar.tsx
@@ -1,0 +1,362 @@
+import { PanelLeft } from "lucide-react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import type { ComponentProps, CSSProperties } from "react";
+import { cn } from "../../lib/utils";
+
+const SIDEBAR_KEYBOARD_SHORTCUT = "b";
+
+interface SidebarContextValue {
+  open: boolean;
+  setOpen: (open: boolean | ((open: boolean) => boolean)) => void;
+  state: "collapsed" | "expanded";
+  toggleSidebar: () => void;
+}
+
+const SidebarContext = createContext<SidebarContextValue | null>(null);
+
+export function useSidebar() {
+  const context = useContext(SidebarContext);
+  if (!context) {
+    throw new Error("useSidebar must be used within a SidebarProvider.");
+  }
+  return context;
+}
+
+export function SidebarProvider({
+  children,
+  className,
+  defaultOpen = true,
+  open: openProp,
+  onOpenChange,
+  style,
+  ...props
+}: ComponentProps<"div"> & {
+  defaultOpen?: boolean;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}) {
+  const [_open, _setOpen] = useState(defaultOpen);
+  const open = openProp ?? _open;
+
+  const setOpen = useCallback(
+    (value: boolean | ((open: boolean) => boolean)) => {
+      const nextOpen = typeof value === "function" ? value(open) : value;
+      onOpenChange?.(nextOpen);
+      if (openProp === undefined) {
+        _setOpen(nextOpen);
+      }
+    },
+    [onOpenChange, open, openProp],
+  );
+
+  const toggleSidebar = useCallback(() => {
+    setOpen((current) => !current);
+  }, [setOpen]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (
+        event.key.toLowerCase() === SIDEBAR_KEYBOARD_SHORTCUT &&
+        (event.metaKey || event.ctrlKey)
+      ) {
+        event.preventDefault();
+        toggleSidebar();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [toggleSidebar]);
+
+  const contextValue = useMemo<SidebarContextValue>(
+    () => ({
+      open,
+      setOpen,
+      state: open ? "expanded" : "collapsed",
+      toggleSidebar,
+    }),
+    [open, setOpen, toggleSidebar],
+  );
+
+  return (
+    <SidebarContext.Provider value={contextValue}>
+      <div
+        className={cn(
+          "group/sidebar-wrapper flex min-h-svh w-full bg-background text-foreground has-[[data-variant=inset]]:bg-background",
+          className,
+        )}
+        style={
+          {
+            "--sidebar-width": "var(--layout-sidebar-width)",
+            ...style,
+          } as CSSProperties
+        }
+        {...props}
+      >
+        {children}
+      </div>
+    </SidebarContext.Provider>
+  );
+}
+
+export function Sidebar({
+  children,
+  className,
+  collapsible = "offcanvas",
+  variant = "sidebar",
+  ...props
+}: ComponentProps<"aside"> & {
+  collapsible?: "none" | "offcanvas";
+  variant?: "inset" | "sidebar";
+}) {
+  const { state } = useSidebar();
+  const isOffcanvasCollapsed =
+    state === "collapsed" && collapsible === "offcanvas";
+  return (
+    <aside
+      data-collapsible={state === "collapsed" ? collapsible : ""}
+      data-state={state}
+      data-variant={variant}
+      className={cn(
+        "group/sidebar relative hidden h-svh shrink-0 flex-col overflow-hidden text-sidebar-foreground transition-[width] duration-[var(--motion-duration-normal)] ease-[var(--motion-ease-standard)] md:flex",
+        isOffcanvasCollapsed && "w-0 border-r-0",
+        (state === "expanded" || collapsible === "none") &&
+          "w-[--sidebar-width]",
+        !isOffcanvasCollapsed &&
+          variant === "sidebar" &&
+          "border-r border-sidebar-border bg-sidebar",
+        !isOffcanvasCollapsed &&
+          variant === "inset" &&
+          "border-r border-sidebar-border bg-sidebar",
+        className,
+      )}
+      {...props}
+    >
+      {!isOffcanvasCollapsed && (
+        <div className="flex h-full min-h-0 flex-col bg-sidebar">
+          {children}
+        </div>
+      )}
+    </aside>
+  );
+}
+
+export function SidebarHeader({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <div
+      className={cn(
+        "flex min-h-[var(--layout-topbar-height)] items-center gap-2 border-b border-sidebar-border px-3 group-data-[state=collapsed]/sidebar:justify-center group-data-[state=collapsed]/sidebar:px-2",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function SidebarInset({ className, ...props }: ComponentProps<"main">) {
+  return (
+    <main
+      className={cn(
+        "relative flex min-w-0 flex-1 flex-col bg-[var(--surface-panel)]",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function SidebarTrigger({
+  className,
+  ...props
+}: ComponentProps<"button">) {
+  const { toggleSidebar } = useSidebar();
+  return (
+    <button
+      className={cn(
+        "inline-flex size-8 shrink-0 items-center justify-center rounded-[var(--radius-sm)] text-muted-foreground outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:shadow-[var(--state-focus-ring)] disabled:pointer-events-none disabled:opacity-[var(--opacity-disabled)]",
+        className,
+      )}
+      onClick={toggleSidebar}
+      title="Toggle sidebar"
+      type="button"
+      {...props}
+    >
+      <PanelLeft className="size-4" />
+      <span className="sr-only">Toggle sidebar</span>
+    </button>
+  );
+}
+
+export function SidebarRail({ className, ...props }: ComponentProps<"button">) {
+  const { toggleSidebar } = useSidebar();
+  return (
+    <button
+      aria-label="Toggle sidebar"
+      className={cn(
+        "absolute inset-y-0 -right-3 z-20 hidden w-6 -translate-x-px transition-colors after:absolute after:inset-y-0 after:left-1/2 after:w-px hover:after:bg-sidebar-border sm:flex",
+        className,
+      )}
+      onClick={toggleSidebar}
+      tabIndex={-1}
+      type="button"
+      {...props}
+    />
+  );
+}
+
+export function SidebarContent({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <div
+      className={cn(
+        "min-h-0 flex-1 overflow-y-auto p-2 group-data-[state=collapsed]/sidebar:px-2",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function SidebarFooter({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <div
+      className={cn("border-t border-sidebar-border p-3", className)}
+      {...props}
+    />
+  );
+}
+
+export function SidebarGroup({
+  className,
+  ...props
+}: ComponentProps<"section">) {
+  return (
+    <section
+      className={cn(
+        "relative space-y-1 group-data-[state=collapsed]/sidebar:space-y-2",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function SidebarGroupHeader({
+  className,
+  ...props
+}: ComponentProps<"div">) {
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-2 group-data-[state=collapsed]/sidebar:hidden",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function SidebarGroupLabel({
+  className,
+  ...props
+}: ComponentProps<"div">) {
+  return (
+    <div
+      className={cn(
+        "min-w-0 flex-1 px-2 py-1 text-[length:var(--font-size-xs)] font-medium text-[var(--text-secondary)]",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function SidebarGroupAction({
+  className,
+  ...props
+}: ComponentProps<"button">) {
+  return (
+    <button
+      className={cn(
+        "inline-flex size-7 shrink-0 items-center justify-center rounded-[var(--radius-sm)] text-[var(--icon-color-default)] outline-none transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:shadow-[var(--state-focus-ring)]",
+        className,
+      )}
+      type="button"
+      {...props}
+    />
+  );
+}
+
+export function SidebarGroupContent({
+  className,
+  ...props
+}: ComponentProps<"div">) {
+  return <div className={cn("w-full", className)} {...props} />;
+}
+
+export function SidebarMenu({ className, ...props }: ComponentProps<"ul">) {
+  return <ul className={cn("space-y-1", className)} {...props} />;
+}
+
+export function SidebarMenuItem({ className, ...props }: ComponentProps<"li">) {
+  return <li className={cn("min-w-0", className)} {...props} />;
+}
+
+export function SidebarMenuButton({
+  className,
+  isActive,
+  ...props
+}: ComponentProps<"button"> & { isActive?: boolean }) {
+  return (
+    <button
+      className={cn(
+        "flex min-h-8 w-full min-w-0 items-center gap-2 rounded-[var(--radius-sm)] px-2 py-1.5 text-left text-[length:var(--font-size-sm)] outline-none transition-colors duration-[var(--motion-duration-fast)] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:shadow-[var(--state-focus-ring)] group-data-[state=collapsed]/sidebar:justify-center group-data-[state=collapsed]/sidebar:px-0",
+        isActive && "bg-sidebar-accent text-sidebar-accent-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function SidebarMenuSub({ className, ...props }: ComponentProps<"ul">) {
+  return (
+    <ul
+      className={cn(
+        "ml-4 mt-1 space-y-1 border-l border-sidebar-border pl-2 group-data-[state=collapsed]/sidebar:hidden",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function SidebarMenuSubItem({
+  className,
+  ...props
+}: ComponentProps<"li">) {
+  return <li className={cn("min-w-0", className)} {...props} />;
+}
+
+export function SidebarMenuSubButton({
+  className,
+  isActive,
+  ...props
+}: ComponentProps<"button"> & { isActive?: boolean }) {
+  return (
+    <button
+      className={cn(
+        "flex min-h-7 w-full min-w-0 items-center gap-2 rounded-[var(--radius-sm)] px-2 py-1 text-left text-[length:var(--font-size-sm)] outline-none transition-colors duration-[var(--motion-duration-fast)] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:shadow-[var(--state-focus-ring)]",
+        isActive && "bg-sidebar-accent text-sidebar-accent-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/packages/app/src/components/ui/textarea.tsx
+++ b/packages/app/src/components/ui/textarea.tsx
@@ -1,0 +1,14 @@
+import type { ComponentProps } from "react";
+import { cn } from "../../lib/utils";
+
+export function Textarea({ className, ...props }: ComponentProps<"textarea">) {
+  return (
+    <textarea
+      className={cn(
+        "flex min-h-16 w-full min-w-0 resize-none rounded-[var(--radius-sm)] border border-input bg-[var(--surface-input)] px-3 py-2 text-[length:var(--font-size-md)] shadow-[var(--shadow-xs)] outline-none transition-[border-color,box-shadow] duration-[var(--motion-duration-fast)] placeholder:text-[var(--text-tertiary)] focus-visible:border-ring focus-visible:shadow-[var(--state-focus-ring)] disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-[var(--opacity-disabled)]",
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/packages/app/src/lib/utils.ts
+++ b/packages/app/src/lib/utils.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: Array<boolean | null | string | undefined>) {
+  return classes.filter(Boolean).join(" ");
+}

--- a/packages/app/src/routes/index.tsx
+++ b/packages/app/src/routes/index.tsx
@@ -297,6 +297,11 @@ function Home() {
 
   async function addProject(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
+    const trimmedProjectPath = projectPath.trim();
+    if (!trimmedProjectPath) {
+      return;
+    }
+
     setError(null);
     setIsBusy(true);
     try {
@@ -304,7 +309,7 @@ function Home() {
         "/api/projects",
         {
           method: "POST",
-          body: JSON.stringify({ path: projectPath }),
+          body: JSON.stringify({ path: trimmedProjectPath }),
         },
       );
       setProjectPath("");
@@ -590,7 +595,7 @@ function Home() {
               >
                 Cancel
               </Button>
-              <Button disabled={isBusy || !projectPath} type="submit">
+              <Button disabled={isBusy || !projectPath.trim()} type="submit">
                 Add project
               </Button>
             </DialogFooter>

--- a/packages/app/src/routes/index.tsx
+++ b/packages/app/src/routes/index.tsx
@@ -1,16 +1,56 @@
 import { createFileRoute } from "@tanstack/react-router";
 import {
+  AlertTriangle,
+  ChevronRight,
+  Clock3,
   FolderGit2,
-  Loader2,
+  Inbox,
+  MessageSquare,
   MessageSquarePlus,
   Plus,
   Send,
   Square,
 } from "lucide-react";
+import type { ReactNode } from "react";
 import { FormEvent, useEffect, useMemo, useState } from "react";
+import { Badge } from "../components/ui/badge";
+import { Button } from "../components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "../components/ui/dialog";
+import { Input } from "../components/ui/input";
+import { Label } from "../components/ui/label";
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarGroup,
+  SidebarGroupAction,
+  SidebarGroupContent,
+  SidebarGroupHeader,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarInset,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
+  SidebarProvider,
+  SidebarRail,
+  SidebarTrigger,
+} from "../components/ui/sidebar";
+import { Textarea } from "../components/ui/textarea";
+import { cn } from "../lib/utils";
 import type {
   ChatMessageRecord,
   ChatRecord,
+  ChatStatus,
   PhantomEvent,
   ProjectRecord,
 } from "../server/types";
@@ -35,22 +75,66 @@ const chatEventNames = [
   "auth.updated",
 ];
 
+const statusMeta: Record<
+  ChatStatus,
+  {
+    badge: "danger" | "info" | "secondary" | "success" | "warning";
+    dot: string;
+    label: string;
+  }
+> = {
+  archived: {
+    badge: "secondary",
+    dot: "bg-[var(--color-gray-400)]",
+    label: "Archived",
+  },
+  failed: {
+    badge: "danger",
+    dot: "bg-[var(--semantic-danger-fg)]",
+    label: "Failed",
+  },
+  idle: {
+    badge: "secondary",
+    dot: "bg-[var(--color-gray-500)]",
+    label: "Idle",
+  },
+  running: {
+    badge: "info",
+    dot: "bg-[var(--semantic-info-fg)]",
+    label: "Running",
+  },
+  waitingForApproval: {
+    badge: "warning",
+    dot: "bg-[var(--semantic-warning-fg)]",
+    label: "Approval",
+  },
+};
+
 interface PendingApproval {
   requestId: string;
   method: string;
   params: unknown;
 }
 
+type VisibleMessageRecord = ChatMessageRecord & {
+  role: "assistant" | "error" | "user";
+};
+
 function Home() {
   const [projects, setProjects] = useState<ProjectRecord[]>([]);
   const [selectedProjectId, setSelectedProjectId] = useState<string | null>(
     null,
   );
-  const [chats, setChats] = useState<ChatRecord[]>([]);
+  const [chatsByProject, setChatsByProject] = useState<
+    Record<string, ChatRecord[]>
+  >({});
+  const [expandedProjectIds, setExpandedProjectIds] = useState<Set<string>>(
+    () => new Set(),
+  );
   const [selectedChatId, setSelectedChatId] = useState<string | null>(null);
   const [messages, setMessages] = useState<ChatMessageRecord[]>([]);
+  const [isAddProjectOpen, setIsAddProjectOpen] = useState(false);
   const [projectPath, setProjectPath] = useState("");
-  const [newChatName, setNewChatName] = useState("");
   const [composerText, setComposerText] = useState("");
   const [status, setStatus] = useState("Starting");
   const [error, setError] = useState<string | null>(null);
@@ -62,9 +146,21 @@ function Home() {
     () => projects.find((project) => project.id === selectedProjectId) ?? null,
     [projects, selectedProjectId],
   );
+
   const selectedChat = useMemo(
-    () => chats.find((chat) => chat.id === selectedChatId) ?? null,
-    [chats, selectedChatId],
+    () =>
+      Object.values(chatsByProject)
+        .flat()
+        .find((chat) => chat.id === selectedChatId) ?? null,
+    [chatsByProject, selectedChatId],
+  );
+
+  const visibleMessages = useMemo(
+    () =>
+      messages.filter(
+        (message): message is VisibleMessageRecord => message.role !== "event",
+      ),
+    [messages],
   );
 
   useEffect(() => {
@@ -76,10 +172,14 @@ function Home() {
 
   useEffect(() => {
     if (!selectedProjectId) {
-      setChats([]);
       setSelectedChatId(null);
       return;
     }
+    setExpandedProjectIds((current) => {
+      const next = new Set(current);
+      next.add(selectedProjectId);
+      return next;
+    });
     void refreshChats(selectedProjectId);
   }, [selectedProjectId]);
 
@@ -128,26 +228,64 @@ function Home() {
       "/api/projects",
     );
     setProjects(data.projects);
-    setSelectedProjectId((current) => current ?? data.projects[0]?.id ?? null);
+    const chatEntries = await Promise.all(
+      data.projects.map(
+        async (project) => [project.id, await loadChats(project.id)] as const,
+      ),
+    );
+    const nextChatsByProject = Object.fromEntries(chatEntries);
+    setChatsByProject(nextChatsByProject);
+    setSelectedProjectId((current) => {
+      const nextProjectId = current ?? data.projects[0]?.id ?? null;
+      if (nextProjectId) {
+        setExpandedProjectIds((expanded) => {
+          const next = new Set(expanded);
+          next.add(nextProjectId);
+          return next;
+        });
+      }
+      return nextProjectId;
+    });
+    setSelectedChatId((current) =>
+      Object.values(nextChatsByProject)
+        .flat()
+        .some((chat) => chat.id === current)
+        ? current
+        : null,
+    );
   }
 
-  async function refreshChats(projectId: string) {
+  async function loadChats(projectId: string) {
     const data = await fetchJson<{ chats: ChatRecord[] }>(
       `/api/projects/${projectId}/chats`,
     );
-    setChats(data.chats);
+    return data.chats;
+  }
+
+  async function refreshChats(projectId: string) {
+    const nextChats = await loadChats(projectId);
+    setChatsByProject((current) => ({
+      ...current,
+      [projectId]: nextChats,
+    }));
     setSelectedChatId((current) =>
-      data.chats.some((chat) => chat.id === current)
+      nextChats.some((chat) => chat.id === current)
         ? current
-        : (data.chats[0]?.id ?? null),
+        : (nextChats[0]?.id ?? null),
     );
   }
 
   async function refreshSelectedChat(chatId: string) {
     const data = await fetchJson<{ chat: ChatRecord }>(`/api/chats/${chatId}`);
-    setChats((current) =>
-      current.map((chat) => (chat.id === chatId ? data.chat : chat)),
-    );
+    setChatsByProject((current) => {
+      const projectChats = current[data.chat.projectId] ?? [];
+      return {
+        ...current,
+        [data.chat.projectId]: projectChats.map((chat) =>
+          chat.id === chatId ? data.chat : chat,
+        ),
+      };
+    });
   }
 
   async function refreshMessages(chatId: string) {
@@ -170,6 +308,7 @@ function Home() {
         },
       );
       setProjectPath("");
+      setIsAddProjectOpen(false);
       await refreshProjects();
       setSelectedProjectId(data.project.id);
     } catch (err) {
@@ -179,22 +318,20 @@ function Home() {
     }
   }
 
-  async function createChat() {
-    if (!selectedProjectId) {
-      return;
-    }
+  async function createChat(projectId: string) {
     setError(null);
     setIsBusy(true);
     try {
       const data = await fetchJson<{ chat: ChatRecord }>(
-        `/api/projects/${selectedProjectId}/chats`,
+        `/api/projects/${projectId}/chats`,
         {
           method: "POST",
-          body: JSON.stringify({ name: newChatName || undefined }),
+          body: JSON.stringify({}),
         },
       );
-      setNewChatName("");
-      await refreshChats(selectedProjectId);
+      setSelectedProjectId(projectId);
+      setExpandedProjectIds((current) => new Set(current).add(projectId));
+      await refreshChats(projectId);
       setSelectedChatId(data.chat.id);
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
@@ -255,244 +392,451 @@ function Home() {
     }
   }
 
+  function toggleProject(projectId: string) {
+    setExpandedProjectIds((current) => {
+      const next = new Set(current);
+      if (next.has(projectId)) {
+        next.delete(projectId);
+      } else {
+        next.add(projectId);
+      }
+      return next;
+    });
+  }
+
+  function selectProject(projectId: string) {
+    setSelectedProjectId(projectId);
+    setExpandedProjectIds((current) => new Set(current).add(projectId));
+    const projectChats = chatsByProject[projectId] ?? [];
+    setSelectedChatId((current) =>
+      projectChats.some((chat) => chat.id === current)
+        ? current
+        : (projectChats[0]?.id ?? null),
+    );
+  }
+
+  function selectChat(chat: ChatRecord) {
+    setSelectedProjectId(chat.projectId);
+    setSelectedChatId(chat.id);
+    setExpandedProjectIds((current) => new Set(current).add(chat.projectId));
+  }
+
   return (
-    <main className="grid h-screen min-h-0 grid-cols-[260px_300px_1fr] bg-slate-50 text-slate-950">
-      <aside className="flex min-h-0 flex-col border-r border-slate-200 bg-white">
-        <div className="flex h-12 items-center gap-2 border-b border-slate-200 px-3">
-          <FolderGit2 className="size-4 text-slate-600" />
-          <h1 className="text-sm font-semibold">Phantom</h1>
-          <span className="ml-auto text-xs text-slate-500">{status}</span>
-        </div>
-
-        <form className="border-b border-slate-200 p-3" onSubmit={addProject}>
-          <label className="text-xs font-medium text-slate-600">
-            Project path
-          </label>
-          <div className="mt-2 flex gap-2">
-            <input
-              className="min-w-0 flex-1 rounded-md border border-slate-300 bg-white px-2 py-1.5 text-sm outline-none focus:border-slate-500"
-              placeholder="/Users/me/project"
-              value={projectPath}
-              onChange={(event) => setProjectPath(event.target.value)}
-            />
-            <button
-              className="inline-flex size-8 items-center justify-center rounded-md border border-slate-300 bg-white text-slate-700 hover:bg-slate-100 disabled:opacity-50"
-              disabled={isBusy || !projectPath}
-              title="Add project"
-              type="submit"
-            >
-              {isBusy ? (
-                <Loader2 className="size-4 animate-spin" />
-              ) : (
-                <Plus className="size-4" />
-              )}
-            </button>
+    <SidebarProvider className="h-screen min-h-0">
+      <Sidebar collapsible="offcanvas" variant="inset">
+        <SidebarHeader>
+          <div className="flex size-8 shrink-0 items-center justify-center rounded-[var(--radius-sm)] bg-[var(--color-gray-900)] text-primary-foreground">
+            <FolderGit2 className="size-4" />
           </div>
-        </form>
+          <div className="min-w-0 flex-1 group-data-[state=collapsed]/sidebar:hidden">
+            <h1 className="truncate text-[length:var(--font-size-lg)] font-semibold leading-tight">
+              Phantom
+            </h1>
+          </div>
+          <Badge
+            className="max-w-24 truncate group-data-[state=collapsed]/sidebar:hidden"
+            variant={status === "Ready" ? "success" : "warning"}
+          >
+            {status}
+          </Badge>
+        </SidebarHeader>
 
-        <nav className="min-h-0 flex-1 overflow-y-auto p-2">
-          {projects.length === 0 ? (
-            <p className="px-2 py-3 text-sm text-slate-500">
-              Add a Git project to begin.
-            </p>
-          ) : (
-            projects.map((project) => (
-              <button
-                className={`mb-1 block w-full rounded-md px-2 py-2 text-left text-sm ${
-                  project.id === selectedProjectId
-                    ? "bg-slate-900 text-white"
-                    : "text-slate-700 hover:bg-slate-100"
-                }`}
-                key={project.id}
-                onClick={() => setSelectedProjectId(project.id)}
-                type="button"
+        <SidebarContent>
+          <SidebarGroup>
+            <SidebarGroupHeader>
+              <SidebarGroupLabel>Projects</SidebarGroupLabel>
+              <SidebarGroupAction
+                aria-label="Add project"
+                onClick={() => setIsAddProjectOpen(true)}
+                title="Add project"
               >
-                <span className="block truncate font-medium">
-                  {project.name}
-                </span>
-                <span className="block truncate text-xs opacity-70">
-                  {project.rootPath}
-                </span>
-              </button>
-            ))
-          )}
-        </nav>
-      </aside>
+                <Plus className="size-4" />
+              </SidebarGroupAction>
+            </SidebarGroupHeader>
+            <SidebarGroupContent>
+              <SidebarMenu>
+                {projects.length === 0 ? (
+                  <li className="px-2 py-4 group-data-[state=collapsed]/sidebar:hidden">
+                    <div className="rounded-[var(--radius-md)] border border-dashed border-sidebar-border bg-[var(--surface-card)] px-3 py-3 text-[length:var(--font-size-sm)] text-muted-foreground">
+                      Add a Git project to begin.
+                    </div>
+                  </li>
+                ) : (
+                  projects.map((project) => {
+                    const isProjectExpanded = expandedProjectIds.has(
+                      project.id,
+                    );
+                    const isProjectSelected = project.id === selectedProjectId;
+                    const projectChats = chatsByProject[project.id] ?? [];
 
-      <section className="flex min-h-0 flex-col border-r border-slate-200 bg-white">
-        <div className="flex h-12 items-center border-b border-slate-200 px-3">
-          <div className="min-w-0">
-            <p className="truncate text-sm font-medium">
-              {selectedProject?.name ?? "No project"}
-            </p>
-            <p className="truncate text-xs text-slate-500">
-              {selectedProject?.rootPath ?? "Select or add a project"}
-            </p>
-          </div>
-        </div>
+                    return (
+                      <SidebarMenuItem key={project.id}>
+                        <div
+                          className={cn(
+                            "group/project flex items-center rounded-[var(--radius-sm)]",
+                            isProjectSelected && "bg-sidebar-accent",
+                          )}
+                        >
+                          <Button
+                            aria-label={
+                              isProjectExpanded
+                                ? "Collapse project"
+                                : "Expand project"
+                            }
+                            className="ml-1 size-7 text-[var(--icon-color-default)] group-data-[state=collapsed]/sidebar:hidden"
+                            onClick={() => toggleProject(project.id)}
+                            size="icon"
+                            type="button"
+                            variant="ghost"
+                          >
+                            <ChevronRight
+                              className={cn(
+                                "transition-transform duration-[var(--motion-duration-fast)]",
+                                isProjectExpanded && "rotate-90",
+                              )}
+                            />
+                          </Button>
+                          <SidebarMenuButton
+                            className="min-h-8 flex-1 group-data-[state=collapsed]/sidebar:flex-none"
+                            isActive={isProjectSelected}
+                            onClick={() => selectProject(project.id)}
+                            title={project.name}
+                            type="button"
+                          >
+                            <FolderGit2 className="size-4 text-[var(--icon-color-default)]" />
+                            <span className="min-w-0 flex-1 group-data-[state=collapsed]/sidebar:hidden">
+                              <span className="block truncate font-medium">
+                                {project.name}
+                              </span>
+                            </span>
+                          </SidebarMenuButton>
+                          <Button
+                            aria-label={`Create worktree in ${project.name}`}
+                            className="mr-1 size-7 text-[var(--icon-color-default)] group-data-[state=collapsed]/sidebar:hidden"
+                            disabled={isBusy}
+                            onClick={() => void createChat(project.id)}
+                            size="icon"
+                            title="Create worktree"
+                            type="button"
+                            variant="ghost"
+                          >
+                            <MessageSquarePlus className="size-4" />
+                          </Button>
+                        </div>
+                        {isProjectExpanded && (
+                          <SidebarMenuSub>
+                            {projectChats.length === 0 ? (
+                              <li className="px-2 py-1.5 text-[length:var(--font-size-xs)] text-[var(--text-tertiary)]">
+                                No worktrees
+                              </li>
+                            ) : (
+                              projectChats.map((chat) => {
+                                return (
+                                  <SidebarMenuSubItem key={chat.id}>
+                                    <SidebarMenuSubButton
+                                      isActive={chat.id === selectedChatId}
+                                      onClick={() => selectChat(chat)}
+                                      title={chat.title}
+                                      type="button"
+                                    >
+                                      <MessageSquare className="size-3.5 text-[var(--icon-color-default)]" />
+                                      <span className="min-w-0 flex-1">
+                                        <span className="block truncate font-medium">
+                                          {chat.title}
+                                        </span>
+                                      </span>
+                                    </SidebarMenuSubButton>
+                                  </SidebarMenuSubItem>
+                                );
+                              })
+                            )}
+                          </SidebarMenuSub>
+                        )}
+                      </SidebarMenuItem>
+                    );
+                  })
+                )}
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+        </SidebarContent>
 
-        <div className="border-b border-slate-200 p-3">
-          <label className="text-xs font-medium text-slate-600">New chat</label>
-          <div className="mt-2 flex gap-2">
-            <input
-              className="min-w-0 flex-1 rounded-md border border-slate-300 bg-white px-2 py-1.5 text-sm outline-none focus:border-slate-500"
-              placeholder="optional-name"
-              value={newChatName}
-              onChange={(event) => setNewChatName(event.target.value)}
-            />
-            <button
-              className="inline-flex size-8 items-center justify-center rounded-md border border-slate-300 bg-white text-slate-700 hover:bg-slate-100 disabled:opacity-50"
-              disabled={!selectedProjectId || isBusy}
-              onClick={createChat}
-              title="Create chat"
-              type="button"
-            >
-              <MessageSquarePlus className="size-4" />
-            </button>
-          </div>
-        </div>
+        <SidebarRail />
+      </Sidebar>
 
-        <div className="min-h-0 flex-1 overflow-y-auto p-2">
-          {chats.map((chat) => (
-            <button
-              className={`mb-1 block w-full rounded-md px-2 py-2 text-left text-sm ${
-                chat.id === selectedChatId
-                  ? "bg-slate-900 text-white"
-                  : "text-slate-700 hover:bg-slate-100"
-              }`}
-              key={chat.id}
-              onClick={() => setSelectedChatId(chat.id)}
-              type="button"
-            >
-              <span className="block truncate font-medium">{chat.title}</span>
-              <span className="block truncate text-xs opacity-70">
-                {chat.status} / {chat.branchName}
-              </span>
-            </button>
-          ))}
-        </div>
-      </section>
+      <Dialog open={isAddProjectOpen} onOpenChange={setIsAddProjectOpen}>
+        <DialogContent aria-labelledby="add-project-title">
+          <DialogHeader>
+            <DialogTitle id="add-project-title">Add project</DialogTitle>
+            <DialogDescription>
+              Add a local Git project to the Phantom sidebar.
+            </DialogDescription>
+          </DialogHeader>
+          <form className="grid gap-4" onSubmit={addProject}>
+            <div className="grid gap-2">
+              <Label htmlFor="project-path">Project path</Label>
+              <Input
+                id="project-path"
+                placeholder="/Users/me/project"
+                value={projectPath}
+                onChange={(event) => setProjectPath(event.target.value)}
+              />
+            </div>
+            <DialogFooter>
+              <Button
+                onClick={() => setIsAddProjectOpen(false)}
+                type="button"
+                variant="outline"
+              >
+                Cancel
+              </Button>
+              <Button disabled={isBusy || !projectPath} type="submit">
+                Add project
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
 
-      <section className="flex min-h-0 flex-col">
-        <header className="flex h-12 items-center gap-3 border-b border-slate-200 bg-white px-4">
+      <SidebarInset>
+        <header className="flex min-h-[var(--layout-topbar-height)] items-center gap-3 border-b border-border bg-[var(--surface-panel)] px-4">
+          <SidebarTrigger className="-ml-1" />
+          <div className="h-5 w-px bg-[var(--border-divider)]" />
           <div className="min-w-0 flex-1">
-            <p className="truncate text-sm font-medium">
-              {selectedChat?.title ?? "No chat selected"}
-            </p>
-            <p className="truncate text-xs text-slate-500">
-              {selectedChat?.worktreePath ??
-                "Create a chat to create a worktree"}
+            <div className="flex min-w-0 items-center gap-2">
+              <p className="truncate text-[length:var(--font-size-xl)] font-semibold leading-tight">
+                {selectedChat?.title ?? "Workspace"}
+              </p>
+              {selectedChat && <StatusBadge status={selectedChat.status} />}
+            </div>
+            <p className="truncate text-[length:var(--font-size-xs)] text-muted-foreground">
+              {selectedProject?.name ?? "No project selected"}
+              {selectedChat ? ` / ${selectedChat.branchName}` : ""}
             </p>
           </div>
-          <button
-            className="inline-flex items-center gap-2 rounded-md border border-slate-300 bg-white px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-100 disabled:opacity-50"
+          <Button
             disabled={!selectedChat?.activeTurnId}
             onClick={interruptChat}
+            size="sm"
             type="button"
+            variant="outline"
           >
             <Square className="size-3" />
             Stop
-          </button>
+          </Button>
         </header>
 
         {error && (
-          <div className="border-b border-red-200 bg-red-50 px-4 py-2 text-sm text-red-700">
-            {error}
-          </div>
+          <SystemBanner tone="danger">
+            <AlertTriangle className="size-4" />
+            <span>{error}</span>
+          </SystemBanner>
         )}
 
         {pendingApproval && (
-          <div className="border-b border-amber-200 bg-amber-50 px-4 py-3">
-            <p className="text-sm font-medium text-amber-900">
-              Approval requested
-            </p>
-            <p className="mt-1 text-xs text-amber-800">
-              {pendingApproval.method}
-            </p>
-            <div className="mt-3 flex gap-2">
-              <button
-                className="rounded-md bg-slate-900 px-3 py-1.5 text-sm text-white"
-                onClick={() => void answerApproval("accept")}
-                type="button"
-              >
-                Accept
-              </button>
-              <button
-                className="rounded-md border border-slate-300 bg-white px-3 py-1.5 text-sm"
-                onClick={() => void answerApproval("acceptForSession")}
-                type="button"
-              >
-                Accept for session
-              </button>
-              <button
-                className="rounded-md border border-slate-300 bg-white px-3 py-1.5 text-sm"
-                onClick={() => void answerApproval("decline")}
-                type="button"
-              >
-                Decline
-              </button>
+          <div className="border-b border-[var(--semantic-warning-border)] bg-[var(--semantic-warning-bg)] px-4 py-3 text-[var(--semantic-warning-fg)]">
+            <div className="mx-auto flex max-w-[var(--layout-max-content-width)] flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div className="min-w-0">
+                <p className="flex items-center gap-2 text-[length:var(--font-size-md)] font-semibold">
+                  <Clock3 className="size-4" />
+                  Approval requested
+                </p>
+                <p className="mt-1 truncate font-mono text-[length:var(--font-size-xs)]">
+                  {pendingApproval.method}
+                </p>
+              </div>
+              <div className="flex shrink-0 flex-wrap gap-2">
+                <Button
+                  onClick={() => void answerApproval("accept")}
+                  size="sm"
+                  type="button"
+                >
+                  Accept
+                </Button>
+                <Button
+                  onClick={() => void answerApproval("acceptForSession")}
+                  size="sm"
+                  type="button"
+                  variant="outline"
+                >
+                  Accept for session
+                </Button>
+                <Button
+                  onClick={() => void answerApproval("decline")}
+                  size="sm"
+                  type="button"
+                  variant="outline"
+                >
+                  Decline
+                </Button>
+              </div>
             </div>
           </div>
         )}
 
-        <div className="min-h-0 flex-1 overflow-y-auto px-4 py-3">
-          {messages.length === 0 ? (
-            <div className="flex h-full items-center justify-center text-sm text-slate-500">
-              Send a message to start working with Codex.
-            </div>
+        <section className="min-h-0 flex-1 overflow-y-auto px-4 py-4">
+          {visibleMessages.length === 0 ? (
+            <EmptyTimeline
+              hasChat={Boolean(selectedChat)}
+              selectedProject={selectedProject}
+              onCreateChat={
+                selectedProject
+                  ? () => void createChat(selectedProject.id)
+                  : undefined
+              }
+              onOpenProjectDialog={() => setIsAddProjectOpen(true)}
+            />
           ) : (
-            <div className="mx-auto flex max-w-4xl flex-col gap-3">
-              {messages.map((message) => (
-                <article
-                  className={`rounded-md border px-3 py-2 text-sm ${
-                    message.role === "user"
-                      ? "ml-auto max-w-[75%] border-slate-900 bg-slate-900 text-white"
-                      : message.role === "assistant"
-                        ? "mr-auto max-w-[80%] border-slate-200 bg-white"
-                        : message.role === "error"
-                          ? "border-red-200 bg-red-50 text-red-800"
-                          : "border-slate-200 bg-slate-100 text-slate-600"
-                  }`}
-                  key={message.id}
-                >
-                  <pre className="whitespace-pre-wrap break-words font-sans">
-                    {message.text}
-                  </pre>
-                </article>
+            <div className="mx-auto flex max-w-[var(--layout-max-content-width)] flex-col gap-2">
+              {visibleMessages.map((message) => (
+                <MessageCard key={message.id} message={message} />
               ))}
             </div>
           )}
-        </div>
+        </section>
 
         <form
-          className="border-t border-slate-200 bg-white p-3"
+          className="border-t border-border bg-[var(--surface-floating)] p-3 backdrop-blur"
           onSubmit={sendMessage}
         >
-          <div className="mx-auto flex max-w-4xl gap-2">
-            <textarea
-              className="min-h-11 flex-1 resize-none rounded-md border border-slate-300 px-3 py-2 text-sm outline-none focus:border-slate-500"
-              disabled={!selectedChatId}
-              placeholder={
-                selectedChatId
-                  ? "Ask Codex to work in this worktree"
-                  : "Create a chat first"
-              }
-              rows={2}
-              value={composerText}
-              onChange={(event) => setComposerText(event.target.value)}
-            />
-            <button
-              className="inline-flex h-11 w-11 items-center justify-center rounded-md bg-slate-900 text-white hover:bg-slate-700 disabled:opacity-50"
+          <div className="mx-auto flex max-w-[var(--layout-max-content-width)] items-end gap-2 border border-transparent border-t-[var(--border-divider)] bg-transparent p-1">
+            <div className="min-w-0 flex-1">
+              <Label className="sr-only" htmlFor="composer">
+                Message
+              </Label>
+              <Textarea
+                className="min-h-12 border-0 bg-transparent px-2 py-2 shadow-none focus-visible:shadow-none"
+                disabled={!selectedChatId}
+                id="composer"
+                placeholder={
+                  selectedChatId
+                    ? "Ask Codex to work in this worktree"
+                    : "Create or select a worktree to start"
+                }
+                rows={2}
+                value={composerText}
+                onChange={(event) => setComposerText(event.target.value)}
+              />
+            </div>
+            <Button
+              aria-label="Send message"
+              className="size-10"
               disabled={!selectedChatId || !composerText.trim()}
+              size="icon"
               title="Send"
               type="submit"
             >
-              <Send className="size-4" />
-            </button>
+              <Send />
+            </Button>
           </div>
         </form>
+      </SidebarInset>
+    </SidebarProvider>
+  );
+}
+
+function StatusBadge({ status }: { status: ChatStatus }) {
+  const meta = statusMeta[status];
+  return (
+    <Badge variant={meta.badge}>
+      <span className={cn("size-1.5 rounded-full", meta.dot)} />
+      {meta.label}
+    </Badge>
+  );
+}
+
+function SystemBanner({
+  children,
+  tone,
+}: {
+  children: ReactNode;
+  tone: "danger" | "info";
+}) {
+  const toneClass =
+    tone === "danger"
+      ? "border-[var(--semantic-danger-border)] bg-[var(--semantic-danger-bg)] text-[var(--semantic-danger-fg)]"
+      : "border-[var(--semantic-info-border)] bg-[var(--semantic-info-bg)] text-[var(--semantic-info-fg)]";
+
+  return (
+    <div
+      className={cn(
+        "border-b px-4 py-2 text-[length:var(--font-size-sm)]",
+        toneClass,
+      )}
+      role="status"
+    >
+      <div className="mx-auto flex max-w-[var(--layout-max-content-width)] items-center gap-2">
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function EmptyTimeline({
+  hasChat,
+  onCreateChat,
+  onOpenProjectDialog,
+  selectedProject,
+}: {
+  hasChat: boolean;
+  onCreateChat?: () => void;
+  onOpenProjectDialog: () => void;
+  selectedProject: ProjectRecord | null;
+}) {
+  return (
+    <div className="mx-auto flex h-full max-w-[var(--layout-max-content-width)] items-center justify-center py-8">
+      <section className="grid w-full max-w-xl gap-4 px-5 py-6 text-center">
+        <div className="mx-auto flex size-10 items-center justify-center rounded-[var(--radius-md)] bg-[var(--surface-code)] text-[var(--icon-color-default)]">
+          <Inbox className="size-5" />
+        </div>
+        <div>
+          <h2 className="text-[length:var(--font-size-xl)] font-semibold">
+            {hasChat ? "No messages yet" : "Select a worktree"}
+          </h2>
+          <p className="mt-1 text-[length:var(--font-size-md)] text-muted-foreground">
+            {hasChat
+              ? "Send a message to start a focused Codex session."
+              : "Create a worktree under a project to begin a Codex session."}
+          </p>
+        </div>
+        <div className="flex justify-center gap-2">
+          {selectedProject ? (
+            <Button onClick={onCreateChat} type="button">
+              <MessageSquarePlus className="size-4" />
+              Create worktree
+            </Button>
+          ) : (
+            <Button onClick={onOpenProjectDialog} type="button">
+              <Plus className="size-4" />
+              Add project
+            </Button>
+          )}
+        </div>
       </section>
-    </main>
+    </div>
+  );
+}
+
+function MessageCard({ message }: { message: VisibleMessageRecord }) {
+  const isUser = message.role === "user";
+  const isError = message.role === "error";
+
+  return (
+    <article
+      className={cn(
+        "rounded-[var(--radius-lg)] border px-4 py-3 shadow-[var(--shadow-xs)]",
+        isUser &&
+          "ml-auto max-w-[78%] border-transparent bg-[var(--color-gray-900)] text-primary-foreground",
+        message.role === "assistant" &&
+          "mr-auto max-w-[82%] border-border bg-card text-card-foreground",
+        isError &&
+          "border-[var(--semantic-danger-border)] bg-[var(--semantic-danger-bg)] text-[var(--semantic-danger-fg)]",
+      )}
+    >
+      <pre className="whitespace-pre-wrap break-words font-sans text-[length:var(--font-size-md)] leading-[var(--line-height-relaxed)]">
+        {message.text}
+      </pre>
+    </article>
   );
 }
 

--- a/packages/app/src/routes/index.tsx
+++ b/packages/app/src/routes/index.tsx
@@ -12,7 +12,7 @@ import {
   Square,
 } from "lucide-react";
 import type { ReactNode } from "react";
-import { FormEvent, useEffect, useMemo, useState } from "react";
+import { FormEvent, useEffect, useMemo, useRef, useState } from "react";
 import { Badge } from "../components/ui/badge";
 import { Button } from "../components/ui/button";
 import {
@@ -139,6 +139,7 @@ function Home() {
   const [status, setStatus] = useState("Starting");
   const [error, setError] = useState<string | null>(null);
   const [isBusy, setIsBusy] = useState(false);
+  const createChatInFlightRef = useRef(false);
   const [pendingApproval, setPendingApproval] =
     useState<PendingApproval | null>(null);
 
@@ -324,7 +325,12 @@ function Home() {
   }
 
   async function createChat(projectId: string) {
+    if (isBusy || createChatInFlightRef.current) {
+      return;
+    }
+
     setError(null);
+    createChatInFlightRef.current = true;
     setIsBusy(true);
     try {
       const data = await fetchJson<{ chat: ChatRecord }>(
@@ -341,6 +347,7 @@ function Home() {
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
+      createChatInFlightRef.current = false;
       setIsBusy(false);
     }
   }
@@ -683,6 +690,7 @@ function Home() {
           {visibleMessages.length === 0 ? (
             <EmptyTimeline
               hasChat={Boolean(selectedChat)}
+              isBusy={isBusy}
               selectedProject={selectedProject}
               onCreateChat={
                 selectedProject
@@ -779,11 +787,13 @@ function SystemBanner({
 
 function EmptyTimeline({
   hasChat,
+  isBusy,
   onCreateChat,
   onOpenProjectDialog,
   selectedProject,
 }: {
   hasChat: boolean;
+  isBusy: boolean;
   onCreateChat?: () => void;
   onOpenProjectDialog: () => void;
   selectedProject: ProjectRecord | null;
@@ -806,7 +816,7 @@ function EmptyTimeline({
         </div>
         <div className="flex justify-center gap-2">
           {selectedProject ? (
-            <Button onClick={onCreateChat} type="button">
+            <Button disabled={isBusy} onClick={onCreateChat} type="button">
               <MessageSquarePlus className="size-4" />
               Create worktree
             </Button>

--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -1,29 +1,277 @@
 @import "tailwindcss";
 
 :root {
-  color-scheme: light;
-  font-family:
-    Inter,
-    ui-sans-serif,
-    system-ui,
-    -apple-system,
-    BlinkMacSystemFont,
-    "Segoe UI",
+  --color-white: #fdfdfd;
+
+  --color-gray-50: #f7f8fa;
+  --color-gray-75: #f3f4f7;
+  --color-gray-100: #f0f1f5;
+  --color-gray-150: #edeef0;
+  --color-gray-200: #e5e7ec;
+  --color-gray-250: #dadde5;
+  --color-gray-300: #c9ccd6;
+  --color-gray-400: #aeb1bb;
+  --color-gray-500: #8d909b;
+  --color-gray-600: #747783;
+  --color-gray-700: #565a66;
+  --color-gray-800: #343844;
+  --color-gray-900: #1f2330;
+
+  --color-green-50: #e7f0ea;
+  --color-green-100: #dde7df;
+  --color-green-500: #2f7a4e;
+
+  --color-rose-50: #f0e1e7;
+  --color-rose-100: #e8d7df;
+  --color-rose-500: #9b3f5a;
+
+  --color-yellow-50: #f3ead2;
+  --color-yellow-100: #eadcad;
+  --color-yellow-600: #8a6a1d;
+
+  --color-blue-50: #e4e9f7;
+  --color-blue-100: #d8e0f3;
+  --color-blue-600: #4d5f9e;
+
+  --surface-window: #f0f1f5;
+  --surface-sidebar: #edeef0;
+  --surface-panel: #f3f4f7;
+  --surface-card: #f7f8fa;
+  --surface-code: #f1f2f6;
+  --surface-input: #f3f4f7;
+  --surface-floating: rgba(255, 255, 255, 0.72);
+  --surface-overlay: rgba(31, 35, 48, 0.36);
+
+  --text-primary: #2c303a;
+  --text-secondary: #5f636f;
+  --text-tertiary: #8a8e99;
+  --text-muted: #a9adb6;
+  --text-disabled: #c4c7cf;
+
+  --text-link: #4d5f9e;
+  --text-success: #2f7a4e;
+  --text-danger: #9b3f5a;
+  --text-warning: #8a6a1d;
+
+  --border-subtle: #e0e2e8;
+  --border-default: #d5d8e0;
+  --border-strong: #c4c8d2;
+  --border-focus: #aeb7d8;
+  --border-divider: rgba(31, 35, 48, 0.08);
+
+  --semantic-success-bg: #e7f0ea;
+  --semantic-success-fg: #2f7a4e;
+  --semantic-success-border: #8ec7a2;
+
+  --semantic-danger-bg: #f0e1e7;
+  --semantic-danger-fg: #9b3f5a;
+  --semantic-danger-border: #d18ba0;
+
+  --semantic-warning-bg: #f3ead2;
+  --semantic-warning-fg: #8a6a1d;
+  --semantic-warning-border: #d7bc73;
+
+  --semantic-info-bg: #e4e9f7;
+  --semantic-info-fg: #4d5f9e;
+  --semantic-info-border: #a8b7e0;
+
+  --diff-added-bg: #dde7df;
+  --diff-added-bg-soft: #e7f0ea;
+  --diff-added-fg: #2f7a4e;
+  --diff-added-border: #8ec7a2;
+
+  --diff-removed-bg: #e8d7df;
+  --diff-removed-bg-soft: #f0e1e7;
+  --diff-removed-fg: #9b3f5a;
+  --diff-removed-border: #d18ba0;
+
+  --diff-hunk-bg: #e9e7f5;
+  --diff-hunk-fg: #6b61a8;
+  --diff-hunk-border: #c8c2ea;
+
+  --font-sans:
+    -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue",
     sans-serif;
-  background: #f8fafc;
-  color: #0f172a;
+  --font-mono:
+    "SF Mono", "Menlo", "Monaco", "Consolas", "Liberation Mono", monospace;
+
+  --font-size-2xs: 10px;
+  --font-size-xs: 11px;
+  --font-size-sm: 12px;
+  --font-size-md: 13px;
+  --font-size-lg: 14px;
+  --font-size-xl: 16px;
+  --font-size-2xl: 20px;
+
+  --line-height-tight: 1.25;
+  --line-height-normal: 1.45;
+  --line-height-relaxed: 1.6;
+
+  --font-weight-regular: 400;
+  --font-weight-medium: 500;
+  --font-weight-semibold: 600;
+  --font-weight-bold: 700;
+
+  --space-0: 0;
+  --space-0_5: 2px;
+  --space-1: 4px;
+  --space-1_5: 6px;
+  --space-2: 8px;
+  --space-2_5: 10px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-10: 40px;
+  --space-12: 48px;
+
+  --radius-xs: 4px;
+  --radius-sm: 6px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-xl: 16px;
+  --radius-pill: 9999px;
+
+  --shadow-xs: 0 1px 2px rgba(31, 35, 48, 0.06);
+  --shadow-sm: 0 2px 6px rgba(31, 35, 48, 0.08);
+  --shadow-md: 0 8px 24px rgba(31, 35, 48, 0.12);
+  --shadow-lg: 0 16px 48px rgba(31, 35, 48, 0.16);
+
+  --motion-duration-fast: 120ms;
+  --motion-duration-normal: 180ms;
+  --motion-duration-slow: 240ms;
+  --motion-ease-standard: cubic-bezier(0.2, 0, 0, 1);
+  --motion-ease-out: cubic-bezier(0, 0, 0.2, 1);
+  --motion-ease-in: cubic-bezier(0.4, 0, 1, 1);
+
+  --state-hover-bg: rgba(31, 35, 48, 0.05);
+  --state-pressed-bg: rgba(31, 35, 48, 0.09);
+  --state-selected-bg: rgba(31, 35, 48, 0.07);
+  --state-focus-ring: 0 0 0 3px rgba(104, 116, 180, 0.22);
+  --opacity-disabled: 0.42;
+  --opacity-muted: 0.64;
+
+  --layout-sidebar-width: 320px;
+  --layout-topbar-height: 56px;
+  --layout-panel-min-width: 320px;
+  --layout-max-content-width: 1200px;
+
+  --icon-size-xs: 12px;
+  --icon-size-sm: 14px;
+  --icon-size-md: 16px;
+  --icon-size-lg: 20px;
+  --icon-color-default: #747783;
+  --icon-color-muted: #a9adb6;
+  --icon-color-active: #343844;
+
+  --background: var(--surface-window);
+  --foreground: var(--text-primary);
+  --card: var(--surface-card);
+  --card-foreground: var(--text-primary);
+  --popover: var(--surface-floating);
+  --popover-foreground: var(--text-primary);
+  --primary: var(--color-gray-900);
+  --primary-foreground: var(--color-white);
+  --secondary: var(--color-gray-100);
+  --secondary-foreground: var(--text-primary);
+  --muted: var(--surface-panel);
+  --muted-foreground: var(--text-secondary);
+  --accent: var(--state-hover-bg);
+  --accent-foreground: var(--text-primary);
+  --destructive: var(--semantic-danger-fg);
+  --destructive-foreground: var(--color-white);
+  --border: var(--border-default);
+  --input: var(--border-default);
+  --ring: var(--border-focus);
+  --sidebar: var(--surface-sidebar);
+  --sidebar-foreground: var(--text-primary);
+  --sidebar-accent: var(--state-selected-bg);
+  --sidebar-accent-foreground: var(--text-primary);
+  --sidebar-border: var(--border-divider);
+
+  color-scheme: light;
+  font-family: var(--font-sans);
+  background: var(--surface-window);
+  color: var(--text-primary);
+}
+
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --color-sidebar: var(--sidebar);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-border: var(--sidebar-border);
 }
 
 * {
   box-sizing: border-box;
 }
 
+html,
+body {
+  min-height: 100%;
+}
+
 body {
   margin: 0;
+  background: var(--surface-window);
+  color: var(--text-primary);
+  font-family: var(--font-sans);
+  font-size: var(--font-size-md);
+  line-height: var(--line-height-normal);
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
 }
 
 button,
 input,
 textarea {
   font: inherit;
+}
+
+::selection {
+  background: var(--semantic-info-bg);
+  color: var(--text-primary);
+}
+
+::-webkit-scrollbar {
+  height: 10px;
+  width: 10px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--color-gray-300);
+  border: 3px solid transparent;
+  border-radius: var(--radius-pill);
+  background-clip: padding-box;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--color-gray-400);
+  border: 3px solid transparent;
+  background-clip: padding-box;
 }


### PR DESCRIPTION
## Summary
- Add `DESIGN.md` with Phantom-specific UI principles for future frontend work.
- Rebuild `packages/app` around shadcn-style primitives for buttons, dialogs, inputs, textareas, badges, and sidebar layout.
- Redesign the Phantom Serve workbench with a compact project/worktree sidebar, offcanvas sidebar hiding, project creation dialog, and simplified chat timeline.
- Remove debug event rows, redundant speaker metadata, timestamps, descriptions, and worktree summary chrome from the main UI.

## Review follow-up
- Fixed the sidebar width utility to use a valid CSS custom property.
- Made the sidebar reachable on narrow viewports with a mobile offcanvas overlay instead of permanently hiding navigation.
- Added keyboard-modal behavior to the add-project dialog, including initial focus, focus return, tab cycling, Escape close, and `aria-modal`.
- Trim project paths before submit and prevent whitespace-only project creation.

## Verification
- `pnpm --filter app-private fix`
- `pnpm --filter app-private typecheck`
- `pnpm --filter app-private test`
- `pnpm --filter app-private build`
- `git diff --check`
- Sub-agent review completed and actionable findings were addressed

## Known gap
- `pnpm ready` still fails in `@phantompane/e2e#test` with 14 exit-code mismatch failures across `attach.test.ts`, `create.test.ts`, `delete.test.ts`, `list.test.ts`, and `where.test.ts`. The package-level app checks above pass.