### PR TITLE
fix: remove stale pnpm action versions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -22,8 +22,6 @@ jobs:
 
       - name: Set up pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320
-        with:
-          version: 10.8.1
 
       - name: Set up Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f

--- a/.github/workflows/release-compile.yml
+++ b/.github/workflows/release-compile.yml
@@ -20,8 +20,6 @@ jobs:
 
       - name: Set up pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320
-        with:
-          version: 10.8.1
 
       - name: Set up Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -32,8 +32,6 @@ jobs:
 
       - name: Set up pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320
-        with:
-          version: 10.8.1
 
       - name: Set up Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f


### PR DESCRIPTION
## Summary
- remove stale `version: 10.8.1` inputs from pnpm setup steps in release and version workflows
- let `pnpm/action-setup` read the canonical pnpm version from `package.json` (`packageManager: pnpm@10.33.2`)

## Why
The version bump workflow failed during the pnpm setup step because GitHub Actions specified pnpm 10.8.1 while `package.json` declares pnpm 10.33.2. `pnpm/action-setup` rejects that mismatch before dependencies can install.

## Verification
- `pnpm ready`