### PR TITLE
test: exclude e2e from ready

### DIFF
--- a/e2e/turbo.json
+++ b/e2e/turbo.json
@@ -1,0 +1,8 @@
+{
+  "extends": ["//"],
+  "tasks": {
+    "test": {
+      "extends": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `e2e/turbo.json` to opt the e2e package out of inherited `test` tasks
- keep `pnpm ready` and `pnpm ready:check` on `turbo run fix typecheck test`
- ensure the e2e package still runs `fix` and `typecheck`, while skipping only e2e tests

## Why
`pnpm ready` should not execute e2e tests, but filtering the package at the root `turbo run` level would also skip `fix` and `typecheck` for `@phantompane/e2e`.

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm exec turbo run fix typecheck test --dry=json`
- `pnpm ready`

## Observed result
- `@phantompane/e2e#fix` and `@phantompane/e2e#typecheck` were included
- `@phantompane/e2e#test` was excluded
- `pnpm ready` completed successfully