### PR TITLE
feat: refine Phantom Serve worktree chat UX

### DIFF
--- a/packages/app/src/routes/api/projects/$projectId/chats.ts
+++ b/packages/app/src/routes/api/projects/$projectId/chats.ts
@@ -11,13 +11,22 @@ import { getServeServices } from "../../../../server/services";
 export const Route = createFileRoute("/api/projects/$projectId/chats")({
   server: {
     handlers: {
-      GET: async ({ params }: ServerRouteContext) => {
+      GET: async ({ request, params }: ServerRouteContext) => {
         try {
           if (!params.projectId) {
             throw new Error("Project id is required");
           }
-          const chats = await getServeServices().listChats(params.projectId);
-          return json({ chats });
+          const services = getServeServices();
+          const shouldSync =
+            new URL(request.url).searchParams.get("sync") === "1";
+          const worktrees = await services.listProjectWorktrees(
+            params.projectId,
+            {
+              sync: shouldSync,
+            },
+          );
+          const chats = await services.listChats(params.projectId);
+          return json({ chats, worktrees });
         } catch (error) {
           return handleApiError(error);
         }

--- a/packages/app/src/routes/index.tsx
+++ b/packages/app/src/routes/index.tsx
@@ -4,6 +4,7 @@ import {
   ChevronRight,
   Clock3,
   FolderGit2,
+  GitBranch,
   Inbox,
   MessageSquare,
   MessageSquarePlus,
@@ -12,7 +13,14 @@ import {
   Square,
 } from "lucide-react";
 import type { ReactNode } from "react";
-import { FormEvent, useEffect, useMemo, useRef, useState } from "react";
+import {
+  FormEvent,
+  KeyboardEvent,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { Badge } from "../components/ui/badge";
 import { Button } from "../components/ui/button";
 import {
@@ -52,6 +60,7 @@ import type {
   ChatRecord,
   ChatStatus,
   PhantomEvent,
+  ProjectWorktreeRecord,
   ProjectRecord,
 } from "../server/types";
 
@@ -120,6 +129,45 @@ type VisibleMessageRecord = ChatMessageRecord & {
   role: "assistant" | "error" | "user";
 };
 
+function firstProjectWorktree(
+  projectId: string | null,
+  worktreesByProject: Record<string, ProjectWorktreeRecord[]>,
+): ProjectWorktreeRecord | null {
+  if (!projectId) {
+    return null;
+  }
+  return worktreesByProject[projectId]?.[0] ?? null;
+}
+
+function formatLeadingEllipsisPath(path: string, maxLength = 44): string {
+  if (path.length <= maxLength) {
+    return path;
+  }
+
+  const suffixLength = maxLength - 3;
+  const suffix = path.slice(-suffixLength);
+  const slashIndex = suffix.indexOf("/");
+  return `...${slashIndex > 0 ? suffix.slice(slashIndex) : suffix}`;
+}
+
+function dedupeChatThreads(chats: ChatRecord[]): ChatRecord[] {
+  const chatsWithThreads = chats.filter((chat) => chat.codexThreadId);
+  const source = chatsWithThreads.length > 0 ? chatsWithThreads : chats;
+  const chatsByThread = new Map<string, ChatRecord>();
+
+  for (const chat of source) {
+    const key = chat.codexThreadId ?? chat.id;
+    const current = chatsByThread.get(key);
+    if (!current || chat.updatedAt.localeCompare(current.updatedAt) > 0) {
+      chatsByThread.set(key, chat);
+    }
+  }
+
+  return [...chatsByThread.values()].sort((left, right) =>
+    right.updatedAt.localeCompare(left.updatedAt),
+  );
+}
+
 function Home() {
   const [projects, setProjects] = useState<ProjectRecord[]>([]);
   const [selectedProjectId, setSelectedProjectId] = useState<string | null>(
@@ -128,9 +176,15 @@ function Home() {
   const [chatsByProject, setChatsByProject] = useState<
     Record<string, ChatRecord[]>
   >({});
+  const [worktreesByProject, setWorktreesByProject] = useState<
+    Record<string, ProjectWorktreeRecord[]>
+  >({});
   const [expandedProjectIds, setExpandedProjectIds] = useState<Set<string>>(
     () => new Set(),
   );
+  const [selectedWorktreePath, setSelectedWorktreePath] = useState<
+    string | null
+  >(null);
   const [selectedChatId, setSelectedChatId] = useState<string | null>(null);
   const [messages, setMessages] = useState<ChatMessageRecord[]>([]);
   const [isAddProjectOpen, setIsAddProjectOpen] = useState(false);
@@ -155,6 +209,29 @@ function Home() {
         .find((chat) => chat.id === selectedChatId) ?? null,
     [chatsByProject, selectedChatId],
   );
+  const isChatRunning = Boolean(selectedChat?.activeTurnId);
+
+  const selectedWorktree = useMemo(() => {
+    if (!selectedProjectId || !selectedWorktreePath) {
+      return null;
+    }
+    return (
+      (worktreesByProject[selectedProjectId] ?? []).find(
+        (worktree) => worktree.path === selectedWorktreePath,
+      ) ?? null
+    );
+  }, [selectedProjectId, selectedWorktreePath, worktreesByProject]);
+
+  const selectedWorktreeChats = useMemo(() => {
+    if (!selectedProjectId || !selectedWorktree) {
+      return [];
+    }
+    return dedupeChatThreads(
+      (chatsByProject[selectedProjectId] ?? []).filter(
+        (chat) => chat.worktreePath === selectedWorktree.path,
+      ),
+    );
+  }, [chatsByProject, selectedProjectId, selectedWorktree]);
 
   const visibleMessages = useMemo(
     () =>
@@ -181,7 +258,7 @@ function Home() {
       next.add(selectedProjectId);
       return next;
     });
-    void refreshChats(selectedProjectId);
+    void refreshChats(selectedProjectId, { sync: true });
   }, [selectedProjectId]);
 
   useEffect(() => {
@@ -224,18 +301,49 @@ function Home() {
     };
   }, [selectedChatId, selectedProjectId]);
 
+  useEffect(() => {
+    if (
+      selectedWorktreeChats.length === 0 ||
+      selectedWorktreeChats.some((chat) => chat.id === selectedChatId)
+    ) {
+      return;
+    }
+    setSelectedChatId(selectedWorktreeChats[0]?.id ?? null);
+  }, [selectedChatId, selectedWorktreeChats]);
+
   async function refreshProjects() {
     const data = await fetchJson<{ projects: ProjectRecord[] }>(
       "/api/projects",
     );
     setProjects(data.projects);
-    const chatEntries = await Promise.all(
+    const projectDataEntries = await Promise.all(
       data.projects.map(
-        async (project) => [project.id, await loadChats(project.id)] as const,
+        async (project) =>
+          [
+            project.id,
+            await loadProjectData(project.id, { sync: true }),
+          ] as const,
       ),
     );
-    const nextChatsByProject = Object.fromEntries(chatEntries);
+    const nextChatsByProject = Object.fromEntries(
+      projectDataEntries.map(([projectId, projectData]) => [
+        projectId,
+        projectData.chats,
+      ]),
+    );
+    const nextWorktreesByProject = Object.fromEntries(
+      projectDataEntries.map(([projectId, projectData]) => [
+        projectId,
+        projectData.worktrees,
+      ]),
+    );
     setChatsByProject(nextChatsByProject);
+    setWorktreesByProject(nextWorktreesByProject);
+    const fallbackProjectId = selectedProjectId ?? data.projects[0]?.id ?? null;
+    const fallbackWorktree = firstProjectWorktree(
+      fallbackProjectId,
+      nextWorktreesByProject,
+    );
     setSelectedProjectId((current) => {
       const nextProjectId = current ?? data.projects[0]?.id ?? null;
       if (nextProjectId) {
@@ -247,32 +355,64 @@ function Home() {
       }
       return nextProjectId;
     });
+    setSelectedWorktreePath((current) => {
+      if (
+        fallbackProjectId &&
+        current &&
+        (nextWorktreesByProject[fallbackProjectId] ?? []).some(
+          (worktree) => worktree.path === current,
+        )
+      ) {
+        return current;
+      }
+      return fallbackWorktree?.path ?? null;
+    });
     setSelectedChatId((current) =>
       Object.values(nextChatsByProject)
         .flat()
         .some((chat) => chat.id === current)
         ? current
-        : null,
+        : (fallbackWorktree?.chatId ?? null),
     );
   }
 
-  async function loadChats(projectId: string) {
-    const data = await fetchJson<{ chats: ChatRecord[] }>(
-      `/api/projects/${projectId}/chats`,
-    );
-    return data.chats;
+  async function loadProjectData(
+    projectId: string,
+    options: { sync?: boolean } = {},
+  ) {
+    return await fetchJson<{
+      chats: ChatRecord[];
+      worktrees: ProjectWorktreeRecord[];
+    }>(`/api/projects/${projectId}/chats${options.sync ? "?sync=1" : ""}`);
   }
 
-  async function refreshChats(projectId: string) {
-    const nextChats = await loadChats(projectId);
+  async function refreshChats(
+    projectId: string,
+    options: { sync?: boolean } = {},
+  ) {
+    const projectData = await loadProjectData(projectId, options);
     setChatsByProject((current) => ({
       ...current,
-      [projectId]: nextChats,
+      [projectId]: projectData.chats,
     }));
-    setSelectedChatId((current) =>
-      nextChats.some((chat) => chat.id === current)
+    setWorktreesByProject((current) => ({
+      ...current,
+      [projectId]: projectData.worktrees,
+    }));
+    const fallbackWorktree = firstProjectWorktree(projectId, {
+      ...worktreesByProject,
+      [projectId]: projectData.worktrees,
+    });
+    setSelectedWorktreePath((current) =>
+      current &&
+      projectData.worktrees.some((worktree) => worktree.path === current)
         ? current
-        : (nextChats[0]?.id ?? null),
+        : (fallbackWorktree?.path ?? null),
+    );
+    setSelectedChatId((current) =>
+      projectData.chats.some((chat) => chat.id === current)
+        ? current
+        : (fallbackWorktree?.chatId ?? null),
     );
   }
 
@@ -287,6 +427,19 @@ function Home() {
         ),
       };
     });
+    setWorktreesByProject((current) => ({
+      ...current,
+      [data.chat.projectId]: (current[data.chat.projectId] ?? []).map(
+        (worktree) =>
+          worktree.chatId === chatId
+            ? {
+                ...worktree,
+                chatStatus: data.chat.status,
+                chatTitle: data.chat.title,
+              }
+            : worktree,
+      ),
+    }));
   }
 
   async function refreshMessages(chatId: string) {
@@ -342,7 +495,8 @@ function Home() {
       );
       setSelectedProjectId(projectId);
       setExpandedProjectIds((current) => new Set(current).add(projectId));
-      await refreshChats(projectId);
+      await refreshChats(projectId, { sync: true });
+      setSelectedWorktreePath(data.chat.worktreePath);
       setSelectedChatId(data.chat.id);
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
@@ -370,6 +524,26 @@ function Home() {
       setComposerText(text);
       setError(err instanceof Error ? err.message : String(err));
     }
+  }
+
+  function handleComposerKeyDown(event: KeyboardEvent<HTMLTextAreaElement>) {
+    const isImeComposing =
+      event.nativeEvent.isComposing || event.keyCode === 229;
+    if (
+      event.key !== "Enter" ||
+      event.shiftKey ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.altKey ||
+      isImeComposing
+    ) {
+      return;
+    }
+    if (!selectedChatId || !composerText.trim() || isChatRunning) {
+      return;
+    }
+    event.preventDefault();
+    event.currentTarget.form?.requestSubmit();
   }
 
   async function interruptChat() {
@@ -416,21 +590,11 @@ function Home() {
     });
   }
 
-  function selectProject(projectId: string) {
+  function selectWorktree(projectId: string, worktree: ProjectWorktreeRecord) {
     setSelectedProjectId(projectId);
+    setSelectedWorktreePath(worktree.path);
+    setSelectedChatId(worktree.chatId);
     setExpandedProjectIds((current) => new Set(current).add(projectId));
-    const projectChats = chatsByProject[projectId] ?? [];
-    setSelectedChatId((current) =>
-      projectChats.some((chat) => chat.id === current)
-        ? current
-        : (projectChats[0]?.id ?? null),
-    );
-  }
-
-  function selectChat(chat: ChatRecord) {
-    setSelectedProjectId(chat.projectId);
-    setSelectedChatId(chat.id);
-    setExpandedProjectIds((current) => new Set(current).add(chat.projectId));
   }
 
   return (
@@ -478,43 +642,25 @@ function Home() {
                     const isProjectExpanded = expandedProjectIds.has(
                       project.id,
                     );
-                    const isProjectSelected = project.id === selectedProjectId;
-                    const projectChats = chatsByProject[project.id] ?? [];
+                    const projectWorktrees =
+                      worktreesByProject[project.id] ?? [];
 
                     return (
                       <SidebarMenuItem key={project.id}>
-                        <div
-                          className={cn(
-                            "group/project flex items-center rounded-[var(--radius-sm)]",
-                            isProjectSelected && "bg-sidebar-accent",
-                          )}
-                        >
-                          <Button
-                            aria-label={
-                              isProjectExpanded
-                                ? "Collapse project"
-                                : "Expand project"
-                            }
-                            className="ml-1 size-7 text-[var(--icon-color-default)] group-data-[state=collapsed]/sidebar:hidden"
-                            onClick={() => toggleProject(project.id)}
-                            size="icon"
-                            type="button"
-                            variant="ghost"
-                          >
-                            <ChevronRight
-                              className={cn(
-                                "transition-transform duration-[var(--motion-duration-fast)]",
-                                isProjectExpanded && "rotate-90",
-                              )}
-                            />
-                          </Button>
+                        <div className="group/project flex items-center rounded-[var(--radius-sm)]">
                           <SidebarMenuButton
+                            aria-expanded={isProjectExpanded}
                             className="min-h-8 flex-1 group-data-[state=collapsed]/sidebar:flex-none"
-                            isActive={isProjectSelected}
-                            onClick={() => selectProject(project.id)}
+                            onClick={() => toggleProject(project.id)}
                             title={project.name}
                             type="button"
                           >
+                            <ChevronRight
+                              className={cn(
+                                "size-4 shrink-0 text-[var(--icon-color-default)] transition-transform duration-[var(--motion-duration-fast)] group-data-[state=collapsed]/sidebar:hidden",
+                                isProjectExpanded && "rotate-90",
+                              )}
+                            />
                             <FolderGit2 className="size-4 text-[var(--icon-color-default)]" />
                             <span className="min-w-0 flex-1 group-data-[state=collapsed]/sidebar:hidden">
                               <span className="block truncate font-medium">
@@ -537,26 +683,37 @@ function Home() {
                         </div>
                         {isProjectExpanded && (
                           <SidebarMenuSub>
-                            {projectChats.length === 0 ? (
+                            {projectWorktrees.length === 0 ? (
                               <li className="px-2 py-1.5 text-[length:var(--font-size-xs)] text-[var(--text-tertiary)]">
                                 No worktrees
                               </li>
                             ) : (
-                              projectChats.map((chat) => {
+                              projectWorktrees.map((worktree) => {
+                                const title = `${worktree.name} (${worktree.path})${
+                                  worktree.isClean ? "" : " [dirty]"
+                                }`;
                                 return (
-                                  <SidebarMenuSubItem key={chat.id}>
+                                  <SidebarMenuSubItem key={worktree.path}>
                                     <SidebarMenuSubButton
-                                      isActive={chat.id === selectedChatId}
-                                      onClick={() => selectChat(chat)}
-                                      title={chat.title}
+                                      disabled={!worktree.chatId}
+                                      isActive={
+                                        worktree.path === selectedWorktreePath
+                                      }
+                                      onClick={() =>
+                                        selectWorktree(project.id, worktree)
+                                      }
+                                      title={title}
                                       type="button"
                                     >
-                                      <MessageSquare className="size-3.5 text-[var(--icon-color-default)]" />
+                                      <GitBranch className="size-3.5 text-[var(--icon-color-default)]" />
                                       <span className="min-w-0 flex-1">
                                         <span className="block truncate font-medium">
-                                          {chat.title}
+                                          {worktree.name}
                                         </span>
                                       </span>
+                                      {!worktree.isClean && (
+                                        <span className="size-1.5 shrink-0 rounded-full bg-[var(--semantic-warning-fg)]" />
+                                      )}
                                     </SidebarMenuSubButton>
                                   </SidebarMenuSubItem>
                                 );
@@ -617,25 +774,20 @@ function Home() {
           <div className="min-w-0 flex-1">
             <div className="flex min-w-0 items-center gap-2">
               <p className="truncate text-[length:var(--font-size-xl)] font-semibold leading-tight">
-                {selectedChat?.title ?? "Workspace"}
+                {selectedWorktree?.name ?? selectedProject?.name ?? "Workspace"}
               </p>
               {selectedChat && <StatusBadge status={selectedChat.status} />}
             </div>
-            <p className="truncate text-[length:var(--font-size-xs)] text-muted-foreground">
-              {selectedProject?.name ?? "No project selected"}
-              {selectedChat ? ` / ${selectedChat.branchName}` : ""}
+            <p className="flex min-w-0 text-[length:var(--font-size-xs)] text-muted-foreground">
+              <span className="shrink-0">
+                {selectedProject?.name ?? "No project selected"}
+                {selectedWorktree ? " / " : ""}
+              </span>
+              {selectedWorktree && (
+                <LeadingEllipsisText text={selectedWorktree.path} />
+              )}
             </p>
           </div>
-          <Button
-            disabled={!selectedChat?.activeTurnId}
-            onClick={interruptChat}
-            size="sm"
-            type="button"
-            variant="outline"
-          >
-            <Square className="size-3" />
-            Stop
-          </Button>
         </header>
 
         {error && (
@@ -686,17 +838,20 @@ function Home() {
           </div>
         )}
 
+        {selectedWorktree && (
+          <ChatHistoryBar
+            chats={selectedWorktreeChats}
+            selectedChatId={selectedChatId}
+            onSelectChat={setSelectedChatId}
+          />
+        )}
+
         <section className="min-h-0 flex-1 overflow-y-auto px-4 py-4">
           {visibleMessages.length === 0 ? (
             <EmptyTimeline
               hasChat={Boolean(selectedChat)}
-              isBusy={isBusy}
+              hasWorktree={Boolean(selectedWorktree)}
               selectedProject={selectedProject}
-              onCreateChat={
-                selectedProject
-                  ? () => void createChat(selectedProject.id)
-                  : undefined
-              }
               onOpenProjectDialog={() => setIsAddProjectOpen(true)}
             />
           ) : (
@@ -729,22 +884,83 @@ function Home() {
                 rows={2}
                 value={composerText}
                 onChange={(event) => setComposerText(event.target.value)}
+                onKeyDown={handleComposerKeyDown}
               />
             </div>
             <Button
-              aria-label="Send message"
+              aria-label={isChatRunning ? "Stop turn" : "Send message"}
               className="size-10"
-              disabled={!selectedChatId || !composerText.trim()}
+              disabled={
+                isChatRunning
+                  ? !selectedChat?.activeTurnId
+                  : !selectedChatId || !composerText.trim()
+              }
+              onClick={isChatRunning ? interruptChat : undefined}
               size="icon"
-              title="Send"
-              type="submit"
+              title={isChatRunning ? "Stop turn" : "Send"}
+              type={isChatRunning ? "button" : "submit"}
+              variant={isChatRunning ? "destructive" : "default"}
             >
-              <Send />
+              {isChatRunning ? <Square /> : <Send />}
             </Button>
           </div>
         </form>
       </SidebarInset>
     </SidebarProvider>
+  );
+}
+
+function ChatHistoryBar({
+  chats,
+  onSelectChat,
+  selectedChatId,
+}: {
+  chats: ChatRecord[];
+  onSelectChat: (chatId: string) => void;
+  selectedChatId: string | null;
+}) {
+  return (
+    <div className="border-b border-border bg-[var(--surface-panel)] px-4 py-2">
+      <div className="mx-auto flex max-w-[var(--layout-max-content-width)] items-center gap-2">
+        <div className="shrink-0 text-[length:var(--font-size-xs)] font-medium text-[var(--text-secondary)]">
+          Chat history
+        </div>
+        <div
+          aria-label="Chat history"
+          className="flex min-w-0 flex-1 gap-1 overflow-x-auto"
+          role="tablist"
+        >
+          {chats.length === 0 ? (
+            <span className="px-2 py-1 text-[length:var(--font-size-xs)] text-[var(--text-tertiary)]">
+              No chat history
+            </span>
+          ) : (
+            chats.map((chat) => {
+              const isSelected = chat.id === selectedChatId;
+              return (
+                <button
+                  aria-selected={isSelected}
+                  className={cn(
+                    "inline-flex max-w-44 shrink-0 items-center gap-1.5 rounded-[var(--radius-sm)] px-2 py-1 text-[length:var(--font-size-xs)] outline-none transition-colors hover:bg-sidebar-accent focus-visible:shadow-[var(--state-focus-ring)]",
+                    isSelected
+                      ? "bg-sidebar-accent text-sidebar-accent-foreground"
+                      : "text-[var(--text-secondary)]",
+                  )}
+                  key={chat.id}
+                  onClick={() => onSelectChat(chat.id)}
+                  role="tab"
+                  title={chat.title}
+                  type="button"
+                >
+                  <MessageSquare className="size-3.5 shrink-0" />
+                  <span className="truncate">{chat.title}</span>
+                </button>
+              );
+            })
+          )}
+        </div>
+      </div>
+    </div>
   );
 }
 
@@ -755,6 +971,14 @@ function StatusBadge({ status }: { status: ChatStatus }) {
       <span className={cn("size-1.5 rounded-full", meta.dot)} />
       {meta.label}
     </Badge>
+  );
+}
+
+function LeadingEllipsisText({ text }: { text: string }) {
+  return (
+    <span className="block min-w-0 truncate" title={text}>
+      {formatLeadingEllipsisPath(text)}
+    </span>
   );
 }
 
@@ -787,14 +1011,12 @@ function SystemBanner({
 
 function EmptyTimeline({
   hasChat,
-  isBusy,
-  onCreateChat,
+  hasWorktree,
   onOpenProjectDialog,
   selectedProject,
 }: {
   hasChat: boolean;
-  isBusy: boolean;
-  onCreateChat?: () => void;
+  hasWorktree: boolean;
   onOpenProjectDialog: () => void;
   selectedProject: ProjectRecord | null;
 }) {
@@ -806,27 +1028,28 @@ function EmptyTimeline({
         </div>
         <div>
           <h2 className="text-[length:var(--font-size-xl)] font-semibold">
-            {hasChat ? "No messages yet" : "Select a worktree"}
+            {hasChat
+              ? "No messages yet"
+              : hasWorktree
+                ? "Select chat history"
+                : "Select a worktree"}
           </h2>
           <p className="mt-1 text-[length:var(--font-size-md)] text-muted-foreground">
             {hasChat
               ? "Send a message to start a focused Codex session."
-              : "Create a worktree under a project to begin a Codex session."}
+              : hasWorktree
+                ? "Choose a chat history for this worktree."
+                : "Create a worktree under a project to begin a Codex session."}
           </p>
         </div>
-        <div className="flex justify-center gap-2">
-          {selectedProject ? (
-            <Button disabled={isBusy} onClick={onCreateChat} type="button">
-              <MessageSquarePlus className="size-4" />
-              Create worktree
-            </Button>
-          ) : (
+        {!selectedProject && (
+          <div className="flex justify-center gap-2">
             <Button onClick={onOpenProjectDialog} type="button">
               <Plus className="size-4" />
               Add project
             </Button>
-          )}
-        </div>
+          </div>
+        )}
       </section>
     </div>
   );

--- a/packages/app/src/server/codex-history.test.ts
+++ b/packages/app/src/server/codex-history.test.ts
@@ -1,0 +1,217 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, it } from "vitest";
+import { listCodexSessionsForWorktrees } from "./codex-history";
+
+const temporaryDirectories: string[] = [];
+
+async function createTemporaryDirectory(): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), "phantom-codex-history-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+async function writeCodexSessionFile(
+  codexHome: string,
+  fileName: string,
+  lines: Array<Record<string, unknown>>,
+): Promise<string> {
+  const directory = join(codexHome, "archived_sessions");
+  await mkdir(directory, { recursive: true });
+  const path = join(directory, fileName);
+  await writeFile(
+    path,
+    `${lines.map((line) => JSON.stringify(line)).join("\n")}\n`,
+  );
+  return path;
+}
+
+function createSessionLines({
+  message,
+  sessionId,
+  timestamp,
+  title,
+  worktreePath,
+}: {
+  message: string;
+  sessionId: string;
+  timestamp: string;
+  title: string;
+  worktreePath: string;
+}): Array<Record<string, unknown>> {
+  return [
+    {
+      timestamp,
+      type: "session_meta",
+      payload: {
+        id: sessionId,
+        timestamp,
+        cwd: worktreePath,
+        source: "vscode",
+      },
+    },
+    {
+      timestamp,
+      type: "event_msg",
+      payload: {
+        type: "thread_name_updated",
+        thread_name: title,
+      },
+    },
+    {
+      timestamp,
+      type: "response_item",
+      payload: {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: message }],
+      },
+    },
+  ];
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+describe("listCodexSessionsForWorktrees", () => {
+  it("deduplicates multiple history files for the same Codex thread", async () => {
+    const codexHome = await createTemporaryDirectory();
+    const sessionId = "019dc000-0000-7000-8000-000000000001";
+    const worktreePath = "/repo/.git/phantom/worktrees/feature";
+    await writeCodexSessionFile(
+      codexHome,
+      "rollout-2026-04-25T00-00-00-019dc000-0000-7000-8000-000000000001.jsonl",
+      createSessionLines({
+        message: "old message",
+        sessionId,
+        timestamp: "2026-04-25T00:00:00.000Z",
+        title: "old title",
+        worktreePath,
+      }),
+    );
+    await writeCodexSessionFile(
+      codexHome,
+      "rollout-2026-04-25T00-05-00-019dc000-0000-7000-8000-000000000001.jsonl",
+      createSessionLines({
+        message: "new message",
+        sessionId,
+        timestamp: "2026-04-25T00:05:00.000Z",
+        title: "new title",
+        worktreePath,
+      }),
+    );
+
+    const sessions = await listCodexSessionsForWorktrees({
+      codexHome,
+      projectId: "proj_1",
+      worktrees: [
+        {
+          branchName: "feature",
+          worktreeName: "feature",
+          worktreePath,
+        },
+      ],
+    });
+
+    strictEqual(sessions.length, 1);
+    strictEqual(sessions[0]?.chat.id, `chat_codex_${sessionId}`);
+    strictEqual(sessions[0]?.chat.title, "new title");
+    deepStrictEqual(
+      sessions[0]?.messages.map((message) => message.text),
+      ["new message"],
+    );
+  });
+
+  it("skips unreadable Codex history files", async () => {
+    const codexHome = await createTemporaryDirectory();
+    const worktreePath = "/repo/.git/phantom/worktrees/feature";
+    const unreadablePath = await writeCodexSessionFile(
+      codexHome,
+      "rollout-2026-04-25T00-00-00-019dc000-0000-7000-8000-000000000001.jsonl",
+      createSessionLines({
+        message: "unreadable message",
+        sessionId: "019dc000-0000-7000-8000-000000000001",
+        timestamp: "2026-04-25T00:00:00.000Z",
+        title: "unreadable",
+        worktreePath,
+      }),
+    );
+    await writeCodexSessionFile(
+      codexHome,
+      "rollout-2026-04-25T00-05-00-019dc000-0000-7000-8000-000000000002.jsonl",
+      createSessionLines({
+        message: "readable message",
+        sessionId: "019dc000-0000-7000-8000-000000000002",
+        timestamp: "2026-04-25T00:05:00.000Z",
+        title: "readable",
+        worktreePath,
+      }),
+    );
+    await chmod(unreadablePath, 0);
+
+    const sessions = await listCodexSessionsForWorktrees({
+      codexHome,
+      projectId: "proj_1",
+      worktrees: [
+        {
+          branchName: "feature",
+          worktreeName: "feature",
+          worktreePath,
+        },
+      ],
+    });
+
+    strictEqual(sessions.length, 1);
+    strictEqual(sessions[0]?.chat.title, "readable");
+  });
+
+  it("strips Codex context preambles without dropping the user prompt", async () => {
+    const codexHome = await createTemporaryDirectory();
+    const worktreePath = "/repo/.git/phantom/worktrees/feature";
+    await writeCodexSessionFile(
+      codexHome,
+      "rollout-2026-04-25T00-00-00-019dc000-0000-7000-8000-000000000001.jsonl",
+      createSessionLines({
+        message: [
+          "# AGENTS.md instructions for /repo",
+          "",
+          "<INSTRUCTIONS>",
+          "Do the project-specific setup.",
+          "</INSTRUCTIONS>",
+          "<environment_context>",
+          "<cwd>/repo</cwd>",
+          "</environment_context>",
+          "Please implement the feature.",
+        ].join("\n"),
+        sessionId: "019dc000-0000-7000-8000-000000000001",
+        timestamp: "2026-04-25T00:00:00.000Z",
+        title: "Context import",
+        worktreePath,
+      }),
+    );
+
+    const sessions = await listCodexSessionsForWorktrees({
+      codexHome,
+      projectId: "proj_1",
+      worktrees: [
+        {
+          branchName: "feature",
+          worktreeName: "feature",
+          worktreePath,
+        },
+      ],
+    });
+
+    deepStrictEqual(
+      sessions[0]?.messages.map((message) => message.text),
+      ["Please implement the feature."],
+    );
+  });
+});

--- a/packages/app/src/server/codex-history.ts
+++ b/packages/app/src/server/codex-history.ts
@@ -1,0 +1,361 @@
+import { readdir, readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { basename, join } from "node:path";
+import type { ChatMessageRecord, ChatRecord } from "./types";
+
+interface CodexHistoryOptions {
+  branchName: string;
+  codexHome?: string;
+  projectId: string;
+  worktreeName: string;
+  worktreePath: string;
+}
+
+interface CodexHistoryWorktree {
+  branchName: string;
+  worktreeName: string;
+  worktreePath: string;
+}
+
+interface CodexProjectHistoryOptions {
+  codexHome?: string;
+  projectId: string;
+  worktrees: CodexHistoryWorktree[];
+}
+
+export interface ImportedCodexSession {
+  chat: ChatRecord;
+  messages: ChatMessageRecord[];
+}
+
+interface ParsedCodexSession {
+  createdAt: string;
+  messages: Array<{
+    createdAt: string;
+    role: "assistant" | "user";
+    text: string;
+  }>;
+  sessionId: string;
+  title: string;
+  updatedAt: string;
+  worktreePath: string;
+}
+
+export async function listCodexSessionsForWorktree({
+  branchName,
+  codexHome = getDefaultCodexHome(),
+  projectId,
+  worktreeName,
+  worktreePath,
+}: CodexHistoryOptions): Promise<ImportedCodexSession[]> {
+  return await listCodexSessionsForWorktrees({
+    codexHome,
+    projectId,
+    worktrees: [{ branchName, worktreeName, worktreePath }],
+  });
+}
+
+export async function listCodexSessionsForWorktrees({
+  codexHome = getDefaultCodexHome(),
+  projectId,
+  worktrees,
+}: CodexProjectHistoryOptions): Promise<ImportedCodexSession[]> {
+  const files = await listCodexSessionFiles(codexHome);
+  const worktreeByPath = new Map(
+    worktrees.map((worktree) => [worktree.worktreePath, worktree]),
+  );
+  const parsedSessionsById = new Map<string, ParsedCodexSession>();
+
+  for (const file of files) {
+    const session = await parseCodexSession(file);
+    if (!session || !worktreeByPath.has(session.worktreePath)) {
+      continue;
+    }
+
+    const existingSession = parsedSessionsById.get(session.sessionId);
+    if (
+      !existingSession ||
+      existingSession.updatedAt.localeCompare(session.updatedAt) < 0
+    ) {
+      parsedSessionsById.set(session.sessionId, session);
+    }
+  }
+
+  return Array.from(parsedSessionsById.values())
+    .map((session) =>
+      createImportedCodexSession({
+        projectId,
+        session,
+        worktree: worktreeByPath.get(session.worktreePath)!,
+      }),
+    )
+    .sort((left, right) =>
+      right.chat.updatedAt.localeCompare(left.chat.updatedAt),
+    );
+}
+
+function getDefaultCodexHome(): string {
+  return process.env.CODEX_HOME ?? join(homedir(), ".codex");
+}
+
+async function listCodexSessionFiles(codexHome: string): Promise<string[]> {
+  const roots = [
+    join(codexHome, "sessions"),
+    join(codexHome, "archived_sessions"),
+  ];
+  const files = await Promise.all(roots.map((root) => listJsonlFiles(root)));
+  return files.flat();
+}
+
+async function listJsonlFiles(root: string): Promise<string[]> {
+  let entries;
+  try {
+    entries = await readdir(root, { withFileTypes: true });
+  } catch (error) {
+    if (isIgnorableHistoryRootError(error)) {
+      return [];
+    }
+    throw error;
+  }
+
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const path = join(root, entry.name);
+      if (entry.isDirectory()) {
+        return await listJsonlFiles(path);
+      }
+      return entry.isFile() && entry.name.endsWith(".jsonl") ? [path] : [];
+    }),
+  );
+  return files.flat();
+}
+
+async function parseCodexSession(
+  path: string,
+): Promise<ParsedCodexSession | null> {
+  let content;
+  try {
+    content = await readFile(path, "utf8");
+  } catch (error) {
+    if (isIgnorableHistoryFileError(error)) {
+      return null;
+    }
+    throw error;
+  }
+
+  let sessionId = sessionIdFromPath(path);
+  let worktreePath: string | null = null;
+  let createdAt: string | null = null;
+  let updatedAt: string | null = null;
+  let title: string | null = null;
+  let isSubagentSession = false;
+  const messages: ParsedCodexSession["messages"] = [];
+
+  for (const line of content.split(/\n/)) {
+    if (!line.trim()) {
+      continue;
+    }
+
+    const event = parseJsonObject(line);
+    const timestamp = getString(event?.timestamp);
+    if (timestamp) {
+      createdAt ??= timestamp;
+      updatedAt = timestamp;
+    }
+
+    if (event?.type === "session_meta") {
+      const payload = getObject(event.payload);
+      sessionId = getString(payload?.id) ?? sessionId;
+      worktreePath = getString(payload?.cwd) ?? worktreePath;
+      createdAt = getString(payload?.timestamp) ?? createdAt;
+      isSubagentSession = Boolean(getObject(payload?.source)?.subagent);
+      continue;
+    }
+
+    if (event?.type === "event_msg") {
+      const payload = getObject(event.payload);
+      if (payload?.type === "thread_name_updated") {
+        title = getString(payload.thread_name) ?? title;
+      }
+      continue;
+    }
+
+    if (event?.type !== "response_item") {
+      continue;
+    }
+
+    const payload = getObject(event.payload);
+    if (payload?.type !== "message") {
+      continue;
+    }
+
+    const role = payload.role;
+    if (role !== "assistant" && role !== "user") {
+      continue;
+    }
+
+    const text =
+      role === "user"
+        ? stripCodexContextPreamble(extractMessageText(payload.content))
+        : extractMessageText(payload.content);
+    if (!text) {
+      continue;
+    }
+
+    messages.push({
+      createdAt:
+        timestamp ?? updatedAt ?? createdAt ?? new Date(0).toISOString(),
+      role,
+      text,
+    });
+    title ??= role === "user" ? truncateTitle(text) : null;
+  }
+
+  if (isSubagentSession || !sessionId || !worktreePath) {
+    return null;
+  }
+
+  return {
+    createdAt: createdAt ?? new Date(0).toISOString(),
+    messages,
+    sessionId,
+    title: title ?? sessionId.slice(0, 8),
+    updatedAt: updatedAt ?? createdAt ?? new Date(0).toISOString(),
+    worktreePath,
+  };
+}
+
+function createImportedCodexSession({
+  projectId,
+  session,
+  worktree,
+}: {
+  projectId: string;
+  session: ParsedCodexSession;
+  worktree: CodexHistoryWorktree;
+}): ImportedCodexSession {
+  const chatId = createImportedChatId(session.sessionId);
+  return {
+    chat: {
+      id: chatId,
+      projectId,
+      worktreeName: worktree.worktreeName,
+      worktreePath: worktree.worktreePath,
+      branchName: worktree.branchName,
+      codexThreadId: session.sessionId,
+      title: session.title,
+      status: "idle",
+      activeTurnId: null,
+      createdAt: session.createdAt,
+      updatedAt: session.updatedAt,
+    },
+    messages: session.messages.map((message, index) => ({
+      id: `${chatId}_msg_${index}`,
+      chatId,
+      role: message.role,
+      text: message.text,
+      createdAt: message.createdAt,
+    })),
+  };
+}
+
+function createImportedChatId(sessionId: string): string {
+  return `chat_codex_${sessionId}`;
+}
+
+function sessionIdFromPath(path: string): string {
+  return basename(path)
+    .replace(/^rollout-/, "")
+    .replace(/\.jsonl$/, "");
+}
+
+function extractMessageText(content: unknown): string {
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  return content
+    .map((item) => {
+      const object = getObject(item);
+      return getString(object?.text) ?? "";
+    })
+    .filter(Boolean)
+    .join("\n\n")
+    .trim();
+}
+
+function stripCodexContextPreamble(text: string): string {
+  let strippedText = text.trimStart();
+
+  while (true) {
+    if (strippedText.startsWith("# AGENTS.md instructions")) {
+      const instructionsEnd = strippedText.indexOf("</INSTRUCTIONS>");
+      if (instructionsEnd === -1) {
+        return "";
+      }
+      strippedText = strippedText
+        .slice(instructionsEnd + "</INSTRUCTIONS>".length)
+        .trimStart();
+      continue;
+    }
+
+    if (strippedText.startsWith("<environment_context>")) {
+      const contextEnd = strippedText.indexOf("</environment_context>");
+      if (contextEnd === -1) {
+        return "";
+      }
+      strippedText = strippedText
+        .slice(contextEnd + "</environment_context>".length)
+        .trimStart();
+      continue;
+    }
+
+    return strippedText.trim();
+  }
+}
+
+function truncateTitle(text: string): string {
+  const firstLine = text.trim().split(/\n/)[0] ?? "";
+  return firstLine.length > 32 ? `${firstLine.slice(0, 31)}...` : firstLine;
+}
+
+function parseJsonObject(line: string): Record<string, unknown> | null {
+  try {
+    return getObject(JSON.parse(line));
+  } catch {
+    return null;
+  }
+}
+
+function getObject(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function getString(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function isIgnorableHistoryFileError(error: unknown): boolean {
+  return Boolean(
+    error &&
+    typeof error === "object" &&
+    "code" in error &&
+    (error.code === "ENOENT" ||
+      error.code === "ENOTDIR" ||
+      error.code === "EACCES" ||
+      error.code === "EPERM"),
+  );
+}
+
+function isIgnorableHistoryRootError(error: unknown): boolean {
+  return Boolean(
+    error &&
+    typeof error === "object" &&
+    "code" in error &&
+    (error.code === "ENOENT" ||
+      error.code === "ENOTDIR" ||
+      error.code === "EACCES" ||
+      error.code === "EPERM"),
+  );
+}

--- a/packages/app/src/server/services.test.ts
+++ b/packages/app/src/server/services.test.ts
@@ -1,5 +1,5 @@
 import { deepStrictEqual, rejects, strictEqual } from "node:assert";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, it, vi } from "vitest";
@@ -10,6 +10,7 @@ import type { ChatRecord, ProjectRecord, ServeState } from "./types";
 
 const coreMocks = vi.hoisted(() => ({
   deleteBranch: vi.fn(),
+  listWorktrees: vi.fn(),
   removeWorktree: vi.fn(),
   runCreateWorktree: vi.fn(),
 }));
@@ -118,14 +119,599 @@ async function createHarness(state: ServeState): Promise<{
   const store = new ServeStateStore(await createTemporaryDirectory());
   await store.save(state);
   const codex = new FakeCodexBridge();
+  const codexHome = await createTemporaryDirectory();
   const services = new ServeServices({
     codex: codex as unknown as CodexBridge,
+    codexHome,
     store,
   });
   return { codex, services, store };
 }
 
+class ImportRaceStore extends ServeStateStore {
+  private hasInjectedState = false;
+
+  constructor(
+    dataDir: string,
+    private readonly injectState: (state: ServeState) => ServeState,
+  ) {
+    super(dataDir);
+  }
+
+  override async update(
+    updater: (state: ServeState) => ServeState | Promise<ServeState>,
+  ): Promise<ServeState> {
+    if (!this.hasInjectedState) {
+      this.hasInjectedState = true;
+      await this.save(this.injectState(await this.load()));
+    }
+    return await super.update(updater);
+  }
+}
+
+async function writeCodexSession(
+  codexHome: string,
+  lines: Array<Record<string, unknown>>,
+  fileName = "rollout-2026-04-25T00-00-00-019dc000-0000-7000-8000-000000000001.jsonl",
+): Promise<void> {
+  const directory = join(codexHome, "archived_sessions");
+  await mkdir(directory, { recursive: true });
+  await writeFile(
+    join(directory, fileName),
+    `${lines.map((line) => JSON.stringify(line)).join("\n")}\n`,
+  );
+}
+
 describe("ServeServices", () => {
+  it("lists project worktrees with phantom list data and creates missing chat records", async () => {
+    const state = {
+      ...createEmptyState(),
+      projects: [createProject()],
+    };
+    const { services, store } = await createHarness(state);
+    coreMocks.listWorktrees.mockResolvedValueOnce({
+      ok: true,
+      value: {
+        worktrees: [
+          {
+            name: "main",
+            path: "/repo",
+            pathToDisplay: ".",
+            branch: "main",
+            isClean: true,
+          },
+          {
+            name: "feature/list",
+            path: "/repo/.git/phantom/worktrees/feature/list",
+            pathToDisplay: ".git/phantom/worktrees/feature/list",
+            branch: "feature/list",
+            isClean: false,
+          },
+        ],
+      },
+    });
+
+    const worktrees = await services.listProjectWorktrees("proj_1");
+
+    deepStrictEqual(
+      worktrees.map((worktree) => ({
+        name: worktree.name,
+        path: worktree.path,
+        pathToDisplay: worktree.pathToDisplay,
+        isClean: worktree.isClean,
+        chatStatus: worktree.chatStatus,
+      })),
+      [
+        {
+          name: "main",
+          path: "/repo",
+          pathToDisplay: ".",
+          isClean: true,
+          chatStatus: "idle",
+        },
+        {
+          name: "feature/list",
+          path: "/repo/.git/phantom/worktrees/feature/list",
+          pathToDisplay: ".git/phantom/worktrees/feature/list",
+          isClean: false,
+          chatStatus: "idle",
+        },
+      ],
+    );
+    strictEqual(
+      worktrees.every((worktree) => worktree.chatId),
+      true,
+    );
+
+    const savedState = await store.load();
+    deepStrictEqual(
+      savedState.chats.map((chat) => chat.worktreePath),
+      ["/repo", "/repo/.git/phantom/worktrees/feature/list"],
+    );
+  });
+
+  it("does not persist state when worktree sync has no changes", async () => {
+    const state = {
+      ...createEmptyState(),
+      projects: [createProject()],
+      chats: [createChat({ worktreeName: "main", worktreePath: "/repo" })],
+    };
+    const { services, store } = await createHarness(state);
+    const saveSpy = vi.spyOn(store, "save");
+    coreMocks.listWorktrees.mockResolvedValueOnce({
+      ok: true,
+      value: {
+        worktrees: [
+          {
+            name: "main",
+            path: "/repo",
+            pathToDisplay: ".",
+            branch: "main",
+            isClean: true,
+          },
+        ],
+      },
+    });
+
+    const worktrees = await services.listProjectWorktrees("proj_1");
+
+    strictEqual(worktrees[0]?.chatId, "chat_1");
+    strictEqual(saveSpy.mock.calls.length, 0);
+  });
+
+  it("falls back to persisted chats when live worktree listing fails", async () => {
+    const state = {
+      ...createEmptyState(),
+      projects: [createProject()],
+      chats: [
+        createChat({
+          branchName: "main",
+          title: "Persisted main",
+          worktreeName: "main",
+          worktreePath: "/repo",
+        }),
+      ],
+    };
+    const { services } = await createHarness(state);
+    coreMocks.listWorktrees.mockRejectedValueOnce(new Error("git failed"));
+
+    const worktrees = await services.listProjectWorktrees("proj_1");
+
+    deepStrictEqual(worktrees, [
+      {
+        name: "main",
+        path: "/repo",
+        pathToDisplay: "/repo",
+        branch: "main",
+        isClean: true,
+        chatId: "chat_1",
+        chatStatus: "idle",
+        chatTitle: "Persisted main",
+      },
+    ]);
+  });
+
+  it("imports existing Codex chat history for project worktrees", async () => {
+    const state = {
+      ...createEmptyState(),
+      projects: [createProject()],
+    };
+    const store = new ServeStateStore(await createTemporaryDirectory());
+    await store.save(state);
+    const codex = new FakeCodexBridge();
+    const codexHome = await createTemporaryDirectory();
+    await writeCodexSession(codexHome, [
+      {
+        timestamp: "2026-04-25T00:00:00.000Z",
+        type: "session_meta",
+        payload: {
+          id: "019dc000-0000-7000-8000-000000000001",
+          timestamp: "2026-04-25T00:00:00.000Z",
+          cwd: "/repo/.git/phantom/worktrees/feature/list",
+          source: "vscode",
+        },
+      },
+      {
+        timestamp: "2026-04-25T00:01:00.000Z",
+        type: "event_msg",
+        payload: {
+          type: "thread_name_updated",
+          thread_name: "Existing work",
+        },
+      },
+      {
+        timestamp: "2026-04-25T00:02:00.000Z",
+        type: "response_item",
+        payload: {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "Please update the page" }],
+        },
+      },
+      {
+        timestamp: "2026-04-25T00:03:00.000Z",
+        type: "response_item",
+        payload: {
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text: "I updated the page." }],
+        },
+      },
+    ]);
+    const services = new ServeServices({
+      codex: codex as unknown as CodexBridge,
+      codexHome,
+      store,
+    });
+    coreMocks.listWorktrees.mockResolvedValueOnce({
+      ok: true,
+      value: {
+        worktrees: [
+          {
+            name: "feature/list",
+            path: "/repo/.git/phantom/worktrees/feature/list",
+            pathToDisplay: ".git/phantom/worktrees/feature/list",
+            branch: "feature/list",
+            isClean: true,
+          },
+        ],
+      },
+    });
+
+    const worktrees = await services.listProjectWorktrees("proj_1");
+
+    strictEqual(worktrees[0]?.chatTitle, "Existing work");
+    strictEqual(worktrees[0]?.chatStatus, "idle");
+    const savedState = await store.load();
+    strictEqual(savedState.chats.length, 1);
+    strictEqual(
+      savedState.chats[0]?.codexThreadId,
+      "019dc000-0000-7000-8000-000000000001",
+    );
+    deepStrictEqual(
+      savedState.messages.map((message) => [message.role, message.text]),
+      [
+        ["user", "Please update the page"],
+        ["assistant", "I updated the page."],
+      ],
+    );
+  });
+
+  it("preserves local chats that already match imported Codex threads", async () => {
+    const threadId = "019dc000-0000-7000-8000-000000000001";
+    const worktreePath = "/repo/.git/phantom/worktrees/feature/list";
+    const state = {
+      ...createEmptyState(),
+      projects: [createProject()],
+      chats: [
+        createChat({
+          id: "chat_local",
+          codexThreadId: threadId,
+          title: "feature/list",
+          worktreeName: "feature/list",
+          worktreePath,
+          branchName: "feature/list",
+          updatedAt: "2026-04-25T00:04:00.000Z",
+        }),
+      ],
+      messages: [
+        {
+          id: "msg_local",
+          chatId: "chat_local",
+          role: "user" as const,
+          text: "hi",
+          createdAt: "2026-04-25T00:04:00.000Z",
+        },
+      ],
+      selectedChatId: "chat_local",
+    };
+    const store = new ServeStateStore(await createTemporaryDirectory());
+    await store.save(state);
+    const codex = new FakeCodexBridge();
+    const codexHome = await createTemporaryDirectory();
+    await writeCodexSession(codexHome, [
+      {
+        timestamp: "2026-04-25T00:00:00.000Z",
+        type: "session_meta",
+        payload: {
+          id: threadId,
+          timestamp: "2026-04-25T00:00:00.000Z",
+          cwd: worktreePath,
+          source: "vscode",
+        },
+      },
+      {
+        timestamp: "2026-04-25T00:01:00.000Z",
+        type: "event_msg",
+        payload: {
+          type: "thread_name_updated",
+          thread_name: "hi",
+        },
+      },
+      {
+        timestamp: "2026-04-25T00:02:00.000Z",
+        type: "response_item",
+        payload: {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "hi" }],
+        },
+      },
+    ]);
+    const services = new ServeServices({
+      codex: codex as unknown as CodexBridge,
+      codexHome,
+      store,
+    });
+    coreMocks.listWorktrees.mockResolvedValueOnce({
+      ok: true,
+      value: {
+        worktrees: [
+          {
+            name: "feature/list",
+            path: worktreePath,
+            pathToDisplay: ".git/phantom/worktrees/feature/list",
+            branch: "feature/list",
+            isClean: true,
+          },
+        ],
+      },
+    });
+
+    const worktrees = await services.listProjectWorktrees("proj_1");
+
+    strictEqual(worktrees[0]?.chatId, "chat_local");
+    strictEqual(worktrees[0]?.chatTitle, "feature/list");
+    const savedState = await store.load();
+    strictEqual(savedState.chats.length, 1);
+    strictEqual(savedState.chats[0]?.id, "chat_local");
+    strictEqual(savedState.selectedChatId, "chat_local");
+    deepStrictEqual(
+      savedState.messages.map((message) => [message.chatId, message.text]),
+      [["chat_local", "hi"]],
+    );
+  });
+
+  it("imports distinct Codex threads when a failed local chat exists for the same worktree", async () => {
+    const failedThreadId = "019dc000-0000-7000-8000-000000000001";
+    const importedThreadId = "019dc000-0000-7000-8000-000000000002";
+    const worktreePath = "/repo/.git/phantom/worktrees/feature/list";
+    const state = {
+      ...createEmptyState(),
+      projects: [createProject()],
+      chats: [
+        createChat({
+          id: "chat_failed",
+          codexThreadId: failedThreadId,
+          title: "failed",
+          status: "failed",
+          worktreeName: "feature/list",
+          worktreePath,
+          branchName: "feature/list",
+          updatedAt: "2026-04-25T00:04:00.000Z",
+        }),
+      ],
+      selectedChatId: "chat_failed",
+    };
+    const store = new ServeStateStore(await createTemporaryDirectory());
+    await store.save(state);
+    const codex = new FakeCodexBridge();
+    const codexHome = await createTemporaryDirectory();
+    await writeCodexSession(
+      codexHome,
+      [
+        {
+          timestamp: "2026-04-25T00:00:00.000Z",
+          type: "session_meta",
+          payload: {
+            id: importedThreadId,
+            timestamp: "2026-04-25T00:00:00.000Z",
+            cwd: worktreePath,
+            source: "vscode",
+          },
+        },
+        {
+          timestamp: "2026-04-25T00:01:00.000Z",
+          type: "event_msg",
+          payload: {
+            type: "thread_name_updated",
+            thread_name: "imported",
+          },
+        },
+      ],
+      "rollout-2026-04-25T00-00-00-019dc000-0000-7000-8000-000000000002.jsonl",
+    );
+    const services = new ServeServices({
+      codex: codex as unknown as CodexBridge,
+      codexHome,
+      store,
+    });
+    coreMocks.listWorktrees.mockResolvedValueOnce({
+      ok: true,
+      value: {
+        worktrees: [
+          {
+            name: "feature/list",
+            path: worktreePath,
+            pathToDisplay: ".git/phantom/worktrees/feature/list",
+            branch: "feature/list",
+            isClean: true,
+          },
+        ],
+      },
+    });
+
+    await services.listProjectWorktrees("proj_1");
+
+    const savedState = await store.load();
+    deepStrictEqual(
+      savedState.chats.map((chat) => [chat.id, chat.codexThreadId]),
+      [
+        ["chat_failed", failedThreadId],
+        [`chat_codex_${importedThreadId}`, importedThreadId],
+      ],
+    );
+  });
+
+  it("uses the latest existing Codex thread after creating a worktree", async () => {
+    const state = {
+      ...createEmptyState(),
+      projects: [createProject()],
+    };
+    const store = new ServeStateStore(await createTemporaryDirectory());
+    await store.save(state);
+    const codex = new FakeCodexBridge();
+    const codexHome = await createTemporaryDirectory();
+    await writeCodexSession(codexHome, [
+      {
+        timestamp: "2026-04-25T00:00:00.000Z",
+        type: "session_meta",
+        payload: {
+          id: "019dc000-0000-7000-8000-000000000002",
+          timestamp: "2026-04-25T00:00:00.000Z",
+          cwd: "/repo/.git/phantom/worktrees/feature",
+          source: "vscode",
+        },
+      },
+      {
+        timestamp: "2026-04-25T00:01:00.000Z",
+        type: "event_msg",
+        payload: {
+          type: "thread_name_updated",
+          thread_name: "Continue feature",
+        },
+      },
+      {
+        timestamp: "2026-04-25T00:02:00.000Z",
+        type: "response_item",
+        payload: {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "Continue from here" }],
+        },
+      },
+    ]);
+    const services = new ServeServices({
+      codex: codex as unknown as CodexBridge,
+      codexHome,
+      store,
+    });
+    coreMocks.runCreateWorktree.mockResolvedValueOnce({
+      ok: true,
+      value: {
+        name: "feature",
+        path: "/repo/.git/phantom/worktrees/feature",
+      },
+    });
+
+    const chat = await services.createChat("proj_1", { name: "feature" });
+
+    strictEqual(chat.title, "Continue feature");
+    strictEqual(chat.codexThreadId, "019dc000-0000-7000-8000-000000000002");
+    strictEqual(codex.startThread.mock.calls.length, 0);
+    const savedState = await store.load();
+    strictEqual(savedState.selectedChatId, chat.id);
+    deepStrictEqual(
+      savedState.messages.map((message) => [message.role, message.text]),
+      [["user", "Continue from here"]],
+    );
+  });
+
+  it("deduplicates imported chats against current state when creating a worktree", async () => {
+    const threadId = "019dc000-0000-7000-8000-000000000002";
+    const worktreePath = "/repo/.git/phantom/worktrees/feature";
+    const state = {
+      ...createEmptyState(),
+      projects: [createProject()],
+    };
+    const importedChat = createChat({
+      id: `chat_codex_${threadId}`,
+      codexThreadId: threadId,
+      title: "Continue feature",
+      worktreeName: "feature",
+      worktreePath,
+      branchName: "feature",
+    });
+    const store = new ImportRaceStore(
+      await createTemporaryDirectory(),
+      (currentState) => ({
+        ...currentState,
+        chats: [...currentState.chats, importedChat],
+        messages: [
+          ...currentState.messages,
+          {
+            id: `${importedChat.id}_msg_0`,
+            chatId: importedChat.id,
+            role: "user" as const,
+            text: "Continue from here",
+            createdAt: "2026-04-25T00:02:00.000Z",
+          },
+        ],
+      }),
+    );
+    await store.save(state);
+    const codex = new FakeCodexBridge();
+    const codexHome = await createTemporaryDirectory();
+    await writeCodexSession(codexHome, [
+      {
+        timestamp: "2026-04-25T00:00:00.000Z",
+        type: "session_meta",
+        payload: {
+          id: threadId,
+          timestamp: "2026-04-25T00:00:00.000Z",
+          cwd: worktreePath,
+          source: "vscode",
+        },
+      },
+      {
+        timestamp: "2026-04-25T00:01:00.000Z",
+        type: "event_msg",
+        payload: {
+          type: "thread_name_updated",
+          thread_name: "Continue feature",
+        },
+      },
+      {
+        timestamp: "2026-04-25T00:02:00.000Z",
+        type: "response_item",
+        payload: {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "Continue from here" }],
+        },
+      },
+    ]);
+    const services = new ServeServices({
+      codex: codex as unknown as CodexBridge,
+      codexHome,
+      store,
+    });
+    coreMocks.runCreateWorktree.mockResolvedValueOnce({
+      ok: true,
+      value: {
+        name: "feature",
+        path: worktreePath,
+      },
+    });
+
+    const chat = await services.createChat("proj_1", { name: "feature" });
+
+    strictEqual(chat.id, importedChat.id);
+    const savedState = await store.load();
+    strictEqual(
+      savedState.chats.filter((candidate) => candidate.id === importedChat.id)
+        .length,
+      1,
+    );
+    strictEqual(
+      savedState.messages.filter(
+        (message) => message.id === `${importedChat.id}_msg_0`,
+      ).length,
+      1,
+    );
+    strictEqual(savedState.selectedChatId, importedChat.id);
+  });
+
   it("rejects approval responses from a different chat", async () => {
     const state = {
       ...createEmptyState(),
@@ -299,6 +885,38 @@ describe("ServeServices", () => {
     ]);
     deepStrictEqual(coreMocks.deleteBranch.mock.calls[0], ["/repo", "feature"]);
     strictEqual((await store.load()).chats.length, 0);
+  });
+
+  it("skips non-directory Codex history roots when creating a worktree", async () => {
+    const state = {
+      ...createEmptyState(),
+      projects: [createProject()],
+    };
+    const store = new ServeStateStore(await createTemporaryDirectory());
+    await store.save(state);
+    const codex = new FakeCodexBridge();
+    const codexHome = await createTemporaryDirectory();
+    await writeFile(join(codexHome, "sessions"), "not a directory");
+    const services = new ServeServices({
+      codex: codex as unknown as CodexBridge,
+      codexHome,
+      store,
+    });
+    coreMocks.runCreateWorktree.mockResolvedValueOnce({
+      ok: true,
+      value: {
+        name: "feature",
+        path: "/repo/.git/phantom/worktrees/feature",
+      },
+    });
+    codex.startThread.mockResolvedValueOnce({ thread: { id: "thread_1" } });
+
+    const chat = await services.createChat("proj_1", { name: "feature" });
+
+    strictEqual(chat.codexThreadId, "thread_1");
+    strictEqual(coreMocks.removeWorktree.mock.calls.length, 0);
+    strictEqual(coreMocks.deleteBranch.mock.calls.length, 0);
+    strictEqual((await store.load()).chats.length, 1);
   });
 
   it("rolls back a created worktree when Codex omits the thread id", async () => {

--- a/packages/app/src/server/services.ts
+++ b/packages/app/src/server/services.ts
@@ -3,6 +3,7 @@ import { basename, isAbsolute } from "node:path";
 import { getGitRoot } from "@phantompane/git";
 import {
   deleteBranch,
+  listWorktrees,
   removeWorktree,
   runCreateWorktree,
 } from "@phantompane/core";
@@ -14,10 +15,16 @@ import {
   ServeStateStore,
   touchProject,
 } from "./storage";
+import {
+  listCodexSessionsForWorktree,
+  listCodexSessionsForWorktrees,
+  type ImportedCodexSession,
+} from "./codex-history";
 import type {
   ChatMessageRecord,
   ChatRecord,
   ChatStatus,
+  ProjectWorktreeRecord,
   ProjectRecord,
   ServeState,
 } from "./types";
@@ -39,6 +46,7 @@ export interface ServeServicesOptions {
   eventHub?: EventHub;
   store?: ServeStateStore;
   codex?: CodexBridge;
+  codexHome?: string;
 }
 
 interface PendingApprovalRequest {
@@ -62,6 +70,7 @@ export class ServeServices {
   readonly eventHub: EventHub;
   readonly store: ServeStateStore;
   readonly codex: CodexBridge;
+  private readonly codexHome?: string;
   private readonly loadedThreadIds = new Set<string>();
   private readonly approvalRequests = new Map<string, PendingApprovalRequest>();
   private readonly pendingTurnEvents = new Map<
@@ -74,6 +83,7 @@ export class ServeServices {
     this.eventHub = options.eventHub ?? new EventHub();
     this.store = options.store ?? new ServeStateStore();
     this.codex = options.codex ?? new CodexBridge();
+    this.codexHome = options.codexHome;
     this.codex.onNotification((message) => {
       void this.handleCodexNotification(message);
     });
@@ -177,6 +187,152 @@ export class ServeServices {
     return state.chats.filter((chat) => chat.projectId === projectId);
   }
 
+  async listProjectWorktrees(
+    projectId: string,
+    options: { sync?: boolean } = {},
+  ): Promise<ProjectWorktreeRecord[]> {
+    const state = await this.store.load();
+    if (options.sync === false) {
+      return projectWorktreesFromPersistedChats(state, projectId);
+    }
+
+    const project = this.requireProject(state, projectId);
+    let result;
+    try {
+      result = await listWorktrees(project.rootPath);
+    } catch {
+      return projectWorktreesFromPersistedChats(state, projectId);
+    }
+    if (!result.ok) {
+      return projectWorktreesFromPersistedChats(state, projectId);
+    }
+
+    const { worktrees } = result.value;
+    const timestamp = createTimestamp();
+    const importedSessions = await listCodexSessionsForWorktrees({
+      codexHome: this.codexHome,
+      projectId,
+      worktrees: worktrees.map((worktree) => ({
+        branchName: worktree.branch,
+        worktreeName: worktree.name,
+        worktreePath: worktree.path,
+      })),
+    });
+
+    if (
+      shouldSyncProjectWorktreeChats({
+        importedSessions,
+        projectId,
+        state,
+        worktrees,
+      })
+    ) {
+      await this.store.update((nextState) => {
+        const existingChatsByPath = new Map(
+          nextState.chats
+            .filter((chat) => chat.projectId === projectId)
+            .map((chat) => [chat.worktreePath, chat]),
+        );
+        const importedWorktreePaths = new Set(
+          importedSessions.map((session) => session.chat.worktreePath),
+        );
+        const chatsToAdd = worktrees
+          .filter(
+            (worktree) =>
+              !existingChatsByPath.has(worktree.path) &&
+              !importedWorktreePaths.has(worktree.path),
+          )
+          .map((worktree) => ({
+            id: createRecordId("chat"),
+            projectId,
+            worktreeName: worktree.name,
+            worktreePath: worktree.path,
+            branchName: worktree.branch,
+            codexThreadId: null,
+            title: worktree.name,
+            status: "idle" as const,
+            activeTurnId: null,
+            createdAt: timestamp,
+            updatedAt: timestamp,
+          }));
+        const importableSessions = importedSessions.filter(
+          (session) =>
+            !nextState.chats.some((chat) =>
+              shouldPreferExistingChatOverImport(chat, session.chat),
+            ),
+        );
+        const importableMessages = importableSessions.flatMap(
+          (session) => session.messages,
+        );
+
+        if (chatsToAdd.length === 0 && importableSessions.length === 0) {
+          return nextState;
+        }
+        const chatsToRemove = nextState.chats.filter(
+          (chat) =>
+            !shouldPreserveChatDuringImport(
+              chat,
+              projectId,
+              importableSessions,
+            ),
+        );
+        const chatIdsToRemove = new Set(chatsToRemove.map((chat) => chat.id));
+        const selectedReplacement = findImportedReplacement(
+          nextState.selectedChatId,
+          chatsToRemove,
+          importableSessions,
+        );
+
+        return {
+          ...nextState,
+          chats: [
+            ...nextState.chats.filter((chat) => !chatIdsToRemove.has(chat.id)),
+            ...importableSessions.map((session) => session.chat),
+            ...chatsToAdd,
+          ],
+          messages: [
+            ...nextState.messages.filter(
+              (message) => !chatIdsToRemove.has(message.chatId),
+            ),
+            ...importableMessages,
+          ],
+          selectedChatId:
+            nextState.selectedChatId &&
+            chatIdsToRemove.has(nextState.selectedChatId)
+              ? (selectedReplacement?.chat.id ?? nextState.selectedChatId)
+              : nextState.selectedChatId,
+        };
+      });
+    }
+
+    const syncedState = await this.store.load();
+    const syncedChatsByPath = new Map<string, ChatRecord[]>();
+    for (const chat of syncedState.chats.filter(
+      (candidate) => candidate.projectId === projectId,
+    )) {
+      syncedChatsByPath.set(chat.worktreePath, [
+        ...(syncedChatsByPath.get(chat.worktreePath) ?? []),
+        chat,
+      ]);
+    }
+
+    return worktrees.map((worktree) => {
+      const chat = latestChatForWorktree(
+        syncedChatsByPath.get(worktree.path) ?? [],
+      );
+      return {
+        name: worktree.name,
+        path: worktree.path,
+        pathToDisplay: worktree.pathToDisplay,
+        branch: worktree.branch,
+        isClean: worktree.isClean,
+        chatId: chat?.id ?? null,
+        chatStatus: chat?.status ?? null,
+        chatTitle: chat?.title ?? worktree.name,
+      };
+    });
+  }
+
   async createChat(
     projectId: string,
     input: CreateChatInput,
@@ -191,6 +347,56 @@ export class ServeServices {
 
     if (!createResult.ok) {
       throw createResult.error;
+    }
+
+    let importedSessions: ImportedCodexSession[];
+    try {
+      importedSessions = await listCodexSessionsForWorktree({
+        branchName: createResult.value.name,
+        codexHome: this.codexHome,
+        projectId,
+        worktreeName: createResult.value.name,
+        worktreePath: createResult.value.path,
+      });
+    } catch (error) {
+      try {
+        await rollbackCreatedWorktree(
+          project.rootPath,
+          createResult.value.path,
+          createResult.value.name,
+        );
+      } catch (rollbackError) {
+        throw new Error(
+          `Failed to import Codex history: ${toErrorMessage(error)}. Rollback failed: ${toErrorMessage(rollbackError)}`,
+        );
+      }
+      throw error instanceof Error ? error : new Error(String(error));
+    }
+    const latestImportedSession = importedSessions[0];
+    if (latestImportedSession) {
+      let selectedImportedChat = latestImportedSession.chat;
+      await this.store.update((nextState) => {
+        selectedImportedChat =
+          findExistingChatForImportedSession(
+            nextState.chats,
+            projectId,
+            latestImportedSession.chat,
+          ) ?? latestImportedSession.chat;
+        return {
+          ...mergeImportedSessionsForProject(
+            nextState,
+            projectId,
+            importedSessions,
+          ),
+          selectedProjectId: projectId,
+          selectedChatId: selectedImportedChat.id,
+        };
+      });
+
+      this.eventHub.emit("chat.created", selectedImportedChat, {
+        chatId: selectedImportedChat.id,
+      });
+      return selectedImportedChat;
     }
 
     let codexThreadId: string;
@@ -918,6 +1124,198 @@ function createMessage(
     itemId,
     createdAt: createTimestamp(),
   };
+}
+
+function latestChatForWorktree(chats: ChatRecord[]): ChatRecord | null {
+  const sortedChats = [...chats].sort((left, right) =>
+    right.updatedAt.localeCompare(left.updatedAt),
+  );
+  return (
+    sortedChats.find((chat) => chat.codexThreadId) ?? sortedChats[0] ?? null
+  );
+}
+
+function projectWorktreesFromPersistedChats(
+  state: ServeState,
+  projectId: string,
+): ProjectWorktreeRecord[] {
+  const chatsByPath = new Map<string, ChatRecord[]>();
+  for (const chat of state.chats.filter(
+    (chat) => chat.projectId === projectId,
+  )) {
+    chatsByPath.set(chat.worktreePath, [
+      ...(chatsByPath.get(chat.worktreePath) ?? []),
+      chat,
+    ]);
+  }
+
+  return Array.from(chatsByPath.values())
+    .map((chats) => latestChatForWorktree(chats))
+    .filter((chat): chat is ChatRecord => Boolean(chat))
+    .sort((left, right) => left.worktreeName.localeCompare(right.worktreeName))
+    .map((chat) => ({
+      name: chat.worktreeName,
+      path: chat.worktreePath,
+      pathToDisplay: chat.worktreePath,
+      branch: chat.branchName,
+      isClean: true,
+      chatId: chat.id,
+      chatStatus: chat.status,
+      chatTitle: chat.title,
+    }));
+}
+
+function shouldSyncProjectWorktreeChats({
+  importedSessions,
+  projectId,
+  state,
+  worktrees,
+}: {
+  importedSessions: ImportedCodexSession[];
+  projectId: string;
+  state: ServeState;
+  worktrees: Array<{ path: string }>;
+}): boolean {
+  const existingChatsByPath = new Map(
+    state.chats
+      .filter((chat) => chat.projectId === projectId)
+      .map((chat) => [chat.worktreePath, chat]),
+  );
+  const importedWorktreePaths = new Set(
+    importedSessions.map((session) => session.chat.worktreePath),
+  );
+  return (
+    worktrees.some(
+      (worktree) =>
+        !existingChatsByPath.has(worktree.path) &&
+        !importedWorktreePaths.has(worktree.path),
+    ) ||
+    importedSessions.some(
+      (session) =>
+        !state.chats.some((chat) =>
+          shouldPreferExistingChatOverImport(chat, session.chat),
+        ),
+    )
+  );
+}
+
+function shouldPreferExistingChatOverImport(
+  chat: ChatRecord,
+  importedChat: ChatRecord,
+): boolean {
+  if (chat.projectId !== importedChat.projectId) {
+    return false;
+  }
+  if (
+    chat.codexThreadId !== null &&
+    chat.codexThreadId === importedChat.codexThreadId
+  ) {
+    return true;
+  }
+  if (chat.codexThreadId !== null) {
+    return false;
+  }
+  return (
+    Boolean(
+      chat.activeTurnId ||
+      chat.status === "running" ||
+      chat.status === "waitingForApproval",
+    ) && chat.worktreePath === importedChat.worktreePath
+  );
+}
+
+function findExistingChatForImportedSession(
+  chats: ChatRecord[],
+  projectId: string,
+  importedChat: ChatRecord,
+): ChatRecord | null {
+  return (
+    chats.find(
+      (chat) =>
+        chat.projectId === projectId &&
+        (chat.id === importedChat.id ||
+          shouldPreferExistingChatOverImport(chat, importedChat)),
+    ) ?? null
+  );
+}
+
+function mergeImportedSessionsForProject(
+  state: ServeState,
+  projectId: string,
+  importedSessions: ImportedCodexSession[],
+): ServeState {
+  const importableSessions = importedSessions.filter(
+    (session) =>
+      !state.chats.some((chat) =>
+        shouldPreferExistingChatOverImport(chat, session.chat),
+      ),
+  );
+  const chatsToRemove = state.chats.filter(
+    (chat) =>
+      !shouldPreserveChatDuringImport(chat, projectId, importableSessions),
+  );
+  const chatIdsToRemove = new Set(chatsToRemove.map((chat) => chat.id));
+
+  return {
+    ...state,
+    chats: [
+      ...state.chats.filter((chat) => !chatIdsToRemove.has(chat.id)),
+      ...importableSessions.map((session) => session.chat),
+    ],
+    messages: [
+      ...state.messages.filter(
+        (message) => !chatIdsToRemove.has(message.chatId),
+      ),
+      ...importableSessions.flatMap((session) => session.messages),
+    ],
+  };
+}
+
+function shouldPreserveChatDuringImport(
+  chat: ChatRecord,
+  projectId: string,
+  importedSessions: ImportedCodexSession[],
+): boolean {
+  if (chat.projectId !== projectId) {
+    return true;
+  }
+  if (
+    chat.activeTurnId ||
+    chat.status === "running" ||
+    chat.status === "waitingForApproval"
+  ) {
+    return true;
+  }
+  return !importedSessions.some((session) => {
+    const importedChat = session.chat;
+    return (
+      chat.id === importedChat.id ||
+      (chat.codexThreadId !== null &&
+        chat.codexThreadId === importedChat.codexThreadId) ||
+      (chat.codexThreadId === null &&
+        chat.worktreePath === importedChat.worktreePath)
+    );
+  });
+}
+
+function findImportedReplacement(
+  selectedChatId: string | null,
+  removedChats: ChatRecord[],
+  importedSessions: ImportedCodexSession[],
+): ImportedCodexSession | null {
+  const removedChat = removedChats.find((chat) => chat.id === selectedChatId);
+  if (!removedChat) {
+    return null;
+  }
+  return (
+    importedSessions.find((session) => {
+      const importedChat = session.chat;
+      return (
+        removedChat.codexThreadId === importedChat.codexThreadId ||
+        removedChat.worktreePath === importedChat.worktreePath
+      );
+    }) ?? null
+  );
 }
 
 function getParamObject(params: unknown): Record<string, unknown> | null {

--- a/packages/app/src/server/storage.test.ts
+++ b/packages/app/src/server/storage.test.ts
@@ -1,9 +1,13 @@
 import { deepStrictEqual, strictEqual } from "node:assert";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, it } from "vitest";
-import { ServeStateStore, createEmptyState } from "./storage";
+import {
+  ServeStateStore,
+  createEmptyState,
+  getDefaultServeDataDir,
+} from "./storage";
 
 const temporaryDirectories: string[] = [];
 
@@ -22,6 +26,27 @@ async function createTemporaryDirectory(): Promise<string> {
 }
 
 describe("ServeStateStore", () => {
+  it("uses the XDG state directory by default", () => {
+    strictEqual(
+      getDefaultServeDataDir({ XDG_STATE_HOME: "/xdg/state" }),
+      "/xdg/state/phantom/serve",
+    );
+  });
+
+  it("falls back to the XDG default state directory", () => {
+    strictEqual(
+      getDefaultServeDataDir({ XDG_STATE_HOME: "" }),
+      join(homedir(), ".local", "state", "phantom", "serve"),
+    );
+  });
+
+  it("ignores a relative XDG state directory", () => {
+    strictEqual(
+      getDefaultServeDataDir({ XDG_STATE_HOME: "relative/state" }),
+      join(homedir(), ".local", "state", "phantom", "serve"),
+    );
+  });
+
   it("loads missing state as an empty state", async () => {
     const store = new ServeStateStore(await createTemporaryDirectory());
 

--- a/packages/app/src/server/storage.ts
+++ b/packages/app/src/server/storage.ts
@@ -1,6 +1,6 @@
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, isAbsolute, join } from "node:path";
 import type {
   ChatMessageRecord,
   ChatRecord,
@@ -25,27 +25,13 @@ export function createEmptyState(): ServeState {
   };
 }
 
-export function getDefaultServeDataDir(
-  platform = process.platform,
-  env = process.env,
-): string {
-  if (platform === "darwin") {
-    return join(
-      homedir(),
-      "Library",
-      "Application Support",
-      "phantom",
-      "serve",
-    );
-  }
-
-  if (platform === "win32") {
-    const appData = env.APPDATA ?? join(homedir(), "AppData", "Roaming");
-    return join(appData, "phantom", "serve");
-  }
-
-  const stateHome = env.XDG_STATE_HOME ?? join(homedir(), ".local", "state");
-  return join(stateHome, "phantom", "serve");
+export function getDefaultServeDataDir(env = process.env): string {
+  const stateHome = env.XDG_STATE_HOME;
+  const baseStateDir =
+    stateHome && isAbsolute(stateHome)
+      ? stateHome
+      : join(homedir(), ".local", "state");
+  return join(baseStateDir, "phantom", "serve");
 }
 
 export function getServeDataDir(): string {

--- a/packages/app/src/server/types.ts
+++ b/packages/app/src/server/types.ts
@@ -38,6 +38,17 @@ export interface ChatRecord {
   updatedAt: string;
 }
 
+export interface ProjectWorktreeRecord {
+  name: string;
+  path: string;
+  pathToDisplay: string;
+  branch: string;
+  isClean: boolean;
+  chatId: string | null;
+  chatStatus: ChatStatus | null;
+  chatTitle: string;
+}
+
 export interface ServeState {
   version: 1;
   projects: ProjectRecord[];


### PR DESCRIPTION
## Summary

- Move Phantom Serve persistence to XDG state directories while keeping the existing explicit data-dir override.
- Show live worktrees as the sidebar unit and move chat history selection into the main pane.
- Import existing Codex session JSONL history for live worktrees, deduplicate matching threads, and resume imported threads instead of treating them as read-only.
- Refine the composer so Enter submits while preserving Shift+Enter newlines and IME composition behavior.
- Move Stop behavior onto the composer action button while a Codex turn is running.

## Verification

- `pnpm --filter app-private fix`
- `pnpm --filter app-private typecheck`
- `pnpm --filter app-private test`
- `git diff --check`
- In-app browser smoke checks for the sidebar/worktree chat history behavior and composer availability

## Notes

- `pnpm ready` was not rerun for this PR because the app-targeted checks above cover the touched package and the broader aggregate has been blocked locally by unrelated e2e/CLI environment constraints in this worktree.