### PR TITLE
feat: add worktree deletion menu

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -17,6 +17,7 @@
     "@phantompane/core": "workspace:*",
     "@phantompane/git": "workspace:*",
     "@phantompane/state": "workspace:*",
+    "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@tanstack/react-router": "^1.168.22",
     "@tanstack/react-start": "^1.167.41",
     "lucide-react": "^0.523.0",

--- a/packages/app/src/components/ui/dropdown-menu.tsx
+++ b/packages/app/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,83 @@
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+import type { ComponentProps } from "react";
+import { cn } from "../../lib/utils";
+
+export const DropdownMenu = DropdownMenuPrimitive.Root;
+
+export const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
+
+export const DropdownMenuGroup = DropdownMenuPrimitive.Group;
+
+export const DropdownMenuPortal = DropdownMenuPrimitive.Portal;
+
+export const DropdownMenuSub = DropdownMenuPrimitive.Sub;
+
+export const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup;
+
+export function DropdownMenuContent({
+  align = "end",
+  className,
+  sideOffset = 4,
+  ...props
+}: ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        align={align}
+        className={cn(
+          "z-50 min-w-40 overflow-hidden rounded-[var(--radius-md)] border border-border bg-popover p-1 text-popover-foreground shadow-[var(--shadow-md)] outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+          className,
+        )}
+        sideOffset={sideOffset}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  );
+}
+
+export function DropdownMenuLabel({
+  className,
+  ...props
+}: ComponentProps<typeof DropdownMenuPrimitive.Label>) {
+  return (
+    <DropdownMenuPrimitive.Label
+      className={cn(
+        "px-2 py-1.5 text-[length:var(--font-size-xs)] font-medium text-[var(--text-tertiary)]",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function DropdownMenuItem({
+  className,
+  variant,
+  ...props
+}: ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+  variant?: "default" | "destructive";
+}) {
+  return (
+    <DropdownMenuPrimitive.Item
+      className={cn(
+        "relative flex cursor-default select-none items-center gap-2 rounded-[var(--radius-sm)] px-2 py-1.5 text-[length:var(--font-size-sm)] outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-[var(--opacity-disabled)] [&_svg]:size-4 [&_svg]:shrink-0",
+        variant === "destructive" &&
+          "text-[var(--semantic-danger-fg)] focus:bg-[var(--semantic-danger-bg)] focus:text-[var(--semantic-danger-fg)]",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function DropdownMenuSeparator({
+  className,
+  ...props
+}: ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      className={cn("-mx-1 my-1 h-px bg-[var(--border-divider)]", className)}
+      {...props}
+    />
+  );
+}

--- a/packages/app/src/routeTree.gen.ts
+++ b/packages/app/src/routeTree.gen.ts
@@ -17,6 +17,7 @@ import { Route as ApiEventsRouteImport } from './routes/api/events'
 import { Route as ApiAuthRouteImport } from './routes/api/auth'
 import { Route as ApiProjectsProjectIdRouteImport } from './routes/api/projects/$projectId'
 import { Route as ApiChatsChatIdRouteImport } from './routes/api/chats/$chatId'
+import { Route as ApiProjectsProjectIdWorktreesRouteImport } from './routes/api/projects/$projectId/worktrees'
 import { Route as ApiProjectsProjectIdChatsRouteImport } from './routes/api/projects/$projectId/chats'
 import { Route as ApiChatsChatIdSteerRouteImport } from './routes/api/chats/$chatId/steer'
 import { Route as ApiChatsChatIdMessagesRouteImport } from './routes/api/chats/$chatId/messages'
@@ -64,6 +65,12 @@ const ApiChatsChatIdRoute = ApiChatsChatIdRouteImport.update({
   path: '/api/chats/$chatId',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiProjectsProjectIdWorktreesRoute =
+  ApiProjectsProjectIdWorktreesRouteImport.update({
+    id: '/worktrees',
+    path: '/worktrees',
+    getParentRoute: () => ApiProjectsProjectIdRoute,
+  } as any)
 const ApiProjectsProjectIdChatsRoute =
   ApiProjectsProjectIdChatsRouteImport.update({
     id: '/chats',
@@ -111,6 +118,7 @@ export interface FileRoutesByFullPath {
   '/api/chats/$chatId/messages': typeof ApiChatsChatIdMessagesRoute
   '/api/chats/$chatId/steer': typeof ApiChatsChatIdSteerRoute
   '/api/projects/$projectId/chats': typeof ApiProjectsProjectIdChatsRoute
+  '/api/projects/$projectId/worktrees': typeof ApiProjectsProjectIdWorktreesRoute
   '/api/chats/$chatId/approvals/$requestId': typeof ApiChatsChatIdApprovalsRequestIdRoute
 }
 export interface FileRoutesByTo {
@@ -127,6 +135,7 @@ export interface FileRoutesByTo {
   '/api/chats/$chatId/messages': typeof ApiChatsChatIdMessagesRoute
   '/api/chats/$chatId/steer': typeof ApiChatsChatIdSteerRoute
   '/api/projects/$projectId/chats': typeof ApiProjectsProjectIdChatsRoute
+  '/api/projects/$projectId/worktrees': typeof ApiProjectsProjectIdWorktreesRoute
   '/api/chats/$chatId/approvals/$requestId': typeof ApiChatsChatIdApprovalsRequestIdRoute
 }
 export interface FileRoutesById {
@@ -144,6 +153,7 @@ export interface FileRoutesById {
   '/api/chats/$chatId/messages': typeof ApiChatsChatIdMessagesRoute
   '/api/chats/$chatId/steer': typeof ApiChatsChatIdSteerRoute
   '/api/projects/$projectId/chats': typeof ApiProjectsProjectIdChatsRoute
+  '/api/projects/$projectId/worktrees': typeof ApiProjectsProjectIdWorktreesRoute
   '/api/chats/$chatId/approvals/$requestId': typeof ApiChatsChatIdApprovalsRequestIdRoute
 }
 export interface FileRouteTypes {
@@ -162,6 +172,7 @@ export interface FileRouteTypes {
     | '/api/chats/$chatId/messages'
     | '/api/chats/$chatId/steer'
     | '/api/projects/$projectId/chats'
+    | '/api/projects/$projectId/worktrees'
     | '/api/chats/$chatId/approvals/$requestId'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -178,6 +189,7 @@ export interface FileRouteTypes {
     | '/api/chats/$chatId/messages'
     | '/api/chats/$chatId/steer'
     | '/api/projects/$projectId/chats'
+    | '/api/projects/$projectId/worktrees'
     | '/api/chats/$chatId/approvals/$requestId'
   id:
     | '__root__'
@@ -194,6 +206,7 @@ export interface FileRouteTypes {
     | '/api/chats/$chatId/messages'
     | '/api/chats/$chatId/steer'
     | '/api/projects/$projectId/chats'
+    | '/api/projects/$projectId/worktrees'
     | '/api/chats/$chatId/approvals/$requestId'
   fileRoutesById: FileRoutesById
 }
@@ -265,6 +278,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiChatsChatIdRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/projects/$projectId/worktrees': {
+      id: '/api/projects/$projectId/worktrees'
+      path: '/worktrees'
+      fullPath: '/api/projects/$projectId/worktrees'
+      preLoaderRoute: typeof ApiProjectsProjectIdWorktreesRouteImport
+      parentRoute: typeof ApiProjectsProjectIdRoute
+    }
     '/api/projects/$projectId/chats': {
       id: '/api/projects/$projectId/chats'
       path: '/chats'
@@ -312,10 +332,12 @@ declare module '@tanstack/react-router' {
 
 interface ApiProjectsProjectIdRouteChildren {
   ApiProjectsProjectIdChatsRoute: typeof ApiProjectsProjectIdChatsRoute
+  ApiProjectsProjectIdWorktreesRoute: typeof ApiProjectsProjectIdWorktreesRoute
 }
 
 const ApiProjectsProjectIdRouteChildren: ApiProjectsProjectIdRouteChildren = {
   ApiProjectsProjectIdChatsRoute: ApiProjectsProjectIdChatsRoute,
+  ApiProjectsProjectIdWorktreesRoute: ApiProjectsProjectIdWorktreesRoute,
 }
 
 const ApiProjectsProjectIdRouteWithChildren =

--- a/packages/app/src/routes/api/projects/$projectId/worktrees.ts
+++ b/packages/app/src/routes/api/projects/$projectId/worktrees.ts
@@ -1,0 +1,49 @@
+import { createFileRoute } from "@tanstack/react-router";
+import {
+  getString,
+  handleApiError,
+  json,
+  readJsonObject,
+  type ServerRouteContext,
+} from "../../../../server/http";
+import { getServeServices } from "../../../../server/services";
+
+function getBoolean(
+  body: Record<string, unknown>,
+  key: string,
+): boolean | undefined {
+  const value = body[key];
+  return typeof value === "boolean" ? value : undefined;
+}
+
+export const Route = createFileRoute("/api/projects/$projectId/worktrees")({
+  server: {
+    handlers: {
+      DELETE: async ({ request, params }: ServerRouteContext) => {
+        try {
+          if (!params.projectId) {
+            throw new Error("Project id is required");
+          }
+          const body = await readJsonObject(request);
+          const name = getString(body, "name");
+          if (!name) {
+            throw new Error("Worktree name is required");
+          }
+
+          const result = await getServeServices().deleteProjectWorktree(
+            params.projectId,
+            {
+              name,
+              path: getString(body, "path"),
+              force: getBoolean(body, "force"),
+              keepBranch: getBoolean(body, "keepBranch"),
+            },
+          );
+          return json(result);
+        } catch (error) {
+          return handleApiError(error);
+        }
+      },
+    },
+  },
+});

--- a/packages/app/src/routes/index.tsx
+++ b/packages/app/src/routes/index.tsx
@@ -11,10 +11,12 @@ import {
   Inbox,
   MessageSquare,
   MessageSquarePlus,
+  MoreHorizontal,
   Plus,
   Send,
   Sparkles,
   Square,
+  Trash2,
   X,
 } from "lucide-react";
 import type { ReactNode } from "react";
@@ -37,6 +39,12 @@ import {
   DialogHeader,
   DialogTitle,
 } from "../components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "../components/ui/dropdown-menu";
 import { Input } from "../components/ui/input";
 import { Label } from "../components/ui/label";
 import {
@@ -134,6 +142,11 @@ interface PendingApproval {
   params: unknown;
 }
 
+interface DeleteWorktreeTarget {
+  projectId: string;
+  worktreePath: string;
+}
+
 type VisibleMessageRecord = ChatMessageRecord & {
   role: "assistant" | "error" | "user";
 };
@@ -198,6 +211,12 @@ function Home() {
   const [messages, setMessages] = useState<ChatMessageRecord[]>([]);
   const [isAddProjectOpen, setIsAddProjectOpen] = useState(false);
   const [projectPath, setProjectPath] = useState("");
+  const [deleteWorktreeTarget, setDeleteWorktreeTarget] =
+    useState<DeleteWorktreeTarget | null>(null);
+  const [deleteWorktreeBranchMode, setDeleteWorktreeBranchMode] = useState<
+    "default" | "keep" | "delete"
+  >("default");
+  const [deleteWorktreeForce, setDeleteWorktreeForce] = useState(false);
   const [composerText, setComposerText] = useState("");
   const [models, setModels] = useState<CodexModelRecord[]>([]);
   const [selectedModelId, setSelectedModelId] = useState<string | null>(null);
@@ -216,6 +235,7 @@ function Home() {
   const [error, setError] = useState<string | null>(null);
   const [isBusy, setIsBusy] = useState(false);
   const createChatInFlightRef = useRef(false);
+  const selectedProjectIdRef = useRef<string | null>(null);
   const selectedChatIdRef = useRef<string | null>(null);
   const selectedChatVersionRef = useRef(0);
   const sendMessageRequestIdRef = useRef(0);
@@ -311,6 +331,27 @@ function Home() {
     [fileSearchResults, selectedFiles],
   );
 
+  const pendingDeleteProject = useMemo(
+    () =>
+      deleteWorktreeTarget
+        ? (projects.find(
+            (project) => project.id === deleteWorktreeTarget.projectId,
+          ) ?? null)
+        : null,
+    [deleteWorktreeTarget, projects],
+  );
+
+  const pendingDeleteWorktree = useMemo(() => {
+    if (!deleteWorktreeTarget) {
+      return null;
+    }
+    return (
+      (worktreesByProject[deleteWorktreeTarget.projectId] ?? []).find(
+        (worktree) => worktree.path === deleteWorktreeTarget.worktreePath,
+      ) ?? null
+    );
+  }, [deleteWorktreeTarget, worktreesByProject]);
+
   const selectedWorktree = useMemo(() => {
     if (!selectedProjectId || !selectedWorktreePath) {
       return null;
@@ -350,6 +391,7 @@ function Home() {
   }, []);
 
   useEffect(() => {
+    selectedProjectIdRef.current = selectedProjectId;
     if (!selectedProjectId) {
       setSelectedChatId(null);
       return;
@@ -595,7 +637,7 @@ function Home() {
 
   async function refreshChats(
     projectId: string,
-    options: { sync?: boolean } = {},
+    options: { sync?: boolean; updateSelection?: boolean } = {},
   ) {
     const projectData = await loadProjectData(projectId, options);
     setChatsByProject((current) => ({
@@ -606,6 +648,9 @@ function Home() {
       ...current,
       [projectId]: projectData.worktrees,
     }));
+    if (options.updateSelection === false) {
+      return;
+    }
     const fallbackWorktree = firstProjectWorktree(projectId, {
       ...worktreesByProject,
       [projectId]: projectData.worktrees,
@@ -709,6 +754,64 @@ function Home() {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
       createChatInFlightRef.current = false;
+      setIsBusy(false);
+    }
+  }
+
+  function openDeleteWorktree(
+    projectId: string,
+    worktree: ProjectWorktreeRecord,
+  ) {
+    setError(null);
+    setDeleteWorktreeBranchMode("default");
+    setDeleteWorktreeForce(false);
+    setDeleteWorktreeTarget({ projectId, worktreePath: worktree.path });
+  }
+
+  function closeDeleteWorktreeDialog() {
+    setDeleteWorktreeTarget(null);
+    setDeleteWorktreeBranchMode("default");
+    setDeleteWorktreeForce(false);
+  }
+
+  async function deleteSelectedWorktree(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!deleteWorktreeTarget || !pendingDeleteWorktree) {
+      return;
+    }
+
+    setError(null);
+    setIsBusy(true);
+    try {
+      const projectId = deleteWorktreeTarget.projectId;
+      const deleteWorktreeInput: {
+        force: boolean;
+        keepBranch?: boolean;
+        name: string;
+        path: string;
+      } = {
+        name: pendingDeleteWorktree.name,
+        path: pendingDeleteWorktree.path,
+        force: deleteWorktreeForce,
+      };
+      if (deleteWorktreeBranchMode === "keep") {
+        deleteWorktreeInput.keepBranch = true;
+      }
+      if (deleteWorktreeBranchMode === "delete") {
+        deleteWorktreeInput.keepBranch = false;
+      }
+      await fetchJson(`/api/projects/${projectId}/worktrees`, {
+        method: "DELETE",
+        body: JSON.stringify(deleteWorktreeInput),
+      });
+      closeDeleteWorktreeDialog();
+      await refreshChats(projectId, {
+        sync: true,
+        updateSelection: selectedProjectIdRef.current === projectId,
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
       setIsBusy(false);
     }
   }
@@ -946,32 +1049,71 @@ function Home() {
                               </li>
                             ) : (
                               projectWorktrees.map((worktree) => {
+                                const isSelectedWorktree =
+                                  worktree.path === selectedWorktreePath;
                                 const title = `${worktree.name} (${worktree.path})${
                                   worktree.isClean ? "" : " [dirty]"
                                 }`;
+                                const canDeleteWorktree =
+                                  worktree.isManagedByPhantom;
                                 return (
                                   <SidebarMenuSubItem key={worktree.path}>
-                                    <SidebarMenuSubButton
-                                      disabled={!worktree.chatId}
-                                      isActive={
-                                        worktree.path === selectedWorktreePath
-                                      }
-                                      onClick={() =>
-                                        selectWorktree(project.id, worktree)
-                                      }
-                                      title={title}
-                                      type="button"
-                                    >
-                                      <GitBranch className="size-3.5 text-[var(--icon-color-default)]" />
-                                      <span className="min-w-0 flex-1">
-                                        <span className="block truncate font-medium">
-                                          {worktree.name}
+                                    <div className="group/worktree flex items-center rounded-[var(--radius-sm)]">
+                                      <SidebarMenuSubButton
+                                        disabled={!worktree.chatId}
+                                        isActive={isSelectedWorktree}
+                                        onClick={() =>
+                                          selectWorktree(project.id, worktree)
+                                        }
+                                        title={title}
+                                        type="button"
+                                      >
+                                        <GitBranch className="size-3.5 text-[var(--icon-color-default)]" />
+                                        <span className="min-w-0 flex-1">
+                                          <span className="block truncate font-medium">
+                                            {worktree.name}
+                                          </span>
                                         </span>
-                                      </span>
-                                      {!worktree.isClean && (
-                                        <span className="size-1.5 shrink-0 rounded-full bg-[var(--semantic-warning-fg)]" />
+                                        {!worktree.isClean && (
+                                          <span className="size-1.5 shrink-0 rounded-full bg-[var(--semantic-warning-fg)]" />
+                                        )}
+                                      </SidebarMenuSubButton>
+                                      {canDeleteWorktree && (
+                                        <DropdownMenu>
+                                          <DropdownMenuTrigger asChild>
+                                            <Button
+                                              aria-label={`Open actions for ${worktree.name}`}
+                                              className={cn(
+                                                "mr-1 size-7 text-[var(--icon-color-default)] opacity-100 data-[state=open]:opacity-100 sm:opacity-0 sm:group-focus-within/worktree:opacity-100 sm:group-hover/worktree:opacity-100",
+                                                isSelectedWorktree &&
+                                                  "sm:opacity-100",
+                                              )}
+                                              disabled={isBusy}
+                                              size="icon"
+                                              title="Worktree actions"
+                                              type="button"
+                                              variant="ghost"
+                                            >
+                                              <MoreHorizontal className="size-4" />
+                                            </Button>
+                                          </DropdownMenuTrigger>
+                                          <DropdownMenuContent align="end">
+                                            <DropdownMenuItem
+                                              onSelect={() =>
+                                                openDeleteWorktree(
+                                                  project.id,
+                                                  worktree,
+                                                )
+                                              }
+                                              variant="destructive"
+                                            >
+                                              <Trash2 className="size-4" />
+                                              <span>Delete worktree</span>
+                                            </DropdownMenuItem>
+                                          </DropdownMenuContent>
+                                        </DropdownMenu>
                                       )}
-                                    </SidebarMenuSubButton>
+                                    </div>
                                   </SidebarMenuSubItem>
                                 );
                               })
@@ -1018,6 +1160,85 @@ function Home() {
               </Button>
               <Button disabled={isBusy || !projectPath.trim()} type="submit">
                 Add project
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={Boolean(deleteWorktreeTarget)}
+        onOpenChange={(open) => {
+          if (!open) {
+            closeDeleteWorktreeDialog();
+          }
+        }}
+      >
+        <DialogContent aria-labelledby="delete-worktree-title">
+          <DialogHeader>
+            <DialogTitle id="delete-worktree-title">
+              Delete worktree
+            </DialogTitle>
+            <DialogDescription>
+              Remove this worktree from{" "}
+              {pendingDeleteProject?.name ?? "the project"}.
+            </DialogDescription>
+          </DialogHeader>
+          <form className="grid gap-4" onSubmit={deleteSelectedWorktree}>
+            <div className="grid gap-2 rounded-[var(--radius-sm)] bg-[var(--surface-code)] px-3 py-2">
+              <p className="truncate text-[length:var(--font-size-sm)] font-medium">
+                {pendingDeleteWorktree?.name ?? "Unknown worktree"}
+              </p>
+              {pendingDeleteWorktree && (
+                <p className="truncate font-mono text-[length:var(--font-size-xs)] text-muted-foreground">
+                  {pendingDeleteWorktree.path}
+                </p>
+              )}
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="delete-worktree-branch-mode">
+                Branch handling
+              </Label>
+              <select
+                className="h-9 rounded-[var(--radius-sm)] border border-input bg-background px-3 text-[length:var(--font-size-sm)] shadow-xs outline-none transition-[border-color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50"
+                id="delete-worktree-branch-mode"
+                onChange={(event) =>
+                  setDeleteWorktreeBranchMode(
+                    event.target.value as "default" | "keep" | "delete",
+                  )
+                }
+                value={deleteWorktreeBranchMode}
+              >
+                <option value="default">Use project preference</option>
+                <option value="keep">Keep branch</option>
+                <option value="delete">Delete branch</option>
+              </select>
+            </div>
+            <label className="flex items-start gap-2 text-[length:var(--font-size-sm)] text-[var(--semantic-danger-fg)]">
+              <input
+                checked={deleteWorktreeForce}
+                className="mt-0.5 size-4 accent-[var(--semantic-danger-fg)]"
+                onChange={(event) =>
+                  setDeleteWorktreeForce(event.target.checked)
+                }
+                type="checkbox"
+              />
+              <span>Force delete uncommitted changes</span>
+            </label>
+            <DialogFooter>
+              <Button
+                onClick={closeDeleteWorktreeDialog}
+                type="button"
+                variant="outline"
+              >
+                Cancel
+              </Button>
+              <Button
+                disabled={isBusy || !pendingDeleteWorktree}
+                type="submit"
+                variant="destructive"
+              >
+                Delete
               </Button>
             </DialogFooter>
           </form>

--- a/packages/app/src/server/services.test.ts
+++ b/packages/app/src/server/services.test.ts
@@ -9,7 +9,9 @@ import type { ChatRecord, ProjectRecord, ServeState } from "@phantompane/state";
 import { ServeServices } from "./services";
 
 const coreMocks = vi.hoisted(() => ({
+  createContext: vi.fn(),
   deleteBranch: vi.fn(),
+  deleteWorktree: vi.fn(),
   listWorktrees: vi.fn(),
   removeWorktree: vi.fn(),
   runCreateWorktree: vi.fn(),
@@ -298,11 +300,48 @@ describe("ServeServices", () => {
         pathToDisplay: "/repo",
         branch: "main",
         isClean: true,
+        isManagedByPhantom: false,
         chatId: "chat_1",
         chatStatus: "idle",
         chatTitle: "Persisted main",
       },
     ]);
+  });
+
+  it("preserves managed status when returning persisted chats without sync", async () => {
+    const worktreePath = "/repo/.git/phantom/worktrees/feature";
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [
+        createChat({
+          branchName: "feature",
+          title: "Persisted feature",
+          worktreeName: "feature",
+          worktreePath,
+        }),
+      ],
+    };
+    const { services } = await createHarness(state);
+
+    const worktrees = await services.listProjectWorktrees("proj_1", {
+      sync: false,
+    });
+
+    deepStrictEqual(worktrees, [
+      {
+        name: "feature",
+        path: worktreePath,
+        pathToDisplay: worktreePath,
+        branch: "feature",
+        isClean: true,
+        isManagedByPhantom: true,
+        chatId: "chat_1",
+        chatStatus: "idle",
+        chatTitle: "Persisted feature",
+      },
+    ]);
+    strictEqual(coreMocks.listWorktrees.mock.calls.length, 0);
   });
 
   it("imports existing Codex chat history for project worktrees", async () => {
@@ -899,6 +938,396 @@ describe("ServeServices", () => {
     ]);
     deepStrictEqual(coreMocks.deleteBranch.mock.calls[0], ["/repo", "feature"]);
     strictEqual((await store.load()).chats.length, 0);
+  });
+
+  it("deletes a project worktree and removes its local chat history", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [
+        createChat({
+          id: "chat_feature",
+          worktreeName: "feature",
+          worktreePath: "/repo/.git/phantom/worktrees/feature",
+          branchName: "feature",
+        }),
+        createChat({
+          id: "chat_other",
+          worktreeName: "other",
+          worktreePath: "/repo/.git/phantom/worktrees/other",
+          branchName: "other",
+        }),
+      ],
+      messages: [
+        {
+          id: "msg_feature",
+          chatId: "chat_feature",
+          role: "user" as const,
+          text: "remove me",
+          createdAt: timestamp,
+        },
+        {
+          id: "msg_other",
+          chatId: "chat_other",
+          role: "user" as const,
+          text: "keep me",
+          createdAt: timestamp,
+        },
+      ],
+      selectedChatId: "chat_feature",
+    };
+    const { services, store } = await createHarness(state);
+    coreMocks.createContext.mockResolvedValueOnce({
+      gitRoot: "/repo",
+      worktreesDirectory: "/repo/.git/phantom/worktrees",
+      preferences: { keepBranch: true },
+      config: { preDelete: { commands: ["pnpm stop"] } },
+    });
+    coreMocks.listWorktrees.mockResolvedValueOnce({
+      ok: true,
+      value: {
+        worktrees: [
+          {
+            name: "feature",
+            path: "/repo/.git/phantom/worktrees/feature",
+            pathToDisplay: ".git/phantom/worktrees/feature",
+            branch: "feature",
+            isClean: true,
+          },
+        ],
+      },
+    });
+    coreMocks.deleteWorktree.mockResolvedValueOnce({
+      ok: true,
+      value: { message: "Deleted worktree 'feature'" },
+    });
+
+    const result = await services.deleteProjectWorktree("proj_1", {
+      name: "feature",
+      force: true,
+    });
+
+    deepStrictEqual(result, { message: "Deleted worktree 'feature'" });
+    deepStrictEqual(coreMocks.deleteWorktree.mock.calls[0], [
+      "/repo",
+      "/repo/.git/phantom/worktrees",
+      "feature",
+      {
+        force: true,
+        keepBranch: true,
+        path: "/repo/.git/phantom/worktrees/feature",
+      },
+      ["pnpm stop"],
+    ]);
+    const savedState = await store.load();
+    deepStrictEqual(
+      savedState.chats.map((chat) => chat.id),
+      ["chat_other"],
+    );
+    deepStrictEqual(
+      savedState.messages.map((message) => message.id),
+      ["msg_other"],
+    );
+    strictEqual(savedState.selectedChatId, null);
+  });
+
+  it("deletes persisted chats matched by worktree path when names drift", async () => {
+    const worktreePath = "/repo/.git/phantom/worktrees/renamed";
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [
+        createChat({
+          id: "chat_renamed",
+          worktreeName: "old-name",
+          worktreePath,
+          branchName: "old-name",
+        }),
+      ],
+      messages: [
+        {
+          id: "msg_renamed",
+          chatId: "chat_renamed",
+          role: "user" as const,
+          text: "remove me too",
+          createdAt: timestamp,
+        },
+      ],
+      selectedChatId: "chat_renamed",
+    };
+    const { services, store } = await createHarness(state);
+    coreMocks.createContext.mockResolvedValueOnce({
+      gitRoot: "/repo",
+      worktreesDirectory: "/repo/.git/phantom/worktrees",
+      preferences: {},
+      config: {},
+    });
+    coreMocks.listWorktrees.mockResolvedValueOnce({
+      ok: true,
+      value: {
+        worktrees: [
+          {
+            name: "renamed",
+            path: worktreePath,
+            pathToDisplay: ".git/phantom/worktrees/renamed",
+            branch: "renamed",
+            isClean: true,
+          },
+        ],
+      },
+    });
+    coreMocks.deleteWorktree.mockResolvedValueOnce({
+      ok: true,
+      value: { message: "Deleted worktree 'renamed'" },
+    });
+
+    await services.deleteProjectWorktree("proj_1", { name: "renamed" });
+
+    const savedState = await store.load();
+    deepStrictEqual(savedState.chats, []);
+    deepStrictEqual(savedState.messages, []);
+    strictEqual(savedState.selectedChatId, null);
+  });
+
+  it("rejects deleting worktrees outside the managed Phantom directory", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+    };
+    const { services } = await createHarness(state);
+    coreMocks.createContext.mockResolvedValueOnce({
+      gitRoot: "/repo",
+      worktreesDirectory: "/repo/.git/phantom/worktrees",
+      preferences: {},
+      config: {},
+    });
+    coreMocks.listWorktrees.mockResolvedValueOnce({
+      ok: true,
+      value: {
+        worktrees: [
+          {
+            name: "feature",
+            path: "/repo/other-worktree",
+            pathToDisplay: "other-worktree",
+            branch: "feature",
+            isClean: true,
+          },
+          {
+            name: "feature",
+            path: "/repo/.git/phantom/worktrees/feature",
+            pathToDisplay: ".git/phantom/worktrees/feature",
+            branch: "feature",
+            isClean: true,
+          },
+        ],
+      },
+    });
+
+    await rejects(
+      services.deleteProjectWorktree("proj_1", {
+        name: "feature",
+        path: "/repo/other-worktree",
+      }),
+      /not managed by Phantom/,
+    );
+
+    strictEqual(coreMocks.deleteWorktree.mock.calls.length, 0);
+  });
+
+  it("deletes and cleans up only the selected worktree path when names collide", async () => {
+    const targetPath = "/repo/.git/phantom/worktrees/first";
+    const otherPath = "/repo/.git/phantom/worktrees/second";
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [
+        createChat({
+          id: "chat_target",
+          branchName: "abc1234",
+          worktreeName: "abc1234",
+          worktreePath: targetPath,
+        }),
+        createChat({
+          id: "chat_other",
+          branchName: "abc1234",
+          worktreeName: "abc1234",
+          worktreePath: otherPath,
+        }),
+      ],
+      messages: [
+        {
+          id: "msg_target",
+          chatId: "chat_target",
+          role: "user" as const,
+          text: "remove me",
+          createdAt: timestamp,
+        },
+        {
+          id: "msg_other",
+          chatId: "chat_other",
+          role: "user" as const,
+          text: "keep me",
+          createdAt: timestamp,
+        },
+      ],
+      selectedChatId: "chat_target",
+    };
+    const { services, store } = await createHarness(state);
+    coreMocks.createContext.mockResolvedValueOnce({
+      gitRoot: "/repo",
+      worktreesDirectory: "/repo/.git/phantom/worktrees",
+      preferences: {},
+      config: {},
+    });
+    coreMocks.listWorktrees.mockResolvedValueOnce({
+      ok: true,
+      value: {
+        worktrees: [
+          {
+            name: "abc1234",
+            path: targetPath,
+            pathToDisplay: ".git/phantom/worktrees/first",
+            branch: "abc1234",
+            isClean: true,
+          },
+          {
+            name: "abc1234",
+            path: otherPath,
+            pathToDisplay: ".git/phantom/worktrees/second",
+            branch: "abc1234",
+            isClean: true,
+          },
+        ],
+      },
+    });
+    coreMocks.deleteWorktree.mockResolvedValueOnce({
+      ok: true,
+      value: { message: "Deleted worktree 'abc1234'" },
+    });
+
+    await services.deleteProjectWorktree("proj_1", {
+      name: "abc1234",
+      path: targetPath,
+    });
+
+    deepStrictEqual(coreMocks.deleteWorktree.mock.calls[0], [
+      "/repo",
+      "/repo/.git/phantom/worktrees",
+      "abc1234",
+      { force: undefined, keepBranch: false, path: targetPath },
+      undefined,
+    ]);
+    const savedState = await store.load();
+    deepStrictEqual(
+      savedState.chats.map((chat) => chat.id),
+      ["chat_other"],
+    );
+    deepStrictEqual(
+      savedState.messages.map((message) => message.id),
+      ["msg_other"],
+    );
+    strictEqual(savedState.selectedChatId, null);
+  });
+
+  it("does not delete a worktree with an active chat", async () => {
+    const worktreePath = "/repo/.git/phantom/worktrees/worktree";
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [
+        createChat({
+          branchName: "old-name",
+          status: "running",
+          activeTurnId: "turn_1",
+          worktreeName: "old-name",
+          worktreePath,
+        }),
+      ],
+    };
+    const { services } = await createHarness(state);
+    coreMocks.createContext.mockResolvedValueOnce({
+      gitRoot: "/repo",
+      worktreesDirectory: "/repo/.git/phantom/worktrees",
+      preferences: {},
+      config: {},
+    });
+    coreMocks.listWorktrees.mockResolvedValueOnce({
+      ok: true,
+      value: {
+        worktrees: [
+          {
+            name: "worktree",
+            path: worktreePath,
+            pathToDisplay: ".git/phantom/worktrees/worktree",
+            branch: "worktree",
+            isClean: true,
+          },
+        ],
+      },
+    });
+
+    await rejects(
+      services.deleteProjectWorktree("proj_1", { name: "worktree" }),
+      /has an active chat/,
+    );
+
+    strictEqual(coreMocks.deleteWorktree.mock.calls.length, 0);
+  });
+
+  it("does not delete a worktree while a chat is starting a turn", async () => {
+    const worktreePath = "/repo/.git/phantom/worktrees/worktree";
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ worktreePath })],
+    };
+    const { codex, services } = await createHarness(state);
+    let resolveStartTurn: ((value: unknown) => void) | undefined;
+    codex.resumeThread.mockResolvedValueOnce({});
+    codex.startTurn.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveStartTurn = resolve;
+        }),
+    );
+
+    const send = services.sendMessage("chat_1", { text: "start work" });
+    await vi.waitFor(() => {
+      strictEqual(codex.startTurn.mock.calls.length, 1);
+    });
+
+    coreMocks.createContext.mockResolvedValueOnce({
+      gitRoot: "/repo",
+      worktreesDirectory: "/repo/.git/phantom/worktrees",
+      preferences: {},
+      config: {},
+    });
+    coreMocks.listWorktrees.mockResolvedValueOnce({
+      ok: true,
+      value: {
+        worktrees: [
+          {
+            name: "worktree",
+            path: worktreePath,
+            pathToDisplay: ".git/phantom/worktrees/worktree",
+            branch: "worktree",
+            isClean: true,
+          },
+        ],
+      },
+    });
+
+    await rejects(
+      services.deleteProjectWorktree("proj_1", { name: "worktree" }),
+      /has an active chat/,
+    );
+
+    strictEqual(coreMocks.deleteWorktree.mock.calls.length, 0);
+    if (!resolveStartTurn) {
+      throw new Error("startTurn was not invoked");
+    }
+    resolveStartTurn({ turn: { id: "turn_1" } });
+    await send;
   });
 
   it("skips non-directory Codex history roots when creating a worktree", async () => {

--- a/packages/app/src/server/services.ts
+++ b/packages/app/src/server/services.ts
@@ -2,7 +2,9 @@ import { realpath, stat } from "node:fs/promises";
 import { basename, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { getGitRoot } from "@phantompane/git";
 import {
+  createContext,
   deleteBranch,
+  deleteWorktree as deleteWorktreeCore,
   listWorktrees,
   removeWorktree,
   runCreateWorktree,
@@ -47,6 +49,17 @@ import type {
 export interface CreateChatInput {
   name?: string;
   base?: string;
+}
+
+export interface DeleteProjectWorktreeInput {
+  force?: boolean;
+  keepBranch?: boolean;
+  name: string;
+  path?: string;
+}
+
+export interface DeleteProjectWorktreeResult {
+  message: string;
 }
 
 export interface SendMessageInput {
@@ -211,19 +224,34 @@ export class ServeServices {
     options: { sync?: boolean } = {},
   ): Promise<ProjectWorktreeRecord[]> {
     const state = await this.store.load();
+    const project = this.requireProject(state, projectId);
+    const worktreesDirectory = await getProjectWorktreesDirectory(
+      project.rootPath,
+    );
     if (options.sync === false) {
-      return projectWorktreesFromPersistedChats(state, projectId);
+      return projectWorktreesFromPersistedChats(
+        state,
+        projectId,
+        worktreesDirectory,
+      );
     }
 
-    const project = this.requireProject(state, projectId);
     let result;
     try {
       result = await listWorktrees(project.rootPath);
     } catch {
-      return projectWorktreesFromPersistedChats(state, projectId);
+      return projectWorktreesFromPersistedChats(
+        state,
+        projectId,
+        worktreesDirectory,
+      );
     }
     if (!result.ok) {
-      return projectWorktreesFromPersistedChats(state, projectId);
+      return projectWorktreesFromPersistedChats(
+        state,
+        projectId,
+        worktreesDirectory,
+      );
     }
 
     const { worktrees } = result.value;
@@ -345,6 +373,10 @@ export class ServeServices {
         pathToDisplay: worktree.pathToDisplay,
         branch: worktree.branch,
         isClean: worktree.isClean,
+        isManagedByPhantom: isPathInsideDirectory(
+          worktree.path,
+          worktreesDirectory,
+        ),
         chatId: chat?.id ?? null,
         chatStatus: chat?.status ?? null,
         chatTitle: chat?.title ?? worktree.name,
@@ -464,6 +496,91 @@ export class ServeServices {
 
     this.eventHub.emit("chat.created", chat, { chatId: chat.id });
     return chat;
+  }
+
+  async deleteProjectWorktree(
+    projectId: string,
+    input: DeleteProjectWorktreeInput,
+  ): Promise<DeleteProjectWorktreeResult> {
+    const worktreeName = input.name.trim();
+    if (!worktreeName) {
+      throw new Error("Worktree name is required");
+    }
+    const worktreePath = input.path?.trim();
+
+    const state = await this.store.load();
+    const project = this.requireProject(state, projectId);
+    const context = await createContext(project.rootPath);
+    const worktreesResult = await listWorktrees(context.gitRoot, {
+      excludeDefault: true,
+    });
+    const targetWorktree = worktreesResult.ok
+      ? worktreesResult.value.worktrees.find(
+          (worktree) =>
+            worktree.name === worktreeName &&
+            (!worktreePath || worktree.path === worktreePath),
+        )
+      : null;
+    if (!targetWorktree) {
+      throw new Error(`Worktree '${worktreeName}' not found`);
+    }
+    if (
+      !isPathInsideDirectory(targetWorktree.path, context.worktreesDirectory)
+    ) {
+      throw new Error(
+        `Worktree '${worktreeName}' is not managed by Phantom and cannot be deleted from Serve.`,
+      );
+    }
+    const worktreeChats = state.chats.filter(
+      (chat) =>
+        chat.projectId === projectId &&
+        chat.worktreePath === targetWorktree.path,
+    );
+    const activeChat = worktreeChats.find(
+      (chat) =>
+        this.pendingChatTurns.has(chat.id) ||
+        chat.status === "running" ||
+        chat.status === "waitingForApproval" ||
+        Boolean(chat.activeTurnId),
+    );
+    if (activeChat) {
+      throw new Error(
+        `Worktree '${worktreeName}' has an active chat. Stop the chat before deleting the worktree.`,
+      );
+    }
+
+    const result = await deleteWorktreeCore(
+      context.gitRoot,
+      context.worktreesDirectory,
+      worktreeName,
+      {
+        force: input.force,
+        keepBranch: input.keepBranch ?? context.preferences.keepBranch ?? false,
+        path: targetWorktree.path,
+      },
+      context.config?.preDelete?.commands,
+    );
+    if (!result.ok) {
+      throw result.error;
+    }
+
+    const removedChatIds = new Set(worktreeChats.map((chat) => chat.id));
+    await this.store.update((nextState) => ({
+      ...nextState,
+      chats: nextState.chats.filter((chat) => !removedChatIds.has(chat.id)),
+      messages: nextState.messages.filter(
+        (message) => !removedChatIds.has(message.chatId),
+      ),
+      selectedChatId: removedChatIds.has(nextState.selectedChatId ?? "")
+        ? null
+        : nextState.selectedChatId,
+    }));
+
+    this.eventHub.emit("worktree.removed", {
+      projectId,
+      worktreeName,
+    });
+    return { message: result.value.message };
   }
 
   async getChat(chatId: string): Promise<ChatRecord> {
@@ -1254,6 +1371,7 @@ function latestChatForWorktree(chats: ChatRecord[]): ChatRecord | null {
 function projectWorktreesFromPersistedChats(
   state: ServeState,
   projectId: string,
+  worktreesDirectory: string,
 ): ProjectWorktreeRecord[] {
   const chatsByPath = new Map<string, ChatRecord[]>();
   for (const chat of state.chats.filter(
@@ -1275,10 +1393,32 @@ function projectWorktreesFromPersistedChats(
       pathToDisplay: chat.worktreePath,
       branch: chat.branchName,
       isClean: true,
+      isManagedByPhantom: isPathInsideDirectory(
+        chat.worktreePath,
+        worktreesDirectory,
+      ),
       chatId: chat.id,
       chatStatus: chat.status,
       chatTitle: chat.title,
     }));
+}
+
+async function getProjectWorktreesDirectory(
+  projectRootPath: string,
+): Promise<string> {
+  try {
+    const context = await createContext(projectRootPath);
+    return context.worktreesDirectory;
+  } catch {
+    return join(projectRootPath, ".git", "phantom", "worktrees");
+  }
+}
+
+function isPathInsideDirectory(path: string, directory: string): boolean {
+  const relativePath = relative(directory, path);
+  return Boolean(
+    relativePath && !relativePath.startsWith("..") && !isAbsolute(relativePath),
+  );
 }
 
 function shouldSyncProjectWorktreeChats({

--- a/packages/app/src/server/types.ts
+++ b/packages/app/src/server/types.ts
@@ -14,6 +14,7 @@ export interface ProjectWorktreeRecord {
   pathToDisplay: string;
   branch: string;
   isClean: boolean;
+  isManagedByPhantom: boolean;
   chatId: string | null;
   chatStatus: ChatStatus | null;
   chatTitle: string;

--- a/packages/core/src/worktree/delete.test.ts
+++ b/packages/core/src/worktree/delete.test.ts
@@ -150,6 +150,67 @@ describe("deleteWorktree", () => {
     strictEqual(deleteBranchMock.mock.calls.length, 0);
   });
 
+  it("validates the expected worktree path when provided", async () => {
+    resetMocks();
+    validateWorktreeExistsMock.mockResolvedValue(
+      ok({ path: "/test/repo/.git/phantom/worktrees/second" }),
+    );
+    getStatusMock.mockResolvedValue(cleanStatus());
+    removeWorktreeMock.mockResolvedValue(undefined);
+    deleteBranchMock.mockResolvedValue(undefined);
+
+    const result = await deleteWorktree(
+      "/test/repo",
+      "/test/repo/.git/phantom/worktrees",
+      "abc1234",
+      { path: "/test/repo/.git/phantom/worktrees/second" },
+      undefined,
+    );
+
+    strictEqual(isOk(result), true);
+    deepStrictEqual(validateWorktreeExistsMock.mock.calls[0], [
+      "/test/repo",
+      "/test/repo/.git/phantom/worktrees",
+      "abc1234",
+      {
+        excludeDefault: true,
+        expectedPath: "/test/repo/.git/phantom/worktrees/second",
+      },
+    ]);
+    deepStrictEqual(removeWorktreeMock.mock.calls[0], [
+      {
+        gitRoot: "/test/repo",
+        path: "/test/repo/.git/phantom/worktrees/second",
+        force: false,
+      },
+    ]);
+  });
+
+  it("rejects worktrees outside the managed directory", async () => {
+    resetMocks();
+    validateWorktreeExistsMock.mockResolvedValue(
+      ok({ path: "/test/repo/other-worktree" }),
+    );
+
+    const result = await deleteWorktree(
+      "/test/repo",
+      "/test/repo/.git/phantom/worktrees",
+      "feature",
+      {},
+      undefined,
+    );
+
+    strictEqual(isErr(result), true);
+    if (isErr(result)) {
+      strictEqual(
+        result.error.message,
+        "Worktree 'feature' is not managed by Phantom and cannot be deleted.",
+      );
+    }
+    strictEqual(getStatusMock.mock.calls.length, 0);
+    strictEqual(removeWorktreeMock.mock.calls.length, 0);
+  });
+
   it("fails when the worktree does not exist", async () => {
     resetMocks();
     validateWorktreeExistsMock.mockResolvedValue(

--- a/packages/core/src/worktree/delete.ts
+++ b/packages/core/src/worktree/delete.ts
@@ -1,3 +1,4 @@
+import { isAbsolute, relative } from "node:path";
 import {
   deleteBranch as gitDeleteBranch,
   getStatus,
@@ -11,6 +12,7 @@ import { validateWorktreeExists } from "./validate.ts";
 export interface DeleteWorktreeOptions {
   force?: boolean;
   keepBranch?: boolean;
+  path?: string;
 }
 
 export interface DeleteWorktreeSuccess {
@@ -83,18 +85,31 @@ export async function deleteWorktree(
 > {
   const { force = false } = options || {};
   const keepBranch = options?.keepBranch ?? false;
+  const validateOptions: { excludeDefault: true; expectedPath?: string } = {
+    excludeDefault: true,
+  };
+  if (options?.path) {
+    validateOptions.expectedPath = options.path;
+  }
 
   const validation = await validateWorktreeExists(
     gitRoot,
     worktreeDirectory,
     name,
-    { excludeDefault: true },
+    validateOptions,
   );
   if (isErr(validation)) {
     return err(validation.error);
   }
 
   const worktreePath = validation.value.path;
+  if (!isPathInsideDirectory(worktreePath, worktreeDirectory)) {
+    return err(
+      new WorktreeError(
+        `Worktree '${name}' is not managed by Phantom and cannot be deleted.`,
+      ),
+    );
+  }
 
   const status = await getWorktreeChangesStatus(worktreePath);
 
@@ -153,4 +168,11 @@ export async function deleteWorktree(
     const errorMessage = error instanceof Error ? error.message : String(error);
     return err(new WorktreeError(`worktree remove failed: ${errorMessage}`));
   }
+}
+
+function isPathInsideDirectory(path: string, directory: string): boolean {
+  const relativePath = relative(directory, path);
+  return Boolean(
+    relativePath && !relativePath.startsWith("..") && !isAbsolute(relativePath),
+  );
 }

--- a/packages/core/src/worktree/validate.test.ts
+++ b/packages/core/src/worktree/validate.test.ts
@@ -69,6 +69,77 @@ describe("validateWorktreeExists", () => {
     }
   });
 
+  it("should return ok for worktrees outside the managed directory", async () => {
+    resetMocks();
+    listWorktreesMock.mockImplementation(() =>
+      Promise.resolve(
+        ok({
+          worktrees: [
+            {
+              name: "my-feature",
+              path: "/test/repo/other-worktree",
+              branch: "my-feature",
+              isClean: true,
+            },
+          ],
+        }),
+      ),
+    );
+
+    const result = await validateWorktreeExists(
+      "/test/repo",
+      "/test/repo/.git/phantom/worktrees",
+      "my-feature",
+    );
+
+    deepStrictEqual(isOk(result), true);
+    if (isOk(result)) {
+      deepStrictEqual(result.value, {
+        path: "/test/repo/other-worktree",
+      });
+    }
+  });
+
+  it("should use the expected path when worktree names collide", async () => {
+    resetMocks();
+    listWorktreesMock.mockImplementation(() =>
+      Promise.resolve(
+        ok({
+          worktrees: [
+            {
+              name: "abc1234",
+              path: "/test/repo/.git/phantom/worktrees/first",
+              branch: "abc1234",
+              isClean: true,
+            },
+            {
+              name: "abc1234",
+              path: "/test/repo/.git/phantom/worktrees/second",
+              branch: "abc1234",
+              isClean: true,
+            },
+          ],
+        }),
+      ),
+    );
+
+    const result = await validateWorktreeExists(
+      "/test/repo",
+      "/test/repo/.git/phantom/worktrees",
+      "abc1234",
+      {
+        expectedPath: "/test/repo/.git/phantom/worktrees/second",
+      },
+    );
+
+    deepStrictEqual(isOk(result), true);
+    if (isOk(result)) {
+      deepStrictEqual(result.value, {
+        path: "/test/repo/.git/phantom/worktrees/second",
+      });
+    }
+  });
+
   it("should return err when worktree listing fails", async () => {
     resetMocks();
     listWorktreesMock.mockImplementation(() =>

--- a/packages/core/src/worktree/validate.ts
+++ b/packages/core/src/worktree/validate.ts
@@ -7,20 +7,25 @@ export interface WorktreeExistsSuccess {
   path: string;
 }
 
+export interface ValidateWorktreeExistsOptions extends ListWorktreesOptions {
+  expectedPath?: string;
+}
+
 export async function validateWorktreeExists(
   gitRoot: string,
   _worktreeDirectory: string,
   name: string,
-  options: ListWorktreesOptions = {},
+  options: ValidateWorktreeExistsOptions = {},
 ): Promise<Result<WorktreeExistsSuccess, WorktreeNotFoundError>> {
-  const worktreesResult = await listWorktrees(gitRoot, options);
+  const { expectedPath, ...listOptions } = options;
+  const worktreesResult = await listWorktrees(gitRoot, listOptions);
 
   if (isErr(worktreesResult)) {
     return err(new WorktreeNotFoundError(name));
   }
 
   const worktree = worktreesResult.value.worktrees.find(
-    (wt) => wt.name === name,
+    (wt) => wt.name === name && (!expectedPath || wt.path === expectedPath),
   );
 
   if (!worktree) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       '@phantompane/state':
         specifier: workspace:*
         version: link:../state
+      '@radix-ui/react-dropdown-menu':
+        specifier: ^2.1.16
+        version: 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@tanstack/react-router':
         specifier: ^1.168.22
         version: 1.168.22(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -1039,6 +1042,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-dropdown-menu@2.1.16':
+    resolution: {integrity: sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-focus-guards@1.1.3':
     resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
     peerDependencies:
@@ -1077,6 +1093,19 @@ packages:
 
   '@radix-ui/react-label@2.1.8':
     resolution: {integrity: sha512-FmXs37I6hSBVDlO4y764TNz1rLgKwjJMQ0EGte6F3Cb3f4bIuHB/iLa/8I9VKkmOy+gNHq8rql3j686ACVV21A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-menu@2.1.16':
+    resolution: {integrity: sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -3900,6 +3929,12 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  '@floating-ui/react-dom@2.1.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
   '@floating-ui/utils@0.2.11': {}
 
   '@hono/node-server@1.19.13(hono@4.12.12)':
@@ -4311,6 +4346,15 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-checkbox@1.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -4339,15 +4383,39 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-collection@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.14)(react@18.3.1)':
     dependencies:
       react: 18.3.1
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-context@1.1.2(@types/react@19.2.14)(react@18.3.1)':
     dependencies:
       react: 18.3.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-context@1.1.2(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
     optionalDependencies:
       '@types/react': 19.2.14
 
@@ -4379,6 +4447,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-direction@1.1.1(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -4392,9 +4466,43 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-dropdown-menu@2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.14)(react@18.3.1)':
     dependencies:
       react: 18.3.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
     optionalDependencies:
       '@types/react': 19.2.14
 
@@ -4405,6 +4513,17 @@ snapshots:
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -4420,11 +4539,44 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-id@1.1.1(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-label@2.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-menu@2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      aria-hidden: 1.2.6
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.5)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -4470,12 +4622,40 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-popper@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-rect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/rect': 1.1.1
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -4490,11 +4670,30 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -4521,6 +4720,23 @@ snapshots:
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -4558,6 +4774,13 @@ snapshots:
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@18.3.1)
       react: 18.3.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-slot@1.2.3(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
     optionalDependencies:
       '@types/react': 19.2.14
 
@@ -4645,11 +4868,25 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.14)(react@18.3.1)':
     dependencies:
       '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@18.3.1)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@18.3.1)
       react: 18.3.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
     optionalDependencies:
       '@types/react': 19.2.14
 
@@ -4660,6 +4897,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.14)(react@18.3.1)':
     dependencies:
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@18.3.1)
@@ -4667,9 +4911,22 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.14)(react@18.3.1)':
     dependencies:
       react: 18.3.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
     optionalDependencies:
       '@types/react': 19.2.14
 
@@ -4686,10 +4943,24 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-use-rect@1.1.1(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@radix-ui/rect': 1.1.1
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-use-size@1.1.1(@types/react@19.2.14)(react@18.3.1)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@18.3.1)
       react: 18.3.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-size@1.1.1(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
     optionalDependencies:
       '@types/react': 19.2.14
 
@@ -6206,6 +6477,14 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.5)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   react-remove-scroll@2.7.2(@types/react@19.2.14)(react@18.3.1):
     dependencies:
       react: 18.3.1
@@ -6214,6 +6493,17 @@ snapshots:
       tslib: 2.8.1
       use-callback-ref: 1.3.3(@types/react@19.2.14)(react@18.3.1)
       use-sidecar: 1.1.3(@types/react@19.2.14)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  react-remove-scroll@2.7.2(@types/react@19.2.14)(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      react-remove-scroll-bar: 2.3.8(@types/react@19.2.14)(react@19.2.5)
+      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.5)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@19.2.14)(react@19.2.5)
+      use-sidecar: 1.1.3(@types/react@19.2.14)(react@19.2.5)
     optionalDependencies:
       '@types/react': 19.2.14
 
@@ -6226,6 +6516,14 @@ snapshots:
     dependencies:
       get-nonce: 1.0.1
       react: 18.3.1
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  react-style-singleton@2.2.3(@types/react@19.2.14)(react@19.2.5):
+    dependencies:
+      get-nonce: 1.0.1
+      react: 19.2.5
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.14
@@ -6629,10 +6927,25 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  use-callback-ref@1.3.3(@types/react@19.2.14)(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   use-sidecar@1.1.3(@types/react@19.2.14)(react@18.3.1):
     dependencies:
       detect-node-es: 1.1.0
       react: 18.3.1
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  use-sidecar@1.1.3(@types/react@19.2.14)(react@19.2.5):
+    dependencies:
+      detect-node-es: 1.1.0
+      react: 19.2.5
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.14


### PR DESCRIPTION
## Summary
- add a Serve API endpoint that deletes project worktrees through the existing core delete flow
- remove local chat/message records for deleted worktrees and block deletion while a chat is active
- add a shadcn/Radix dropdown menu primitive and expose worktree delete from a row actions menu
- keep the existing confirmation flow with keep-branch and force-delete options

## Verification
- `pnpm ready`

## Notes
- PR title follows the recent repository pattern (`feat: ...`) and intentionally does not use a `[codex]` prefix.