### PR TITLE
feat: add root dev script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "dev": "turbo run dev",
     "build": "turbo run build",
     "test": "turbo run test --filter=!@phantompane/e2e",
     "test:e2e": "pnpm --filter @phantompane/e2e test",

--- a/turbo.json
+++ b/turbo.json
@@ -10,6 +10,10 @@
     "tsconfig.json"
   ],
   "tasks": {
+    "dev": {
+      "cache": false,
+      "persistent": true
+    },
     "transit": {
       "dependsOn": ["^transit"]
     },


### PR DESCRIPTION
## Summary
- add a root `dev` script that delegates to Turbo
- add a persistent, uncached Turbo `dev` task for local dev server processes

## Why
Running `pnpm dev` from the repository root should start the app dev workflow through Turbo instead of requiring a package-scoped command.

## Verification
- `pnpm dev --dry=json`
- `pnpm dev` starts `app-private:dev` and Vite at `http://localhost:3000/`
- `pnpm ready`

## Notes
- `gh auth status` currently reports an invalid local GitHub CLI token, so the PR was created through the GitHub connector after pushing the branch with git.