### PR TITLE
refactor: move github checkout flow into core

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,7 +23,6 @@
   "dependencies": {
     "@phantompane/core": "workspace:*",
     "@phantompane/git": "workspace:*",
-    "@phantompane/github": "workspace:*",
     "@phantompane/mcp": "workspace:*",
     "@phantompane/preferences": "workspace:*",
     "@phantompane/process": "workspace:*",

--- a/packages/cli/src/handlers/github-checkout-postcreate.test.ts
+++ b/packages/cli/src/handlers/github-checkout-postcreate.test.ts
@@ -21,7 +21,7 @@ vi.doMock("../output.ts", () => ({
   output: { log: outputLogMock, error: outputErrorMock },
 }));
 
-vi.doMock("@phantompane/github", () => ({
+vi.doMock("@phantompane/core", () => ({
   githubCheckout: githubCheckoutMock,
 }));
 

--- a/packages/cli/src/handlers/github-checkout.test.ts
+++ b/packages/cli/src/handlers/github-checkout.test.ts
@@ -26,7 +26,7 @@ vi.doMock("../output.ts", () => ({
   output: { log: outputLogMock, error: outputErrorMock },
 }));
 
-vi.doMock("@phantompane/github", () => ({
+vi.doMock("@phantompane/core", () => ({
   githubCheckout: githubCheckoutMock,
 }));
 

--- a/packages/cli/src/handlers/github-checkout.ts
+++ b/packages/cli/src/handlers/github-checkout.ts
@@ -1,5 +1,5 @@
 import { parseArgs } from "node:util";
-import { githubCheckout } from "@phantompane/github";
+import { githubCheckout } from "@phantompane/core";
 import { getPhantomEnv } from "@phantompane/process";
 import { isErr } from "@phantompane/utils";
 import { executeTmuxCommand, isInsideTmux } from "@phantompane/tmux";

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@phantompane/config": "workspace:*",
     "@phantompane/git": "workspace:*",
+    "@phantompane/github": "workspace:*",
     "@phantompane/preferences": "workspace:*",
     "@phantompane/process": "workspace:*",
     "@phantompane/utils": "workspace:*",

--- a/packages/core/src/github/checkout.test.ts
+++ b/packages/core/src/github/checkout.test.ts
@@ -8,7 +8,7 @@ const isPullRequestMock = vi.fn();
 const checkoutPullRequestMock = vi.fn();
 const checkoutIssueMock = vi.fn();
 
-vi.doMock("./api/index.ts", () => ({
+vi.doMock("@phantompane/github", () => ({
   getGitHubRepoInfo: getGitHubRepoInfoMock,
   fetchIssue: fetchIssueMock,
   isPullRequest: isPullRequestMock,

--- a/packages/core/src/github/checkout.ts
+++ b/packages/core/src/github/checkout.ts
@@ -1,7 +1,13 @@
 import { err, type Result } from "@phantompane/utils";
-import { fetchIssue, getGitHubRepoInfo, isPullRequest } from "./api/index.ts";
+import {
+  fetchIssue,
+  getGitHubRepoInfo,
+  isPullRequest,
+} from "@phantompane/github";
 import { checkoutIssue } from "./checkout/issue.ts";
 import { type CheckoutResult, checkoutPullRequest } from "./checkout/pr.ts";
+
+export type { CheckoutResult } from "./checkout/pr.ts";
 
 export interface GitHubCheckoutOptions {
   number: string;

--- a/packages/core/src/github/checkout/issue.test.ts
+++ b/packages/core/src/github/checkout/issue.test.ts
@@ -6,31 +6,26 @@ const getGitRootMock = vi.fn();
 const createWorktreeCoreMock = vi.fn();
 const isPullRequestMock = vi.fn();
 const createContextMock = vi.fn();
-const getWorktreePathFromDirectoryMock = vi.fn();
 const validateWorktreeExistsMock = vi.fn();
-
-// Mock the WorktreeAlreadyExistsError class
-class MockWorktreeAlreadyExistsError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "WorktreeAlreadyExistsError";
-  }
-}
 
 vi.doMock("@phantompane/git", () => ({
   getGitRoot: getGitRootMock,
 }));
 
-vi.doMock("@phantompane/core", () => ({
-  createWorktree: createWorktreeCoreMock,
-  WorktreeAlreadyExistsError: MockWorktreeAlreadyExistsError,
-  createContext: createContextMock,
-  getWorktreePathFromDirectory: getWorktreePathFromDirectoryMock,
-  validateWorktreeExists: validateWorktreeExistsMock,
+vi.doMock("@phantompane/github", () => ({
+  isPullRequest: isPullRequestMock,
 }));
 
-vi.doMock("../api/index.ts", () => ({
-  isPullRequest: isPullRequestMock,
+vi.doMock("../../context.ts", () => ({
+  createContext: createContextMock,
+}));
+
+vi.doMock("../../worktree/create.ts", () => ({
+  createWorktree: createWorktreeCoreMock,
+}));
+
+vi.doMock("../../worktree/validate.ts", () => ({
+  validateWorktreeExists: validateWorktreeExistsMock,
 }));
 
 const { checkoutIssue } = await import("./issue.ts");

--- a/packages/core/src/github/checkout/issue.ts
+++ b/packages/core/src/github/checkout/issue.ts
@@ -1,11 +1,9 @@
-import {
-  createContext,
-  createWorktree as createWorktreeCore,
-  validateWorktreeExists,
-} from "@phantompane/core";
 import { getGitRoot } from "@phantompane/git";
+import { type GitHubIssue, isPullRequest } from "@phantompane/github";
 import { err, isErr, ok, type Result } from "@phantompane/utils";
-import { type GitHubIssue, isPullRequest } from "../api/index.ts";
+import { createContext } from "../../context.ts";
+import { createWorktree as createWorktreeCore } from "../../worktree/create.ts";
+import { validateWorktreeExists } from "../../worktree/validate.ts";
 import type { CheckoutResult } from "./pr.ts";
 
 export async function checkoutIssue(

--- a/packages/core/src/github/checkout/pr.test.ts
+++ b/packages/core/src/github/checkout/pr.test.ts
@@ -7,16 +7,7 @@ const fetchMock = vi.fn();
 const attachWorktreeCoreMock = vi.fn();
 const setUpstreamBranchMock = vi.fn();
 const createContextMock = vi.fn();
-const getWorktreePathFromDirectoryMock = vi.fn();
 const validateWorktreeExistsMock = vi.fn();
-
-// Mock the WorktreeAlreadyExistsError class
-class MockWorktreeAlreadyExistsError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "WorktreeAlreadyExistsError";
-  }
-}
 
 vi.doMock("@phantompane/git", () => ({
   getGitRoot: getGitRootMock,
@@ -24,11 +15,15 @@ vi.doMock("@phantompane/git", () => ({
   setUpstreamBranch: setUpstreamBranchMock,
 }));
 
-vi.doMock("@phantompane/core", () => ({
-  attachWorktreeCore: attachWorktreeCoreMock,
-  WorktreeAlreadyExistsError: MockWorktreeAlreadyExistsError,
+vi.doMock("../../context.ts", () => ({
   createContext: createContextMock,
-  getWorktreePathFromDirectory: getWorktreePathFromDirectoryMock,
+}));
+
+vi.doMock("../../worktree/attach.ts", () => ({
+  attachWorktreeCore: attachWorktreeCoreMock,
+}));
+
+vi.doMock("../../worktree/validate.ts", () => ({
   validateWorktreeExists: validateWorktreeExistsMock,
 }));
 

--- a/packages/core/src/github/checkout/pr.ts
+++ b/packages/core/src/github/checkout/pr.ts
@@ -1,11 +1,9 @@
-import {
-  attachWorktreeCore,
-  createContext,
-  validateWorktreeExists,
-} from "@phantompane/core";
 import { fetch, getGitRoot, setUpstreamBranch } from "@phantompane/git";
+import type { GitHubPullRequest } from "@phantompane/github";
 import { err, isErr, ok, type Result } from "@phantompane/utils";
-import type { GitHubPullRequest } from "../api/index.ts";
+import { createContext } from "../../context.ts";
+import { attachWorktreeCore } from "../../worktree/attach.ts";
+import { validateWorktreeExists } from "../../worktree/validate.ts";
 
 export interface CheckoutResult {
   message: string;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,7 @@ export * from "@phantompane/config";
 export * from "@phantompane/preferences";
 export * from "./context.ts";
 export * from "./exec.ts";
+export * from "./github/checkout.ts";
 export * from "./paths.ts";
 export * from "./shell.ts";
 export * from "./worktree/attach.ts";

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -12,10 +12,6 @@
     "test": "vitest run --root ../.. packages/github/src"
   },
   "dependencies": {
-    "@phantompane/core": "workspace:*",
-    "@phantompane/git": "workspace:*",
-    "@phantompane/process": "workspace:*",
-    "@phantompane/utils": "workspace:*",
     "@octokit/rest": "^22.0.1",
     "zod": "^4.3.6"
   }

--- a/packages/github/src/index.ts
+++ b/packages/github/src/index.ts
@@ -1,7 +1,1 @@
-export {
-  type GitHubIssue,
-  type GitHubPullRequest,
-  isPullRequest,
-} from "./api/index.ts";
-export type { CheckoutResult } from "./checkout/pr.ts";
-export * from "./checkout.ts";
+export * from "./api/index.ts";

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -15,7 +15,6 @@
   "dependencies": {
     "@phantompane/core": "workspace:*",
     "@phantompane/git": "workspace:*",
-    "@phantompane/github": "workspace:*",
     "@phantompane/process": "workspace:*",
     "@phantompane/utils": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.27.1",

--- a/packages/mcp/src/tools/github-checkout.test.ts
+++ b/packages/mcp/src/tools/github-checkout.test.ts
@@ -1,6 +1,15 @@
-import { deepEqual, equal } from "node:assert/strict";
-import { test } from "vitest";
-import { githubCheckoutTool } from "./github-checkout.ts";
+import { deepEqual, equal, rejects } from "node:assert/strict";
+import { test, vi } from "vitest";
+
+const githubCheckoutMock = vi.fn();
+
+vi.doMock("@phantompane/core", () => ({
+  githubCheckout: githubCheckoutMock,
+}));
+
+const { githubCheckoutTool } = await import("./github-checkout.ts");
+
+const handlerExtra = {} as never;
 
 test("githubCheckoutTool has correct metadata", () => {
   equal(githubCheckoutTool.name, "phantom_github_checkout");
@@ -38,4 +47,54 @@ test("githubCheckoutTool schema rejects missing number", () => {
   const invalidInput = { base: "main" };
   const result = githubCheckoutTool.inputSchema.safeParse(invalidInput);
   equal(result.success, false);
+});
+
+test("githubCheckoutTool handler checks out a GitHub target", async () => {
+  githubCheckoutMock.mockClear();
+  githubCheckoutMock.mockImplementation(async () => ({
+    ok: true,
+    value: {
+      message: "Checked out issue #123",
+      worktree: "issues/123",
+      path: "/repo/.git/phantom/worktrees/issues/123",
+    },
+  }));
+
+  const result = await githubCheckoutTool.handler(
+    { number: "123", base: "develop" },
+    handlerExtra,
+  );
+
+  deepEqual(githubCheckoutMock.mock.calls, [
+    [{ number: "123", base: "develop" }],
+  ]);
+
+  equal(result.content.length, 1);
+  const [content] = result.content;
+  equal(content.type, "text");
+  if (content.type !== "text") {
+    throw new Error("Expected text content");
+  }
+
+  deepEqual(JSON.parse(content.text), {
+    success: true,
+    message: "Successfully checked out #123 to worktree 'issues/123'.",
+    worktree: "issues/123",
+    path: "/repo/.git/phantom/worktrees/issues/123",
+    note: "You can now switch to the worktree using 'cd /repo/.git/phantom/worktrees/issues/123'",
+  });
+});
+
+test("githubCheckoutTool handler reports checkout errors", async () => {
+  githubCheckoutMock.mockClear();
+  githubCheckoutMock.mockImplementation(async () => ({
+    ok: false,
+    error: new Error("GitHub API error"),
+  }));
+
+  await rejects(
+    async () =>
+      await githubCheckoutTool.handler({ number: "123" }, handlerExtra),
+    /GitHub API error/,
+  );
 });

--- a/packages/mcp/src/tools/github-checkout.ts
+++ b/packages/mcp/src/tools/github-checkout.ts
@@ -1,4 +1,4 @@
-import { githubCheckout } from "@phantompane/github";
+import { githubCheckout } from "@phantompane/core";
 import { isOk } from "@phantompane/utils";
 import { z } from "zod";
 import type { Tool } from "./types.ts";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,9 +102,6 @@ importers:
       '@phantompane/git':
         specifier: workspace:*
         version: link:../git
-      '@phantompane/github':
-        specifier: workspace:*
-        version: link:../github
       '@phantompane/mcp':
         specifier: workspace:*
         version: link:../mcp
@@ -142,6 +139,9 @@ importers:
       '@phantompane/git':
         specifier: workspace:*
         version: link:../git
+      '@phantompane/github':
+        specifier: workspace:*
+        version: link:../github
       '@phantompane/preferences':
         specifier: workspace:*
         version: link:../preferences
@@ -172,18 +172,6 @@ importers:
       '@octokit/rest':
         specifier: ^22.0.1
         version: 22.0.1
-      '@phantompane/core':
-        specifier: workspace:*
-        version: link:../core
-      '@phantompane/git':
-        specifier: workspace:*
-        version: link:../git
-      '@phantompane/process':
-        specifier: workspace:*
-        version: link:../process
-      '@phantompane/utils':
-        specifier: workspace:*
-        version: link:../utils
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -199,9 +187,6 @@ importers:
       '@phantompane/git':
         specifier: workspace:*
         version: link:../git
-      '@phantompane/github':
-        specifier: workspace:*
-        version: link:../github
       '@phantompane/process':
         specifier: workspace:*
         version: link:../process


### PR DESCRIPTION
## Summary
- move the `phantom github checkout` application flow from `@phantompane/github` into `@phantompane/core`
- keep `@phantompane/github` focused on GitHub API types and fetch helpers
- update CLI and MCP checkout entrypoints to call `githubCheckout` from `@phantompane/core`
- update package dependencies and lockfile so the dependency direction is `core -> github`

## Why
`@phantompane/github` was mixing GitHub API logic with Phantom worktree orchestration. Moving checkout orchestration into core keeps package responsibilities aligned: GitHub package owns API access, while core owns worktree/application behavior.

## Verification
- `pnpm exec vitest run packages/core/src/github packages/cli/src/handlers/github-checkout.test.ts packages/cli/src/handlers/github-checkout-postcreate.test.ts packages/mcp/src/tools/github-checkout.test.ts`
- `pnpm ready`

## Notes
- The first `pnpm install --frozen-lockfile` attempt failed because the sandbox could not resolve npm registry DNS. It succeeded after rerunning with network permission.
- Commit used `PREK_ALLOW_NO_CONFIG=1` because the local hook expected a missing `.pre-commit-config.yaml`; `pnpm ready` completed successfully after the change.