### PR TITLE
refactor: move Codex core logic into codex package

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -13,6 +13,7 @@
     "test": "vitest run --root ../.. packages/app/src"
   },
   "dependencies": {
+    "@phantompane/codex": "workspace:*",
     "@phantompane/core": "workspace:*",
     "@phantompane/git": "workspace:*",
     "@tanstack/react-router": "^1.168.22",

--- a/packages/app/src/server/services.test.ts
+++ b/packages/app/src/server/services.test.ts
@@ -3,7 +3,7 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, it, vi } from "vitest";
-import type { CodexBridge, CodexMessage } from "./codex-bridge";
+import type { CodexBridge, CodexMessage } from "@phantompane/codex";
 import { ServeServices } from "./services";
 import { createEmptyState, ServeStateStore } from "./storage";
 import type { ChatRecord, ProjectRecord, ServeState } from "./types";

--- a/packages/app/src/server/services.ts
+++ b/packages/app/src/server/services.ts
@@ -7,7 +7,23 @@ import {
   removeWorktree,
   runCreateWorktree,
 } from "@phantompane/core";
-import { CodexBridge, type CodexMessage } from "./codex-bridge";
+import {
+  CodexBridge,
+  extractServerRequestIdFromParams,
+  extractThreadId,
+  extractThreadIdFromParams,
+  extractTurnId,
+  extractTurnIdFromParams,
+  getCodexBin,
+  getParamObject,
+  getServerRequestId,
+  listCodexSessionsForWorktree,
+  listCodexSessionsForWorktrees,
+  mapCodexMethodToEvent,
+  summarizeCodexEvent,
+  type CodexMessage,
+  type ImportedCodexSession,
+} from "@phantompane/codex";
 import { EventHub } from "./event-hub";
 import {
   createRecordId,
@@ -15,11 +31,6 @@ import {
   ServeStateStore,
   touchProject,
 } from "./storage";
-import {
-  listCodexSessionsForWorktree,
-  listCodexSessionsForWorktrees,
-  type ImportedCodexSession,
-} from "./codex-history";
 import type {
   ChatMessageRecord,
   ChatRecord,
@@ -101,7 +112,7 @@ export class ServeServices {
       ok: true,
       projectCount: state.projects.length,
       chatCount: state.chats.length,
-      codexBin: process.env.PHANTOM_SERVE_CODEX_BIN ?? "codex",
+      codexBin: getCodexBin(),
       dataDir: process.env.PHANTOM_SERVE_DATA_DIR ?? null,
     };
   }
@@ -374,7 +385,7 @@ export class ServeServices {
     }
     const latestImportedSession = importedSessions[0];
     if (latestImportedSession) {
-      let selectedImportedChat = latestImportedSession.chat;
+      let selectedImportedChat: ChatRecord = latestImportedSession.chat;
       await this.store.update((nextState) => {
         selectedImportedChat =
           findExistingChatForImportedSession(
@@ -1318,74 +1329,6 @@ function findImportedReplacement(
   );
 }
 
-function getParamObject(params: unknown): Record<string, unknown> | null {
-  return params && typeof params === "object" && !Array.isArray(params)
-    ? (params as Record<string, unknown>)
-    : null;
-}
-
-function extractThreadId(result: unknown): string {
-  const object = getParamObject(result);
-  const thread = getParamObject(object?.thread);
-  const threadId = thread?.id;
-  if (typeof threadId !== "string") {
-    throw new Error("Codex response did not include a thread id");
-  }
-  return threadId;
-}
-
-function extractTurnId(result: unknown): string | null {
-  const object = getParamObject(result);
-  const turn = getParamObject(object?.turn);
-  const turnId = turn?.id;
-  return typeof turnId === "string" ? turnId : null;
-}
-
-function extractThreadIdFromParams(params: unknown): string | null {
-  const object = getParamObject(params);
-  if (!object) {
-    return null;
-  }
-  if (typeof object.threadId === "string") {
-    return object.threadId;
-  }
-  const thread = getParamObject(object.thread);
-  return typeof thread?.id === "string" ? thread.id : null;
-}
-
-function extractTurnIdFromParams(params: unknown): string | null {
-  const object = getParamObject(params);
-  if (!object) {
-    return null;
-  }
-  if (typeof object.turnId === "string") {
-    return object.turnId;
-  }
-  const turn = getParamObject(object.turn);
-  return typeof turn?.id === "string" ? turn.id : null;
-}
-
-function getServerRequestId(requestId: unknown): ServerRequestId | null {
-  if (typeof requestId === "string" || typeof requestId === "number") {
-    return requestId;
-  }
-  return null;
-}
-
-function extractServerRequestIdFromParams(
-  params: unknown,
-): ServerRequestId | null {
-  const object = getParamObject(params);
-  if (!object) {
-    return null;
-  }
-  return (
-    getServerRequestId(object.requestId) ??
-    getServerRequestId(object.serverRequestId) ??
-    getServerRequestId(object.id)
-  );
-}
-
 function toErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
@@ -1411,53 +1354,6 @@ async function rollbackCreatedWorktree(
   if (errors.length > 0) {
     throw new Error(errors.join("; "));
   }
-}
-
-function mapCodexMethodToEvent(method: string): string {
-  if (method === "thread/started") {
-    return "agent.thread.started";
-  }
-  if (method === "turn/started") {
-    return "agent.turn.started";
-  }
-  if (method === "turn/completed") {
-    return "agent.turn.completed";
-  }
-  if (method.startsWith("item/") && method.endsWith("/requestApproval")) {
-    return "agent.approval.requested";
-  }
-  if (method.startsWith("item/")) {
-    return method.includes("delta") ? "agent.item.delta" : "agent.item.updated";
-  }
-  if (method === "serverRequest/resolved") {
-    return "agent.approval.resolved";
-  }
-  if (method === "account/updated") {
-    return "auth.updated";
-  }
-  if (method === "error") {
-    return "agent.error";
-  }
-  return "agent.event";
-}
-
-function summarizeCodexEvent(method: string, params: unknown): string {
-  const object = getParamObject(params);
-  if (method === "item/started" || method === "item/completed") {
-    const item = getParamObject(object?.item);
-    const type = typeof item?.type === "string" ? item.type : "item";
-    return `${method}: ${type}`;
-  }
-  if (method === "turn/completed") {
-    const turn = getParamObject(object?.turn);
-    const status = typeof turn?.status === "string" ? turn.status : "unknown";
-    return `turn completed: ${status}`;
-  }
-  if (method === "error") {
-    const error = getParamObject(object?.error);
-    return typeof error?.message === "string" ? error.message : "Codex error";
-  }
-  return method;
 }
 
 let services: ServeServices | null = null;

--- a/packages/codex/package.json
+++ b/packages/codex/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@phantompane/codex",
+  "version": "6.2.0",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "scripts": {
+    "lint": "oxfmt --check . && oxlint .",
+    "fix": "oxfmt --write . && oxlint --fix .",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run --root ../.. packages/codex/src"
+  }
+}

--- a/packages/codex/src/bridge.test.ts
+++ b/packages/codex/src/bridge.test.ts
@@ -3,7 +3,7 @@ import { EventEmitter } from "node:events";
 import { PassThrough } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 
-import { CodexBridge, type CodexMessage } from "./codex-bridge";
+import { CodexBridge, type CodexMessage } from "./bridge.ts";
 
 type WrittenMessage = {
   id?: number | string;

--- a/packages/codex/src/bridge.ts
+++ b/packages/codex/src/bridge.ts
@@ -32,7 +32,7 @@ interface PendingRequest {
 
 type SpawnCodexProcess = typeof spawn;
 
-function getCodexBin(): string {
+export function getCodexBin(): string {
   return process.env.PHANTOM_SERVE_CODEX_BIN ?? "codex";
 }
 

--- a/packages/codex/src/events.ts
+++ b/packages/codex/src/events.ts
@@ -1,0 +1,120 @@
+export type CodexServerRequestId = number | string;
+
+export function getParamObject(
+  params: unknown,
+): Record<string, unknown> | null {
+  return params && typeof params === "object" && !Array.isArray(params)
+    ? (params as Record<string, unknown>)
+    : null;
+}
+
+export function extractThreadId(result: unknown): string {
+  const object = getParamObject(result);
+  const thread = getParamObject(object?.thread);
+  const threadId = thread?.id;
+  if (typeof threadId !== "string") {
+    throw new Error("Codex response did not include a thread id");
+  }
+  return threadId;
+}
+
+export function extractTurnId(result: unknown): string | null {
+  const object = getParamObject(result);
+  const turn = getParamObject(object?.turn);
+  const turnId = turn?.id;
+  return typeof turnId === "string" ? turnId : null;
+}
+
+export function extractThreadIdFromParams(params: unknown): string | null {
+  const object = getParamObject(params);
+  if (!object) {
+    return null;
+  }
+  if (typeof object.threadId === "string") {
+    return object.threadId;
+  }
+  const thread = getParamObject(object.thread);
+  return typeof thread?.id === "string" ? thread.id : null;
+}
+
+export function extractTurnIdFromParams(params: unknown): string | null {
+  const object = getParamObject(params);
+  if (!object) {
+    return null;
+  }
+  if (typeof object.turnId === "string") {
+    return object.turnId;
+  }
+  const turn = getParamObject(object.turn);
+  return typeof turn?.id === "string" ? turn.id : null;
+}
+
+export function getServerRequestId(
+  requestId: unknown,
+): CodexServerRequestId | null {
+  if (typeof requestId === "string" || typeof requestId === "number") {
+    return requestId;
+  }
+  return null;
+}
+
+export function extractServerRequestIdFromParams(
+  params: unknown,
+): CodexServerRequestId | null {
+  const object = getParamObject(params);
+  if (!object) {
+    return null;
+  }
+  return (
+    getServerRequestId(object.requestId) ??
+    getServerRequestId(object.serverRequestId) ??
+    getServerRequestId(object.id)
+  );
+}
+
+export function mapCodexMethodToEvent(method: string): string {
+  if (method === "thread/started") {
+    return "agent.thread.started";
+  }
+  if (method === "turn/started") {
+    return "agent.turn.started";
+  }
+  if (method === "turn/completed") {
+    return "agent.turn.completed";
+  }
+  if (method.startsWith("item/") && method.endsWith("/requestApproval")) {
+    return "agent.approval.requested";
+  }
+  if (method.startsWith("item/")) {
+    return method.includes("delta") ? "agent.item.delta" : "agent.item.updated";
+  }
+  if (method === "serverRequest/resolved") {
+    return "agent.approval.resolved";
+  }
+  if (method === "account/updated") {
+    return "auth.updated";
+  }
+  if (method === "error") {
+    return "agent.error";
+  }
+  return "agent.event";
+}
+
+export function summarizeCodexEvent(method: string, params: unknown): string {
+  const object = getParamObject(params);
+  if (method === "item/started" || method === "item/completed") {
+    const item = getParamObject(object?.item);
+    const type = typeof item?.type === "string" ? item.type : "item";
+    return `${method}: ${type}`;
+  }
+  if (method === "turn/completed") {
+    const turn = getParamObject(object?.turn);
+    const status = typeof turn?.status === "string" ? turn.status : "unknown";
+    return `turn completed: ${status}`;
+  }
+  if (method === "error") {
+    const error = getParamObject(object?.error);
+    return typeof error?.message === "string" ? error.message : "Codex error";
+  }
+  return method;
+}

--- a/packages/codex/src/history.test.ts
+++ b/packages/codex/src/history.test.ts
@@ -3,7 +3,7 @@ import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, it } from "vitest";
-import { listCodexSessionsForWorktrees } from "./codex-history";
+import { listCodexSessionsForWorktrees } from "./history.ts";
 
 const temporaryDirectories: string[] = [];
 

--- a/packages/codex/src/history.ts
+++ b/packages/codex/src/history.ts
@@ -1,9 +1,8 @@
 import { readdir, readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, join } from "node:path";
-import type { ChatMessageRecord, ChatRecord } from "./types";
 
-interface CodexHistoryOptions {
+export interface CodexHistoryOptions {
   branchName: string;
   codexHome?: string;
   projectId: string;
@@ -11,21 +10,43 @@ interface CodexHistoryOptions {
   worktreePath: string;
 }
 
-interface CodexHistoryWorktree {
+export interface CodexHistoryWorktree {
   branchName: string;
   worktreeName: string;
   worktreePath: string;
 }
 
-interface CodexProjectHistoryOptions {
+export interface CodexProjectHistoryOptions {
   codexHome?: string;
   projectId: string;
   worktrees: CodexHistoryWorktree[];
 }
 
 export interface ImportedCodexSession {
-  chat: ChatRecord;
-  messages: ChatMessageRecord[];
+  chat: ImportedCodexChatRecord;
+  messages: ImportedCodexChatMessageRecord[];
+}
+
+export interface ImportedCodexChatRecord {
+  id: string;
+  projectId: string;
+  worktreeName: string;
+  worktreePath: string;
+  branchName: string;
+  codexThreadId: string;
+  title: string;
+  status: "idle";
+  activeTurnId: null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ImportedCodexChatMessageRecord {
+  id: string;
+  chatId: string;
+  role: "assistant" | "user";
+  text: string;
+  createdAt: string;
 }
 
 interface ParsedCodexSession {

--- a/packages/codex/src/index.ts
+++ b/packages/codex/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./bridge.ts";
+export * from "./events.ts";
+export * from "./history.ts";

--- a/packages/codex/tsconfig.json
+++ b/packages/codex/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
 
   packages/app:
     dependencies:
+      '@phantompane/codex':
+        specifier: workspace:*
+        version: link:../codex
       '@phantompane/core':
         specifier: workspace:*
         version: link:../core
@@ -119,6 +122,8 @@ importers:
         version: link:../utils
 
   packages/cli/dist: {}
+
+  packages/codex: {}
 
   packages/config:
     dependencies:


### PR DESCRIPTION
## Summary

- Add a new `@phantompane/codex` workspace package for Codex bridge, history import, and event parsing helpers.
- Move the existing Codex bridge/history tests alongside the new package.
- Update `app-private` to depend on `@phantompane/codex` and keep app server services focused on state orchestration.

## Verification

- `pnpm --filter @phantompane/codex typecheck`
- `pnpm --filter @phantompane/codex test`
- `pnpm --filter app-private typecheck`
- `pnpm --filter app-private test`
- `pnpm exec turbo run fix typecheck test --filter=!@phantompane/e2e`
- `git diff --check`

## Notes

- `pnpm ready` was run, but the e2e suite failed because the local `phantom` command is not available on PATH in this worktree. The non-e2e workspace checks above pass.