### PR TITLE
feat: enhance chat composer controls

### DIFF
--- a/packages/app/src/components/ui/combobox.tsx
+++ b/packages/app/src/components/ui/combobox.tsx
@@ -1,0 +1,291 @@
+import { Check, ChevronsUpDown, Search } from "lucide-react";
+import type { KeyboardEvent, ReactNode } from "react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
+import { cn } from "../../lib/utils";
+import { Input } from "./input";
+
+export interface ComboboxOption {
+  description?: string;
+  disabled?: boolean;
+  keywords?: string[];
+  label: string;
+  value: string;
+}
+
+export interface ComboboxProps {
+  "aria-label": string;
+  align?: "end" | "start";
+  className?: string;
+  disabled?: boolean;
+  emptyMessage?: string;
+  icon?: ReactNode;
+  onQueryChange?: (query: string) => void;
+  onValueChange: (value: string) => void;
+  options: ComboboxOption[];
+  placeholder: string;
+  query?: string;
+  searchPlaceholder?: string;
+  shouldFilter?: boolean;
+  side?: "bottom" | "top";
+  triggerClassName?: string;
+  value?: string | null;
+}
+
+export function Combobox({
+  "aria-label": ariaLabel,
+  align = "start",
+  className,
+  disabled = false,
+  emptyMessage = "No results",
+  icon,
+  onQueryChange,
+  onValueChange,
+  options,
+  placeholder,
+  query,
+  searchPlaceholder = "Search",
+  shouldFilter = true,
+  side = "bottom",
+  triggerClassName,
+  value,
+}: ComboboxProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [activeOptionIndex, setActiveOptionIndex] = useState(-1);
+  const [internalQuery, setInternalQuery] = useState("");
+  const rootRef = useRef<HTMLDivElement>(null);
+  const listboxId = useId();
+  const searchQuery = query ?? internalQuery;
+  const selectedOption = options.find((option) => option.value === value);
+  const filteredOptions = useMemo(() => {
+    if (!shouldFilter || !searchQuery.trim()) {
+      return options;
+    }
+    const normalizedQuery = searchQuery.trim().toLowerCase();
+    return options.filter((option) => {
+      const searchableText = [
+        option.label,
+        option.description,
+        ...(option.keywords ?? []),
+      ]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
+      return searchableText.includes(normalizedQuery);
+    });
+  }, [options, searchQuery, shouldFilter]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    const handleKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen && query === undefined) {
+      setInternalQuery("");
+    }
+  }, [isOpen, query]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setActiveOptionIndex(-1);
+      return;
+    }
+    setActiveOptionIndex(getNextEnabledIndex(filteredOptions, -1, 1));
+  }, [filteredOptions, isOpen]);
+
+  function updateQuery(nextQuery: string) {
+    if (onQueryChange) {
+      onQueryChange(nextQuery);
+    } else {
+      setInternalQuery(nextQuery);
+    }
+  }
+
+  function selectOption(option: ComboboxOption) {
+    if (option.disabled) {
+      return;
+    }
+    onValueChange(option.value);
+    setIsOpen(false);
+    updateQuery("");
+  }
+
+  function handleSearchKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setActiveOptionIndex((current) =>
+        getNextEnabledIndex(filteredOptions, current, 1),
+      );
+      return;
+    }
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setActiveOptionIndex((current) =>
+        getNextEnabledIndex(filteredOptions, current, -1),
+      );
+      return;
+    }
+    if (event.key === "Home") {
+      event.preventDefault();
+      setActiveOptionIndex(getNextEnabledIndex(filteredOptions, -1, 1));
+      return;
+    }
+    if (event.key === "End") {
+      event.preventDefault();
+      setActiveOptionIndex(
+        getNextEnabledIndex(filteredOptions, filteredOptions.length, -1),
+      );
+      return;
+    }
+    if (event.key === "Enter") {
+      event.preventDefault();
+      if (activeOptionIndex >= 0) {
+        const option = filteredOptions[activeOptionIndex];
+        if (!option) {
+          return;
+        }
+        selectOption(option);
+      }
+    }
+  }
+
+  return (
+    <div className={cn("relative min-w-0", className)} ref={rootRef}>
+      <button
+        aria-controls={listboxId}
+        aria-expanded={isOpen}
+        aria-label={ariaLabel}
+        className={cn(
+          "inline-flex h-8 max-w-full items-center gap-1.5 rounded-[var(--radius-sm)] border border-input bg-[var(--surface-card)] px-2.5 text-[length:var(--font-size-sm)] font-medium text-[var(--text-secondary)] shadow-[var(--shadow-xs)] outline-none transition-colors hover:bg-accent focus-visible:border-ring focus-visible:shadow-[var(--state-focus-ring)] disabled:pointer-events-none disabled:opacity-[var(--opacity-disabled)]",
+          triggerClassName,
+        )}
+        disabled={disabled}
+        onClick={() => setIsOpen((current) => !current)}
+        role="combobox"
+        type="button"
+      >
+        {icon}
+        <span className="min-w-0 truncate">
+          {selectedOption?.label ?? placeholder}
+        </span>
+        <ChevronsUpDown className="size-3.5 shrink-0 text-[var(--icon-color-muted)]" />
+      </button>
+      {isOpen && (
+        <div
+          className={cn(
+            "absolute z-50 w-80 max-w-[calc(100vw-2rem)] overflow-hidden rounded-[var(--radius-md)] border border-border bg-popover text-popover-foreground shadow-[var(--shadow-md)]",
+            side === "top" ? "bottom-full mb-1" : "top-full mt-1",
+            align === "end" ? "right-0" : "left-0",
+          )}
+        >
+          <div className="flex items-center gap-2 border-b border-[var(--border-divider)] px-2 py-2">
+            <Search className="size-3.5 shrink-0 text-[var(--icon-color-muted)]" />
+            <Input
+              aria-activedescendant={
+                activeOptionIndex >= 0
+                  ? `${listboxId}-option-${activeOptionIndex}`
+                  : undefined
+              }
+              aria-autocomplete="list"
+              aria-controls={listboxId}
+              autoFocus
+              className="h-7 border-0 bg-transparent px-0 py-0 shadow-none focus-visible:shadow-none"
+              placeholder={searchPlaceholder}
+              value={searchQuery}
+              onChange={(event) => updateQuery(event.target.value)}
+              onKeyDown={handleSearchKeyDown}
+            />
+          </div>
+          <div
+            className="max-h-64 overflow-y-auto p-1"
+            id={listboxId}
+            role="listbox"
+          >
+            {filteredOptions.length === 0 ? (
+              <div className="px-2 py-3 text-[length:var(--font-size-sm)] text-[var(--text-tertiary)]">
+                {emptyMessage}
+              </div>
+            ) : (
+              filteredOptions.map((option, index) => {
+                const isSelected = option.value === value;
+                const isActive = index === activeOptionIndex;
+                return (
+                  <button
+                    aria-selected={isSelected}
+                    className={cn(
+                      "flex w-full min-w-0 items-start gap-2 rounded-[var(--radius-sm)] px-2 py-2 text-left outline-none transition-colors hover:bg-accent focus-visible:shadow-[var(--state-focus-ring)] disabled:pointer-events-none disabled:opacity-[var(--opacity-disabled)]",
+                      (isActive || isSelected) &&
+                        "bg-[var(--state-selected-bg)]",
+                    )}
+                    disabled={option.disabled}
+                    id={`${listboxId}-option-${index}`}
+                    key={option.value}
+                    onClick={() => selectOption(option)}
+                    onMouseEnter={() => setActiveOptionIndex(index)}
+                    role="option"
+                    type="button"
+                  >
+                    <Check
+                      className={cn(
+                        "mt-0.5 size-3.5 shrink-0 text-[var(--icon-color-active)]",
+                        !isSelected && "opacity-0",
+                      )}
+                    />
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate text-[length:var(--font-size-sm)] font-medium text-[var(--text-primary)]">
+                        {option.label}
+                      </span>
+                      {option.description && (
+                        <span className="mt-0.5 block truncate text-[length:var(--font-size-xs)] text-[var(--text-tertiary)]">
+                          {option.description}
+                        </span>
+                      )}
+                    </span>
+                  </button>
+                );
+              })
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function getNextEnabledIndex(
+  options: ComboboxOption[],
+  currentIndex: number,
+  direction: 1 | -1,
+): number {
+  if (options.length === 0) {
+    return -1;
+  }
+
+  let nextIndex = currentIndex;
+  for (let offset = 0; offset < options.length; offset += 1) {
+    nextIndex = (nextIndex + direction + options.length) % options.length;
+    if (!options[nextIndex]?.disabled) {
+      return nextIndex;
+    }
+  }
+  return -1;
+}

--- a/packages/app/src/routes/api/chats/$chatId.ts
+++ b/packages/app/src/routes/api/chats/$chatId.ts
@@ -9,12 +9,23 @@ import { getServeServices } from "../../../server/services";
 export const Route = createFileRoute("/api/chats/$chatId")({
   server: {
     handlers: {
-      GET: async ({ params }: ServerRouteContext) => {
+      GET: async ({ request, params }: ServerRouteContext) => {
         try {
           if (!params.chatId) {
             throw new Error("Chat id is required");
           }
-          const chat = await getServeServices().getChat(params.chatId);
+          const services = getServeServices();
+          const searchParams = new URL(request.url).searchParams;
+          if (searchParams.get("context") === "skills") {
+            const skills = await services.listSkills(params.chatId);
+            return json({ skills });
+          }
+          const fileQuery = searchParams.get("fileQuery");
+          if (fileQuery !== null) {
+            const files = await services.searchFiles(params.chatId, fileQuery);
+            return json({ files });
+          }
+          const chat = await services.getChat(params.chatId);
           return json({ chat });
         } catch (error) {
           return handleApiError(error);

--- a/packages/app/src/routes/api/chats/$chatId/messages.ts
+++ b/packages/app/src/routes/api/chats/$chatId/messages.ts
@@ -33,6 +33,10 @@ export const Route = createFileRoute("/api/chats/$chatId/messages")({
             throw new Error("Message text is required");
           }
           const chat = await getServeServices().sendMessage(params.chatId, {
+            effort: getString(body, "effort"),
+            files: getContextItems(body, "files"),
+            model: getString(body, "model"),
+            skills: getContextItems(body, "skills"),
             text,
           });
           return json({ chat });
@@ -43,3 +47,27 @@ export const Route = createFileRoute("/api/chats/$chatId/messages")({
     },
   },
 });
+
+function getContextItems(
+  body: Record<string, unknown>,
+  key: string,
+): Array<{ name: string; path: string }> | undefined {
+  const value = body[key];
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  return value
+    .map((item) => {
+      if (!item || typeof item !== "object" || Array.isArray(item)) {
+        return null;
+      }
+      const record = item as Record<string, unknown>;
+      return {
+        name: typeof record.name === "string" ? record.name : "",
+        path: typeof record.path === "string" ? record.path : "",
+      };
+    })
+    .filter((item): item is { name: string; path: string } =>
+      Boolean(item?.name && item.path),
+    );
+}

--- a/packages/app/src/routes/index.tsx
+++ b/packages/app/src/routes/index.tsx
@@ -1,8 +1,11 @@
 import { createFileRoute } from "@tanstack/react-router";
 import {
   AlertTriangle,
+  Bot,
+  Brain,
   ChevronRight,
   Clock3,
+  FileText,
   FolderGit2,
   GitBranch,
   Inbox,
@@ -10,7 +13,9 @@ import {
   MessageSquarePlus,
   Plus,
   Send,
+  Sparkles,
   Square,
+  X,
 } from "lucide-react";
 import type { ReactNode } from "react";
 import {
@@ -23,6 +28,7 @@ import {
 } from "react";
 import { Badge } from "../components/ui/badge";
 import { Button } from "../components/ui/button";
+import { Combobox, type ComboboxOption } from "../components/ui/combobox";
 import {
   Dialog,
   DialogContent,
@@ -59,6 +65,9 @@ import type {
   ChatMessageRecord,
   ChatRecord,
   ChatStatus,
+  CodexFileRecord,
+  CodexModelRecord,
+  CodexSkillRecord,
   PhantomEvent,
   ProjectWorktreeRecord,
   ProjectRecord,
@@ -190,10 +199,26 @@ function Home() {
   const [isAddProjectOpen, setIsAddProjectOpen] = useState(false);
   const [projectPath, setProjectPath] = useState("");
   const [composerText, setComposerText] = useState("");
+  const [models, setModels] = useState<CodexModelRecord[]>([]);
+  const [selectedModelId, setSelectedModelId] = useState<string | null>(null);
+  const [selectedEffort, setSelectedEffort] = useState<string | null>(null);
+  const [skills, setSkills] = useState<CodexSkillRecord[]>([]);
+  const [selectedSkillPaths, setSelectedSkillPaths] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const [fileSearchQuery, setFileSearchQuery] = useState("");
+  const fileSearchRequestIdRef = useRef(0);
+  const [fileSearchResults, setFileSearchResults] = useState<CodexFileRecord[]>(
+    [],
+  );
+  const [selectedFiles, setSelectedFiles] = useState<CodexFileRecord[]>([]);
   const [status, setStatus] = useState("Starting");
   const [error, setError] = useState<string | null>(null);
   const [isBusy, setIsBusy] = useState(false);
   const createChatInFlightRef = useRef(false);
+  const selectedChatIdRef = useRef<string | null>(null);
+  const selectedChatVersionRef = useRef(0);
+  const sendMessageRequestIdRef = useRef(0);
   const [pendingApproval, setPendingApproval] =
     useState<PendingApproval | null>(null);
 
@@ -210,6 +235,81 @@ function Home() {
     [chatsByProject, selectedChatId],
   );
   const isChatRunning = Boolean(selectedChat?.activeTurnId);
+
+  const selectedModel = useMemo(
+    () =>
+      models.find((model) => model.id === selectedModelId) ??
+      models.find((model) => model.isDefault) ??
+      models[0] ??
+      null,
+    [models, selectedModelId],
+  );
+
+  const selectedSkills = useMemo(
+    () => skills.filter((skill) => selectedSkillPaths.has(skill.path)),
+    [selectedSkillPaths, skills],
+  );
+
+  const modelOptions = useMemo<ComboboxOption[]>(
+    () =>
+      models.map((model) => ({
+        value: model.id,
+        label: model.displayName,
+        description: model.description || model.model,
+        keywords: [model.model],
+      })),
+    [models],
+  );
+
+  const effortOptions = useMemo<ComboboxOption[]>(() => {
+    const supportedEfforts = selectedModel?.supportedReasoningEfforts.length
+      ? selectedModel.supportedReasoningEfforts
+      : ["low", "medium", "high", "xhigh"];
+    return [
+      {
+        value: "auto",
+        label: "Auto",
+        description: selectedModel?.defaultReasoningEffort
+          ? `Default: ${selectedModel.defaultReasoningEffort}`
+          : "Use model default",
+      },
+      ...supportedEfforts.map((effort) => ({
+        value: effort,
+        label: formatReasoningEffort(effort),
+      })),
+    ];
+  }, [selectedModel]);
+
+  const skillOptions = useMemo<ComboboxOption[]>(
+    () =>
+      skills
+        .filter((skill) => skill.enabled && !selectedSkillPaths.has(skill.path))
+        .map((skill) => ({
+          value: skill.path,
+          label: skill.displayName,
+          description: skill.shortDescription ?? skill.description,
+          keywords: [skill.name],
+        })),
+    [selectedSkillPaths, skills],
+  );
+
+  const fileOptions = useMemo<ComboboxOption[]>(
+    () =>
+      fileSearchResults
+        .filter(
+          (file) =>
+            !selectedFiles.some(
+              (selectedFile) => selectedFile.path === file.path,
+            ),
+        )
+        .map((file) => ({
+          value: file.path,
+          label: file.relativePath,
+          description: file.root,
+          keywords: [file.name],
+        })),
+    [fileSearchResults, selectedFiles],
+  );
 
   const selectedWorktree = useMemo(() => {
     if (!selectedProjectId || !selectedWorktreePath) {
@@ -243,6 +343,7 @@ function Home() {
 
   useEffect(() => {
     void refreshProjects();
+    void refreshModels();
     void fetchJson("/api/auth")
       .then(() => setStatus("Ready"))
       .catch((err: Error) => setStatus(err.message));
@@ -262,14 +363,29 @@ function Home() {
   }, [selectedProjectId]);
 
   useEffect(() => {
+    selectedChatIdRef.current = selectedChatId;
+    selectedChatVersionRef.current += 1;
+
     if (!selectedChatId) {
       setMessages([]);
       setPendingApproval(null);
+      setSelectedFiles([]);
+      setSelectedSkillPaths(new Set());
+      setFileSearchQuery("");
+      setFileSearchResults([]);
+      setSkills([]);
       return;
     }
 
+    setSelectedFiles([]);
+    setSelectedSkillPaths(new Set());
+    setFileSearchQuery("");
+    setFileSearchResults([]);
+    setSkills([]);
+    const chatContextController = new AbortController();
     void refreshMessages(selectedChatId);
     void refreshSelectedChat(selectedChatId);
+    void refreshChatContext(selectedChatId, chatContextController.signal);
 
     const source = new EventSource(`/api/chats/${selectedChatId}/events`);
     const handleEvent = (event: MessageEvent<string>) => {
@@ -294,12 +410,64 @@ function Home() {
     source.onerror = () => setStatus("Event stream disconnected");
 
     return () => {
+      chatContextController.abort();
       for (const eventName of chatEventNames) {
         source.removeEventListener(eventName, handleEvent);
       }
       source.close();
     };
   }, [selectedChatId, selectedProjectId]);
+
+  useEffect(() => {
+    if (!selectedEffort || selectedEffort === "auto") {
+      return;
+    }
+    const supportedEfforts = selectedModel?.supportedReasoningEfforts ?? [];
+    if (
+      supportedEfforts.length > 0 &&
+      !supportedEfforts.includes(selectedEffort)
+    ) {
+      setSelectedEffort(null);
+    }
+  }, [selectedEffort, selectedModel]);
+
+  useEffect(() => {
+    const requestId = fileSearchRequestIdRef.current + 1;
+    fileSearchRequestIdRef.current = requestId;
+
+    if (!selectedChatId || !fileSearchQuery.trim()) {
+      setFileSearchResults([]);
+      return;
+    }
+
+    const controller = new AbortController();
+    const query = fileSearchQuery.trim();
+    const timeout = setTimeout(() => {
+      void fetchJson<{ files: CodexFileRecord[] }>(
+        `/api/chats/${selectedChatId}?fileQuery=${encodeURIComponent(query)}`,
+        { signal: controller.signal },
+      )
+        .then((data) => {
+          if (
+            controller.signal.aborted ||
+            fileSearchRequestIdRef.current !== requestId
+          ) {
+            return;
+          }
+          setFileSearchResults(data.files);
+        })
+        .catch((err: Error) => {
+          if (err.name !== "AbortError") {
+            setError(err.message);
+          }
+        });
+    }, 160);
+
+    return () => {
+      clearTimeout(timeout);
+      controller.abort();
+    };
+  }, [fileSearchQuery, selectedChatId]);
 
   useEffect(() => {
     if (
@@ -374,6 +542,45 @@ function Home() {
         ? current
         : (fallbackWorktree?.chatId ?? null),
     );
+  }
+
+  async function refreshModels() {
+    try {
+      const data = await fetchJson<{ models: CodexModelRecord[] }>(
+        "/api/models",
+      );
+      setModels(data.models);
+      setSelectedModelId((current) => {
+        if (current && data.models.some((model) => model.id === current)) {
+          return current;
+        }
+        return (
+          data.models.find((model) => model.isDefault)?.id ??
+          data.models[0]?.id ??
+          null
+        );
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  async function refreshChatContext(chatId: string, signal?: AbortSignal) {
+    try {
+      const data = await fetchJson<{ skills: CodexSkillRecord[] }>(
+        `/api/chats/${chatId}?context=skills`,
+        { signal },
+      );
+      if (signal?.aborted) {
+        return;
+      }
+      setSkills(data.skills);
+    } catch (err) {
+      if (err instanceof Error && err.name === "AbortError") {
+        return;
+      }
+      setError(err instanceof Error ? err.message : String(err));
+    }
   }
 
   async function loadProjectData(
@@ -512,15 +719,48 @@ function Home() {
       return;
     }
     setError(null);
+    const requestChatId = selectedChatId;
+    const requestChatVersion = selectedChatVersionRef.current;
+    const requestId = sendMessageRequestIdRef.current + 1;
+    sendMessageRequestIdRef.current = requestId;
+    const isCurrentSendRequest = () =>
+      selectedChatIdRef.current === requestChatId &&
+      selectedChatVersionRef.current === requestChatVersion &&
+      sendMessageRequestIdRef.current === requestId;
     const text = composerText;
     setComposerText("");
+    const turnModel = selectedModel?.id ?? selectedModel?.model;
+    const turnEffort = selectedEffort === "auto" ? null : selectedEffort;
+    const files = selectedFiles.map((file) => ({
+      name: file.relativePath,
+      path: file.path,
+    }));
+    const selectedSkillItems = selectedSkills.map((skill) => ({
+      name: skill.name,
+      path: skill.path,
+    }));
     try {
-      await fetchJson(`/api/chats/${selectedChatId}/messages`, {
+      await fetchJson(`/api/chats/${requestChatId}/messages`, {
         method: "POST",
-        body: JSON.stringify({ text }),
+        body: JSON.stringify({
+          effort: turnEffort,
+          files,
+          model: turnModel,
+          skills: selectedSkillItems,
+          text,
+        }),
       });
-      await refreshMessages(selectedChatId);
+      if (!isCurrentSendRequest()) {
+        return;
+      }
+      setSelectedFiles([]);
+      setSelectedSkillPaths(new Set());
+      setFileSearchQuery("");
+      await refreshMessages(requestChatId);
     } catch (err) {
+      if (!isCurrentSendRequest()) {
+        return;
+      }
       setComposerText(text);
       setError(err instanceof Error ? err.message : String(err));
     }
@@ -595,6 +835,23 @@ function Home() {
     setSelectedWorktreePath(worktree.path);
     setSelectedChatId(worktree.chatId);
     setExpandedProjectIds((current) => new Set(current).add(projectId));
+  }
+
+  function selectFile(path: string) {
+    const file = fileSearchResults.find((candidate) => candidate.path === path);
+    if (!file) {
+      return;
+    }
+    setSelectedFiles((current) =>
+      current.some((selectedFile) => selectedFile.path === file.path)
+        ? current
+        : [...current, file],
+    );
+    setFileSearchQuery("");
+  }
+
+  function selectSkill(path: string) {
+    setSelectedSkillPaths((current) => new Set(current).add(path));
   }
 
   return (
@@ -867,42 +1124,141 @@ function Home() {
           className="border-t border-border bg-[var(--surface-floating)] p-3 backdrop-blur"
           onSubmit={sendMessage}
         >
-          <div className="mx-auto flex max-w-[var(--layout-max-content-width)] items-end gap-2 border border-transparent border-t-[var(--border-divider)] bg-transparent p-1">
-            <div className="min-w-0 flex-1">
-              <Label className="sr-only" htmlFor="composer">
-                Message
-              </Label>
-              <Textarea
-                className="min-h-12 border-0 bg-transparent px-2 py-2 shadow-none focus-visible:shadow-none"
-                disabled={!selectedChatId}
-                id="composer"
-                placeholder={
-                  selectedChatId
-                    ? "Ask Codex to work in this worktree"
-                    : "Create or select a worktree to start"
+          <div className="mx-auto flex max-w-[var(--layout-max-content-width)] flex-col gap-2">
+            {(selectedFiles.length > 0 || selectedSkills.length > 0) && (
+              <div className="flex min-h-8 flex-wrap items-center gap-2 px-1">
+                {selectedFiles.map((file) => (
+                  <ContextChip
+                    icon={<FileText className="size-3.5" />}
+                    key={file.path}
+                    label={file.relativePath}
+                    onRemove={() =>
+                      setSelectedFiles((current) =>
+                        current.filter(
+                          (selectedFile) => selectedFile.path !== file.path,
+                        ),
+                      )
+                    }
+                  />
+                ))}
+                {selectedSkills.map((skill) => (
+                  <ContextChip
+                    icon={<Sparkles className="size-3.5" />}
+                    key={skill.path}
+                    label={skill.displayName}
+                    onRemove={() =>
+                      setSelectedSkillPaths((current) => {
+                        const next = new Set(current);
+                        next.delete(skill.path);
+                        return next;
+                      })
+                    }
+                  />
+                ))}
+              </div>
+            )}
+            <div className="flex items-end gap-2">
+              <div className="min-w-0 flex-1">
+                <Label className="sr-only" htmlFor="composer">
+                  Message
+                </Label>
+                <Textarea
+                  className="min-h-12 border-0 bg-transparent px-2 py-2 shadow-none focus-visible:shadow-none"
+                  disabled={!selectedChatId}
+                  id="composer"
+                  placeholder={
+                    selectedChatId
+                      ? "Ask Codex to work in this worktree"
+                      : "Create or select a worktree to start"
+                  }
+                  rows={2}
+                  value={composerText}
+                  onChange={(event) => setComposerText(event.target.value)}
+                  onKeyDown={handleComposerKeyDown}
+                />
+              </div>
+              <Button
+                aria-label={isChatRunning ? "Stop turn" : "Send message"}
+                className="size-10"
+                disabled={
+                  isChatRunning
+                    ? !selectedChat?.activeTurnId
+                    : !selectedChatId || !composerText.trim()
                 }
-                rows={2}
-                value={composerText}
-                onChange={(event) => setComposerText(event.target.value)}
-                onKeyDown={handleComposerKeyDown}
+                onClick={isChatRunning ? interruptChat : undefined}
+                size="icon"
+                title={isChatRunning ? "Stop turn" : "Send"}
+                type={isChatRunning ? "button" : "submit"}
+                variant={isChatRunning ? "destructive" : "default"}
+              >
+                {isChatRunning ? <Square /> : <Send />}
+              </Button>
+            </div>
+            <div className="flex min-h-8 flex-wrap items-center gap-2 border-t border-[var(--border-divider)] px-1 pt-2">
+              <Combobox
+                aria-label="Select model"
+                className="w-36 max-w-full sm:w-40"
+                disabled={models.length === 0 || isChatRunning}
+                emptyMessage="No models"
+                icon={<Bot className="size-3.5" />}
+                options={modelOptions}
+                placeholder="Model"
+                searchPlaceholder="Search models"
+                side="top"
+                triggerClassName="w-full justify-between"
+                value={selectedModel?.id ?? null}
+                onValueChange={setSelectedModelId}
+              />
+              <Combobox
+                aria-label="Select reasoning effort"
+                className="w-28 max-w-full"
+                disabled={!selectedModel || isChatRunning}
+                icon={<Brain className="size-3.5" />}
+                options={effortOptions}
+                placeholder="Effort"
+                searchPlaceholder="Search effort"
+                side="top"
+                triggerClassName="w-full justify-between"
+                value={selectedEffort ?? "auto"}
+                onValueChange={(value) =>
+                  setSelectedEffort(value === "auto" ? null : value)
+                }
+              />
+              <Combobox
+                aria-label="Attach file"
+                className="w-32 max-w-full"
+                disabled={!selectedChatId || isChatRunning}
+                emptyMessage={
+                  fileSearchQuery.trim() ? "No files" : "Type to search"
+                }
+                icon={<FileText className="size-3.5" />}
+                options={fileOptions}
+                placeholder="Files"
+                query={fileSearchQuery}
+                searchPlaceholder="Search files"
+                shouldFilter={false}
+                side="top"
+                triggerClassName="w-full justify-between"
+                value={null}
+                onQueryChange={setFileSearchQuery}
+                onValueChange={selectFile}
+              />
+              <Combobox
+                aria-label="Select skill"
+                align="end"
+                className="w-32 max-w-full"
+                disabled={!selectedChatId || isChatRunning}
+                emptyMessage="No skills"
+                icon={<Sparkles className="size-3.5" />}
+                options={skillOptions}
+                placeholder="Skills"
+                searchPlaceholder="Search skills"
+                side="top"
+                triggerClassName="w-full justify-between"
+                value={null}
+                onValueChange={selectSkill}
               />
             </div>
-            <Button
-              aria-label={isChatRunning ? "Stop turn" : "Send message"}
-              className="size-10"
-              disabled={
-                isChatRunning
-                  ? !selectedChat?.activeTurnId
-                  : !selectedChatId || !composerText.trim()
-              }
-              onClick={isChatRunning ? interruptChat : undefined}
-              size="icon"
-              title={isChatRunning ? "Stop turn" : "Send"}
-              type={isChatRunning ? "button" : "submit"}
-              variant={isChatRunning ? "destructive" : "default"}
-            >
-              {isChatRunning ? <Square /> : <Send />}
-            </Button>
           </div>
         </form>
       </SidebarInset>
@@ -980,6 +1336,40 @@ function LeadingEllipsisText({ text }: { text: string }) {
       {formatLeadingEllipsisPath(text)}
     </span>
   );
+}
+
+function ContextChip({
+  icon,
+  label,
+  onRemove,
+}: {
+  icon: ReactNode;
+  label: string;
+  onRemove: () => void;
+}) {
+  return (
+    <span className="inline-flex h-8 max-w-52 items-center gap-1.5 rounded-[var(--radius-sm)] border border-[var(--border-divider)] bg-[var(--surface-code)] px-2 text-[length:var(--font-size-sm)] text-[var(--text-secondary)]">
+      {icon}
+      <span className="min-w-0 truncate">{label}</span>
+      <button
+        aria-label={`Remove ${label}`}
+        className="rounded-[var(--radius-xs)] text-[var(--icon-color-muted)] outline-none transition-colors hover:bg-[var(--state-hover-bg)] hover:text-[var(--icon-color-active)] focus-visible:shadow-[var(--state-focus-ring)]"
+        onClick={onRemove}
+        title={`Remove ${label}`}
+        type="button"
+      >
+        <X className="size-3.5" />
+      </button>
+    </span>
+  );
+}
+
+function formatReasoningEffort(effort: string): string {
+  return effort
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
+    .join(" ");
 }
 
 function SystemBanner({

--- a/packages/app/src/server/services.test.ts
+++ b/packages/app/src/server/services.test.ts
@@ -1,5 +1,5 @@
 import { deepStrictEqual, rejects, strictEqual } from "node:assert";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, it, vi } from "vitest";
@@ -26,9 +26,11 @@ class FakeCodexBridge {
   readonly serverRequestHandlers: Array<(message: CodexMessage) => void> = [];
   readonly interruptTurn = vi.fn();
   readonly listModels = vi.fn();
+  readonly listSkills = vi.fn();
   readonly readAccount = vi.fn();
   readonly respondToServerRequest = vi.fn();
   readonly resumeThread = vi.fn();
+  readonly searchFiles = vi.fn();
   readonly startThread = vi.fn();
   readonly startTurn = vi.fn();
   readonly steerTurn = vi.fn();
@@ -988,6 +990,167 @@ describe("ServeServices", () => {
       "/repo/.git/phantom/worktrees/feature",
     ]);
     strictEqual(codex.startTurn.mock.calls.length, 1);
+  });
+
+  it("passes selected model, effort, files, and skills to Codex turns", async () => {
+    const worktreePath = await createTemporaryDirectory();
+    await mkdir(join(worktreePath, "src"));
+    const filePath = join(worktreePath, "src/index.ts");
+    await writeFile(filePath, "export {};\n");
+    const state = {
+      ...createTestState(),
+      projects: [createProject({ rootPath: worktreePath })],
+      chats: [createChat({ worktreePath })],
+    };
+    const { codex, services } = await createHarness(state);
+    codex.resumeThread.mockResolvedValueOnce({});
+    codex.listSkills.mockResolvedValueOnce({
+      skills: [{ name: "review", path: "/skills/review/SKILL.md" }],
+    });
+    codex.startTurn.mockResolvedValueOnce({ turn: { id: "turn_1" } });
+
+    await services.sendMessage("chat_1", {
+      effort: "high",
+      files: [
+        {
+          name: "src/index.ts",
+          path: filePath,
+        },
+      ],
+      model: "gpt-5.2",
+      skills: [{ name: "review", path: "/skills/review/SKILL.md" }],
+      text: "please edit",
+    });
+
+    deepStrictEqual(codex.startTurn.mock.calls[0], [
+      "thread_1",
+      "please edit",
+      worktreePath,
+      {
+        effort: "high",
+        files: [
+          {
+            name: "src/index.ts",
+            path: filePath,
+          },
+        ],
+        model: "gpt-5.2",
+        skills: [{ name: "review", path: "/skills/review/SKILL.md" }],
+      },
+    ]);
+  });
+
+  it("rejects file context paths outside the chat worktree", async () => {
+    const worktreePath = await createTemporaryDirectory();
+    const outsidePath = join(await createTemporaryDirectory(), "secret.txt");
+    await writeFile(outsidePath, "secret\n");
+    const state = {
+      ...createTestState(),
+      projects: [createProject({ rootPath: worktreePath })],
+      chats: [createChat({ worktreePath })],
+    };
+    const { codex, services } = await createHarness(state);
+
+    await rejects(
+      services.sendMessage("chat_1", {
+        files: [{ name: "secret.txt", path: outsidePath }],
+        text: "please read",
+      }),
+      /File context path must be within the chat worktree/,
+    );
+
+    strictEqual(codex.startTurn.mock.calls.length, 0);
+  });
+
+  it("rejects file context paths that resolve to directories", async () => {
+    const worktreePath = await createTemporaryDirectory();
+    const directoryPath = join(worktreePath, "src");
+    await mkdir(directoryPath);
+    const state = {
+      ...createTestState(),
+      projects: [createProject({ rootPath: worktreePath })],
+      chats: [createChat({ worktreePath })],
+    };
+    const { codex, services } = await createHarness(state);
+
+    await rejects(
+      services.sendMessage("chat_1", {
+        files: [{ name: "src", path: directoryPath }],
+        text: "please read",
+      }),
+      /File context path is not a file/,
+    );
+
+    strictEqual(codex.startTurn.mock.calls.length, 0);
+  });
+
+  it("rejects file context symlinks that resolve outside the chat worktree", async () => {
+    const worktreePath = await createTemporaryDirectory();
+    const outsidePath = join(await createTemporaryDirectory(), "secret.txt");
+    await writeFile(outsidePath, "secret\n");
+    const linkPath = join(worktreePath, "secret.txt");
+    await symlink(outsidePath, linkPath);
+    const state = {
+      ...createTestState(),
+      projects: [createProject({ rootPath: worktreePath })],
+      chats: [createChat({ worktreePath })],
+    };
+    const { codex, services } = await createHarness(state);
+
+    await rejects(
+      services.sendMessage("chat_1", {
+        files: [{ name: "secret.txt", path: linkPath }],
+        text: "please read",
+      }),
+      /File context path must resolve within the chat worktree/,
+    );
+
+    strictEqual(codex.startTurn.mock.calls.length, 0);
+  });
+
+  it("rejects skill context paths that are unavailable for the chat cwd", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat()],
+    };
+    const { codex, services } = await createHarness(state);
+    codex.listSkills.mockResolvedValueOnce({ skills: [] });
+
+    await rejects(
+      services.sendMessage("chat_1", {
+        skills: [{ name: "review", path: "/skills/review/SKILL.md" }],
+        text: "please review",
+      }),
+      /Skill context path is not available/,
+    );
+
+    strictEqual(codex.startTurn.mock.calls.length, 0);
+  });
+
+  it("filters fuzzy search results to file matches", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat()],
+    };
+    const { codex, services } = await createHarness(state);
+    codex.searchFiles.mockResolvedValueOnce({
+      files: [
+        { root: "/repo", path: "src", match_type: "dir" },
+        { root: "/repo", path: "src/index.ts", match_type: "file" },
+      ],
+    });
+
+    deepStrictEqual(await services.searchFiles("chat_1", "src"), [
+      {
+        name: "index.ts",
+        path: "/repo/src/index.ts",
+        relativePath: "src/index.ts",
+        root: "/repo",
+        score: 0,
+      },
+    ]);
   });
 
   it("resets transient chat state after the Codex app-server exits", async () => {

--- a/packages/app/src/server/services.ts
+++ b/packages/app/src/server/services.ts
@@ -1,5 +1,5 @@
-import { realpath } from "node:fs/promises";
-import { basename, isAbsolute } from "node:path";
+import { realpath, stat } from "node:fs/promises";
+import { basename, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { getGitRoot } from "@phantompane/git";
 import {
   deleteBranch,
@@ -35,6 +35,10 @@ import type {
   ChatMessageRecord,
   ChatRecord,
   ChatStatus,
+  CodexFileRecord,
+  CodexModelRecord,
+  CodexSkillRecord,
+  CodexTurnContextItem,
   ProjectWorktreeRecord,
   ProjectRecord,
   ServeState,
@@ -46,6 +50,10 @@ export interface CreateChatInput {
 }
 
 export interface SendMessageInput {
+  effort?: string;
+  files?: CodexTurnContextItem[];
+  model?: string;
+  skills?: CodexTurnContextItem[];
   text: string;
 }
 
@@ -508,6 +516,7 @@ export class ServeServices {
     if (options.requireActiveTurn && !isSteeringActiveTurn) {
       throw new Error("Chat does not have an active Codex turn");
     }
+    const turnOptions = await this.createCodexTurnOptions(input, chat);
     if (!isSteeringActiveTurn) {
       if (this.pendingChatTurns.has(chatId)) {
         throw new Error("Chat already has an active Codex turn");
@@ -532,7 +541,16 @@ export class ServeServices {
         const threadId = await this.ensureThread(chat);
         const activeTurnId = chat.activeTurnId;
         if (chat.status === "running" && activeTurnId) {
-          await this.codex.steerTurn(threadId, activeTurnId, text);
+          if (turnOptions) {
+            await this.codex.steerTurn(
+              threadId,
+              activeTurnId,
+              text,
+              turnOptions,
+            );
+          } else {
+            await this.codex.steerTurn(threadId, activeTurnId, text);
+          }
         } else {
           const existingPendingTurn = this.pendingTurnEvents.get(threadId);
           if (existingPendingTurn) {
@@ -547,11 +565,14 @@ export class ServeServices {
             discard: false,
             events: [],
           });
-          const turnResult = await this.codex.startTurn(
-            threadId,
-            text,
-            chat.worktreePath,
-          );
+          const turnResult = turnOptions
+            ? await this.codex.startTurn(
+                threadId,
+                text,
+                chat.worktreePath,
+                turnOptions,
+              )
+            : await this.codex.startTurn(threadId, text, chat.worktreePath);
           const turnId = extractTurnId(turnResult);
           if (turnId) {
             nextStatus = "running";
@@ -679,8 +700,92 @@ export class ServeServices {
     return this.codex.readAccount();
   }
 
-  async listModels(): Promise<unknown> {
-    return this.codex.listModels();
+  async listModels(): Promise<CodexModelRecord[]> {
+    return normalizeModelRecords(await this.codex.listModels());
+  }
+
+  async listSkills(chatId: string): Promise<CodexSkillRecord[]> {
+    const chat = await this.getChat(chatId);
+    return normalizeSkillRecords(
+      await this.codex.listSkills([chat.worktreePath]),
+    );
+  }
+
+  async searchFiles(chatId: string, query: string): Promise<CodexFileRecord[]> {
+    const trimmedQuery = query.trim();
+    if (!trimmedQuery) {
+      return [];
+    }
+
+    const chat = await this.getChat(chatId);
+    return normalizeFileRecords(
+      await this.codex.searchFiles(trimmedQuery, [chat.worktreePath]),
+    );
+  }
+
+  private async createCodexTurnOptions(
+    input: SendMessageInput,
+    chat: ChatRecord,
+  ): Promise<
+    | {
+        effort?: string;
+        files?: CodexTurnContextItem[];
+        model?: string;
+        skills?: CodexTurnContextItem[];
+      }
+    | undefined
+  > {
+    const files = await normalizeFileContextItems(
+      input.files,
+      chat.worktreePath,
+    );
+    const skills = await this.normalizeSkillContextItems(
+      input.skills,
+      chat.worktreePath,
+    );
+    if (
+      !input.effort &&
+      !input.model &&
+      files.length === 0 &&
+      skills.length === 0
+    ) {
+      return undefined;
+    }
+    return {
+      effort: input.effort,
+      files: files.length > 0 ? files : undefined,
+      model: input.model,
+      skills: skills.length > 0 ? skills : undefined,
+    };
+  }
+
+  private async normalizeSkillContextItems(
+    items: CodexTurnContextItem[] | undefined,
+    worktreePath: string,
+  ): Promise<CodexTurnContextItem[]> {
+    const normalized = normalizeTurnContextItems(items);
+    if (normalized.length === 0) {
+      return [];
+    }
+
+    const availableSkills = normalizeSkillRecords(
+      await this.codex.listSkills([worktreePath]),
+    );
+    const skillsByPath = new Map(
+      availableSkills
+        .filter((skill) => skill.enabled)
+        .map((skill) => [skill.path, skill]),
+    );
+    return normalized.map((item) => {
+      const skill = skillsByPath.get(item.path);
+      if (!skill) {
+        throw new Error(`Skill context path is not available: ${item.path}`);
+      }
+      return {
+        name: skill.name,
+        path: skill.path,
+      };
+    });
   }
 
   private async ensureThread(chat: ChatRecord): Promise<string> {
@@ -1327,6 +1432,208 @@ function findImportedReplacement(
       );
     }) ?? null
   );
+}
+
+function normalizeTurnContextItems(
+  items: CodexTurnContextItem[] | undefined,
+): CodexTurnContextItem[] {
+  return (items ?? [])
+    .map((item) => ({
+      name: item.name.trim(),
+      path: item.path.trim(),
+    }))
+    .filter((item) => item.name && item.path);
+}
+
+async function normalizeFileContextItems(
+  items: CodexTurnContextItem[] | undefined,
+  worktreePath: string,
+): Promise<CodexTurnContextItem[]> {
+  const normalized = normalizeTurnContextItems(items);
+  if (normalized.length === 0) {
+    return [];
+  }
+
+  const realWorktreePath = await realpath(worktreePath);
+  return await Promise.all(
+    normalized.map(async (item) => {
+      const resolvedPath = resolve(item.path);
+      if (!isPathInside(worktreePath, resolvedPath)) {
+        throw new Error(
+          `File context path must be within the chat worktree: ${item.path}`,
+        );
+      }
+
+      let realFilePath: string;
+      try {
+        realFilePath = await realpath(resolvedPath);
+      } catch {
+        throw new Error(
+          `File context path is not an existing file: ${item.path}`,
+        );
+      }
+      if (!isPathInside(realWorktreePath, realFilePath)) {
+        throw new Error(
+          `File context path must resolve within the chat worktree: ${item.path}`,
+        );
+      }
+      if (!(await stat(realFilePath)).isFile()) {
+        throw new Error(`File context path is not a file: ${item.path}`);
+      }
+
+      return {
+        name: item.name,
+        path: resolvedPath,
+      };
+    }),
+  );
+}
+
+function isPathInside(rootPath: string, candidatePath: string): boolean {
+  const normalizedRoot = resolve(rootPath);
+  const normalizedCandidate = resolve(candidatePath);
+  const relativePath = relative(normalizedRoot, normalizedCandidate);
+  return (
+    relativePath === "" ||
+    (relativePath !== ".." &&
+      !relativePath.startsWith(`..${sep}`) &&
+      !isAbsolute(relativePath))
+  );
+}
+
+function normalizeModelRecords(value: unknown): CodexModelRecord[] {
+  const source =
+    getRecordArray(value, "data") ?? getRecordArray(value, "models");
+  return (source ?? [])
+    .map((model) => {
+      const id =
+        getRecordString(model, "id") ?? getRecordString(model, "model");
+      if (!id) {
+        return null;
+      }
+      const modelName = getRecordString(model, "model") ?? id;
+      return {
+        id,
+        model: modelName,
+        displayName: getRecordString(model, "displayName") ?? id,
+        description: getRecordString(model, "description") ?? "",
+        defaultReasoningEffort:
+          getRecordString(model, "defaultReasoningEffort") ?? null,
+        inputModalities: getStringArray(model.inputModalities),
+        isDefault: model.isDefault === true,
+        supportedReasoningEfforts: getReasoningEfforts(model),
+      } satisfies CodexModelRecord;
+    })
+    .filter((model): model is CodexModelRecord => Boolean(model));
+}
+
+function normalizeSkillRecords(value: unknown): CodexSkillRecord[] {
+  const entries =
+    getRecordArray(value, "data") ?? getRecordArray(value, "skills");
+  const skills = (entries ?? []).flatMap((entry) => {
+    if (Array.isArray(entry.skills)) {
+      return entry.skills.filter(isRecord);
+    }
+    return isRecord(entry) ? [entry] : [];
+  });
+  return skills
+    .map((skill) => {
+      const name = getRecordString(skill, "name");
+      const path = getRecordString(skill, "path");
+      if (!name || !path) {
+        return null;
+      }
+      const skillInterface = isRecord(skill.interface) ? skill.interface : null;
+      const shortDescription =
+        getRecordString(skillInterface, "shortDescription") ??
+        getRecordString(skill, "shortDescription") ??
+        null;
+      return {
+        name,
+        path,
+        displayName: getRecordString(skillInterface, "displayName") ?? name,
+        description: getRecordString(skill, "description") ?? "",
+        shortDescription,
+        enabled: skill.enabled !== false,
+      } satisfies CodexSkillRecord;
+    })
+    .filter((skill): skill is CodexSkillRecord => Boolean(skill));
+}
+
+function normalizeFileRecords(value: unknown): CodexFileRecord[] {
+  const files = getRecordArray(value, "files");
+  return (files ?? [])
+    .map((file) => {
+      const matchType = getRecordString(file, "match_type");
+      if (matchType && matchType !== "file") {
+        return null;
+      }
+      const root = getRecordString(file, "root");
+      const relativePath = getRecordString(file, "path");
+      if (!root || !relativePath) {
+        return null;
+      }
+      return {
+        name:
+          getRecordString(file, "file_name") ??
+          relativePath.split("/").pop() ??
+          relativePath,
+        path: join(root, relativePath),
+        relativePath,
+        root,
+        score:
+          typeof file.score === "number" && Number.isFinite(file.score)
+            ? file.score
+            : 0,
+      } satisfies CodexFileRecord;
+    })
+    .filter((file): file is CodexFileRecord => Boolean(file));
+}
+
+function getReasoningEfforts(model: Record<string, unknown>): string[] {
+  const supported = model.supportedReasoningEfforts;
+  if (!Array.isArray(supported)) {
+    return [];
+  }
+  return supported
+    .map((effort) =>
+      typeof effort === "string"
+        ? effort
+        : getRecordString(effort, "reasoningEffort"),
+    )
+    .filter((effort): effort is string => Boolean(effort));
+}
+
+function getRecordArray(
+  value: unknown,
+  key: string,
+): Array<Record<string, unknown>> | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const candidate = value[key];
+  if (!Array.isArray(candidate)) {
+    return undefined;
+  }
+  return candidate.filter(isRecord);
+}
+
+function getRecordString(value: unknown, key: string): string | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const candidate = value[key];
+  return typeof candidate === "string" ? candidate : undefined;
+}
+
+function getStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : [];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
 }
 
 function toErrorMessage(error: unknown): string {

--- a/packages/app/src/server/types.ts
+++ b/packages/app/src/server/types.ts
@@ -19,6 +19,39 @@ export interface ProjectWorktreeRecord {
   chatTitle: string;
 }
 
+export interface CodexFileRecord {
+  name: string;
+  path: string;
+  relativePath: string;
+  root: string;
+  score: number;
+}
+
+export interface CodexModelRecord {
+  id: string;
+  model: string;
+  displayName: string;
+  description: string;
+  defaultReasoningEffort: string | null;
+  inputModalities: string[];
+  isDefault: boolean;
+  supportedReasoningEfforts: string[];
+}
+
+export interface CodexSkillRecord {
+  name: string;
+  path: string;
+  displayName: string;
+  description: string;
+  shortDescription: string | null;
+  enabled: boolean;
+}
+
+export interface CodexTurnContextItem {
+  name: string;
+  path: string;
+}
+
 export interface PhantomEvent {
   id: number;
   type: string;

--- a/packages/codex/src/bridge.test.ts
+++ b/packages/codex/src/bridge.test.ts
@@ -133,6 +133,76 @@ describe("CodexBridge", () => {
     });
   });
 
+  it("passes model, effort, file mentions, and skills to new turns", async () => {
+    const { bridge, proc } = createBridge();
+    await initializeBridge(bridge, proc);
+
+    const turn = bridge.startTurn("thread_1", "please edit", "/repo", {
+      effort: "high",
+      files: [{ name: "src/index.ts", path: "/repo/src/index.ts" }],
+      model: "gpt-5.2",
+      skills: [{ name: "review", path: "/skills/review/SKILL.md" }],
+    });
+
+    await vi.waitFor(() => expect(findWrite(proc, "turn/start")).toBeDefined());
+    const request = findWrite(proc, "turn/start");
+    expect(request?.params).toEqual({
+      threadId: "thread_1",
+      cwd: "/repo",
+      input: [
+        {
+          type: "text",
+          text: "please edit",
+          text_elements: [],
+        },
+        {
+          type: "skill",
+          name: "review",
+          path: "/skills/review/SKILL.md",
+        },
+        {
+          type: "mention",
+          name: "src/index.ts",
+          path: "/repo/src/index.ts",
+        },
+      ],
+      model: "gpt-5.2",
+      effort: "high",
+    });
+
+    proc.send({ id: request?.id, result: { turn: { id: "turn_1" } } });
+    await expect(turn).resolves.toEqual({ turn: { id: "turn_1" } });
+  });
+
+  it("passes model and effort to steer turns", async () => {
+    const { bridge, proc } = createBridge();
+    await initializeBridge(bridge, proc);
+
+    const turn = bridge.steerTurn("thread_1", "turn_1", "continue", {
+      effort: "high",
+      model: "gpt-5.2",
+    });
+
+    await vi.waitFor(() => expect(findWrite(proc, "turn/steer")).toBeDefined());
+    const request = findWrite(proc, "turn/steer");
+    expect(request?.params).toEqual({
+      threadId: "thread_1",
+      expectedTurnId: "turn_1",
+      input: [
+        {
+          type: "text",
+          text: "continue",
+          text_elements: [],
+        },
+      ],
+      model: "gpt-5.2",
+      effort: "high",
+    });
+
+    proc.send({ id: request?.id, result: { turn: { id: "turn_1" } } });
+    await expect(turn).resolves.toEqual({ turn: { id: "turn_1" } });
+  });
+
   it("responds to string server request ids without coercing them", async () => {
     const { bridge, proc } = createBridge();
     await initializeBridge(bridge, proc);

--- a/packages/codex/src/bridge.ts
+++ b/packages/codex/src/bridge.ts
@@ -25,6 +25,18 @@ export interface CodexMessage {
   };
 }
 
+export interface CodexTurnContextItem {
+  name: string;
+  path: string;
+}
+
+export interface CodexTurnOptions {
+  effort?: string;
+  files?: CodexTurnContextItem[];
+  model?: string;
+  skills?: CodexTurnContextItem[];
+}
+
 interface PendingRequest {
   resolve: (value: unknown) => void;
   reject: (error: Error) => void;
@@ -36,14 +48,32 @@ export function getCodexBin(): string {
   return process.env.PHANTOM_SERVE_CODEX_BIN ?? "codex";
 }
 
-function createUserInput(text: string): Array<Record<string, unknown>> {
-  return [
+function createUserInput(
+  text: string,
+  options: CodexTurnOptions = {},
+): Array<Record<string, unknown>> {
+  const input: Array<Record<string, unknown>> = [
     {
       type: "text",
       text,
       text_elements: [],
     },
   ];
+  for (const skill of options.skills ?? []) {
+    input.push({
+      type: "skill",
+      name: skill.name,
+      path: skill.path,
+    });
+  }
+  for (const file of options.files ?? []) {
+    input.push({
+      type: "mention",
+      name: file.name,
+      path: file.path,
+    });
+  }
+  return input;
 }
 
 export class CodexBridge {
@@ -116,9 +146,28 @@ export class CodexBridge {
     });
   }
 
-  async startThread(cwd: string): Promise<unknown> {
+  async listSkills(cwds: string[]): Promise<unknown> {
+    return this.request("skills/list", {
+      cwds,
+      forceReload: false,
+    });
+  }
+
+  async searchFiles(query: string, roots: string[]): Promise<unknown> {
+    return this.request("fuzzyFileSearch", {
+      query,
+      roots,
+      cancellationToken: null,
+    });
+  }
+
+  async startThread(
+    cwd: string,
+    options: CodexTurnOptions = {},
+  ): Promise<unknown> {
     return this.request("thread/start", {
       cwd,
+      model: options.model,
       serviceName: "phantom_serve",
       experimentalRawEvents: false,
       persistExtendedHistory: true,
@@ -138,11 +187,14 @@ export class CodexBridge {
     threadId: string,
     text: string,
     cwd: string,
+    options: CodexTurnOptions = {},
   ): Promise<unknown> {
     return this.request("turn/start", {
       threadId,
       cwd,
-      input: createUserInput(text),
+      input: createUserInput(text, options),
+      model: options.model,
+      effort: options.effort,
     });
   }
 
@@ -150,11 +202,14 @@ export class CodexBridge {
     threadId: string,
     turnId: string,
     text: string,
+    options: CodexTurnOptions = {},
   ): Promise<unknown> {
     return this.request("turn/steer", {
       threadId,
       expectedTurnId: turnId,
-      input: createUserInput(text),
+      input: createUserInput(text, options),
+      model: options.model,
+      effort: options.effort,
     });
   }
 


### PR DESCRIPTION
## Summary
- add a reusable shadcn-style combobox for compact composer controls
- wire Codex App Server model, skill, and fuzzy file search APIs into the app chat composer
- pass selected model, reasoning effort, files, and skills into turn start/steer requests
- refine the composer layout so selected context chips sit above the textarea and the menu controls stay compact
- validate selected file/skill context server-side before forwarding it to Codex, and filter fuzzy search results to file matches
- add keyboard navigation and safe Enter handling for the combobox search input

## Why
The Phantom Serve chat composer should expose the same first-class context controls users expect from Codex CLI and Codex App without expanding the input chrome or making popovers unstable. The server also needs to treat composer context as client input and validate it before it reaches the Codex App Server.

## Verification
- `pnpm --filter app-private fix`
- `pnpm --filter app-private typecheck`
- `pnpm --filter app-private test`
- `pnpm --filter app-private build`
- `pnpm exec vitest run packages/codex/src/bridge.test.ts packages/app/src/server/services.test.ts`
- `pnpm ready`
- in-app browser check at `http://127.0.0.1:3000/` for composer chip placement, compact controls, and fixed-width skill popover
- `pr-review-fix-loop`: 3 review passes; final pass found no actionable findings

## Notes
- `pnpm ready` completed with 41 successful tasks. Turbo emitted non-fatal `Operation not permitted` IO warnings in this sandbox.
- The local pre-commit hook expected a missing `.pre-commit-config.yaml`, so commits were created with `PREK_ALLOW_NO_CONFIG=1` after validation passed.
- Residual gap from the final review: there is no browser/DOM regression test specifically covering Enter inside combobox search not submitting the surrounding chat form; the behavior is implemented and covered by review, while server-side validation paths are covered by focused unit tests.