### PR TITLE
[codex] Add app loading states

### DIFF
--- a/packages/app/src/components/loading.tsx
+++ b/packages/app/src/components/loading.tsx
@@ -1,0 +1,170 @@
+import { LoaderCircle } from "lucide-react";
+import type { ReactNode } from "react";
+import { cn } from "../lib/utils";
+
+export function LoadingSpinner({ className }: { className?: string }) {
+  return (
+    <LoaderCircle
+      aria-hidden="true"
+      className={cn("size-4 animate-spin", className)}
+    />
+  );
+}
+
+export function Skeleton({ className }: { className?: string }) {
+  return (
+    <span
+      aria-hidden="true"
+      className={cn(
+        "block animate-pulse rounded-[var(--radius-sm)] bg-[var(--color-gray-200)]",
+        className,
+      )}
+    />
+  );
+}
+
+export function InlineLoading({
+  className,
+  label,
+}: {
+  className?: string;
+  label: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "inline-flex items-center gap-2 text-[length:var(--font-size-xs)] text-[var(--text-tertiary)]",
+        className,
+      )}
+      role="status"
+    >
+      <LoadingSpinner className="size-3.5" />
+      <span>{label}</span>
+    </div>
+  );
+}
+
+export function RoutePending() {
+  return (
+    <div
+      className="flex h-screen min-h-0 bg-[var(--surface-window)] text-[var(--text-primary)]"
+      role="status"
+    >
+      <aside className="hidden w-[var(--layout-sidebar-width)] shrink-0 border-r border-sidebar-border bg-sidebar p-3 md:block">
+        <div className="mb-5 flex min-h-[calc(var(--layout-topbar-height)-24px)] items-center gap-2">
+          <Skeleton className="size-8" />
+          <Skeleton className="h-4 w-28" />
+        </div>
+        <div className="space-y-2">
+          <Skeleton className="h-3 w-20" />
+          <ProjectListSkeleton />
+        </div>
+      </aside>
+      <main className="flex min-w-0 flex-1 flex-col bg-[var(--surface-panel)]">
+        <header className="flex min-h-[var(--layout-topbar-height)] items-center gap-3 border-b border-border px-4">
+          <Skeleton className="size-8" />
+          <div className="min-w-0 flex-1 space-y-2">
+            <Skeleton className="h-4 w-40 max-w-full" />
+            <Skeleton className="h-3 w-64 max-w-full" />
+          </div>
+        </header>
+        <div className="min-h-0 flex-1 px-4 py-4">
+          <TimelineSkeleton />
+        </div>
+      </main>
+    </div>
+  );
+}
+
+export function ProjectListSkeleton() {
+  return (
+    <div className="space-y-2" aria-hidden="true">
+      {Array.from({ length: 4 }, (_, index) => (
+        <div className="space-y-1.5" key={index}>
+          <div className="flex h-8 items-center gap-2 px-2">
+            <Skeleton className="size-4 shrink-0" />
+            <Skeleton className="h-3.5 w-32" />
+          </div>
+          {index < 2 && <WorktreeListSkeleton />}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function WorktreeListSkeleton() {
+  return (
+    <div className="ml-4 space-y-1 border-l border-sidebar-border pl-4">
+      {Array.from({ length: 2 }, (_, index) => (
+        <div className="flex h-7 items-center gap-2" key={index}>
+          <Skeleton className="size-3.5 shrink-0" />
+          <Skeleton className="h-3 w-28" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function TimelineSkeleton() {
+  return (
+    <div className="mx-auto flex max-w-[var(--layout-max-content-width)] flex-col gap-3">
+      <MessageSkeleton align="right" />
+      <MessageSkeleton align="left" lines={4} />
+      <MessageSkeleton align="right" lines={2} />
+      <MessageSkeleton align="left" lines={3} />
+    </div>
+  );
+}
+
+export function ActivityCard({
+  children,
+  label,
+}: {
+  children?: ReactNode;
+  label: string;
+}) {
+  return (
+    <article
+      className="mr-auto flex max-w-[82%] items-start gap-3 rounded-[var(--radius-lg)] border border-border bg-card px-4 py-3 text-card-foreground shadow-[var(--shadow-xs)]"
+      role="status"
+    >
+      <LoadingSpinner className="mt-0.5 text-[var(--semantic-info-fg)]" />
+      <div className="min-w-0">
+        <p className="text-[length:var(--font-size-md)] font-medium">{label}</p>
+        {children && (
+          <div className="mt-1 text-[length:var(--font-size-xs)] text-muted-foreground">
+            {children}
+          </div>
+        )}
+      </div>
+    </article>
+  );
+}
+
+function MessageSkeleton({
+  align,
+  lines = 3,
+}: {
+  align: "left" | "right";
+  lines?: number;
+}) {
+  return (
+    <div
+      className={cn(
+        "rounded-[var(--radius-lg)] border px-4 py-3 shadow-[var(--shadow-xs)]",
+        align === "right"
+          ? "ml-auto w-[min(78%,34rem)] border-transparent bg-[var(--color-gray-900)]/10"
+          : "mr-auto w-[min(82%,42rem)] border-border bg-card",
+      )}
+    >
+      <div className="space-y-2">
+        {Array.from({ length: lines }, (_, index) => (
+          <Skeleton
+            className={cn("h-3", index === lines - 1 ? "w-2/3" : "w-full")}
+            key={index}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/app/src/components/ui/combobox.tsx
+++ b/packages/app/src/components/ui/combobox.tsx
@@ -1,4 +1,4 @@
-import { Check, ChevronsUpDown, Search } from "lucide-react";
+import { Check, ChevronsUpDown, LoaderCircle, Search } from "lucide-react";
 import type { KeyboardEvent, ReactNode } from "react";
 import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { cn } from "../../lib/utils";
@@ -19,6 +19,7 @@ export interface ComboboxProps {
   disabled?: boolean;
   emptyMessage?: string;
   icon?: ReactNode;
+  isLoading?: boolean;
   onQueryChange?: (query: string) => void;
   onValueChange: (value: string) => void;
   options: ComboboxOption[];
@@ -38,6 +39,7 @@ export function Combobox({
   disabled = false,
   emptyMessage = "No results",
   icon,
+  isLoading = false,
   onQueryChange,
   onValueChange,
   options,
@@ -183,7 +185,14 @@ export function Combobox({
         role="combobox"
         type="button"
       >
-        {icon}
+        {isLoading ? (
+          <LoaderCircle
+            aria-hidden="true"
+            className="size-3.5 shrink-0 animate-spin text-[var(--icon-color-muted)]"
+          />
+        ) : (
+          icon
+        )}
         <span className="min-w-0 truncate">
           {selectedOption?.label ?? placeholder}
         </span>
@@ -214,6 +223,12 @@ export function Combobox({
               onChange={(event) => updateQuery(event.target.value)}
               onKeyDown={handleSearchKeyDown}
             />
+            {isLoading && (
+              <LoaderCircle
+                aria-hidden="true"
+                className="size-3.5 shrink-0 animate-spin text-[var(--icon-color-muted)]"
+              />
+            )}
           </div>
           <div
             className="max-h-64 overflow-y-auto p-1"

--- a/packages/app/src/router.test.ts
+++ b/packages/app/src/router.test.ts
@@ -7,6 +7,9 @@ describe("getRouter", () => {
     const router = getRouter();
 
     expect(router.routeTree.id).toBe("__root__");
+    expect(router.options.defaultPendingComponent).toBeDefined();
+    expect(router.options.defaultPendingMs).toBe(300);
+    expect(router.options.defaultPendingMinMs).toBe(350);
     expect(router.options.routeTree).toBe(routeTree);
     expect(router.options.scrollRestoration).toBe(true);
   });

--- a/packages/app/src/router.tsx
+++ b/packages/app/src/router.tsx
@@ -1,8 +1,12 @@
 import { createRouter } from "@tanstack/react-router";
+import { RoutePending } from "./components/loading";
 import { routeTree } from "./routeTree.gen";
 
 export function getRouter() {
   return createRouter({
+    defaultPendingComponent: RoutePending,
+    defaultPendingMinMs: 350,
+    defaultPendingMs: 300,
     routeTree,
     scrollRestoration: true,
   });

--- a/packages/app/src/routes/__root.tsx
+++ b/packages/app/src/routes/__root.tsx
@@ -1,6 +1,7 @@
 /// <reference types="vite/client" />
 
 import type { ReactNode } from "react";
+import { Suspense } from "react";
 import "../styles.css";
 import {
   HeadContent,
@@ -8,6 +9,7 @@ import {
   Scripts,
   createRootRoute,
 } from "@tanstack/react-router";
+import { RoutePending } from "../components/loading";
 
 export const Route = createRootRoute({
   head: () => ({
@@ -31,7 +33,9 @@ export const Route = createRootRoute({
 function RootComponent() {
   return (
     <RootDocument>
-      <Outlet />
+      <Suspense fallback={<RoutePending />}>
+        <Outlet />
+      </Suspense>
     </RootDocument>
   );
 }

--- a/packages/app/src/routes/index.tsx
+++ b/packages/app/src/routes/index.tsx
@@ -33,6 +33,14 @@ import { Badge } from "../components/ui/badge";
 import { Button } from "../components/ui/button";
 import { Combobox, type ComboboxOption } from "../components/ui/combobox";
 import {
+  ActivityCard,
+  InlineLoading,
+  LoadingSpinner,
+  ProjectListSkeleton,
+  TimelineSkeleton,
+  WorktreeListSkeleton,
+} from "../components/loading";
+import {
   Dialog,
   DialogContent,
   DialogDescription,
@@ -304,6 +312,19 @@ function Home() {
   const [status, setStatus] = useState("Starting");
   const [error, setError] = useState<string | null>(null);
   const [isBusy, setIsBusy] = useState(false);
+  const [isProjectsLoading, setIsProjectsLoading] = useState(true);
+  const [loadingProjectIds, setLoadingProjectIds] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const [isModelsLoading, setIsModelsLoading] = useState(true);
+  const [isMessagesLoading, setIsMessagesLoading] = useState(false);
+  const [isChatContextLoading, setIsChatContextLoading] = useState(false);
+  const [isFileSearchLoading, setIsFileSearchLoading] = useState(false);
+  const [creatingProjectId, setCreatingProjectId] = useState<string | null>(
+    null,
+  );
+  const [isSendingMessage, setIsSendingMessage] = useState(false);
+  const [isInterrupting, setIsInterrupting] = useState(false);
   const createChatInFlightRef = useRef(false);
   const chatTimelineRef = useRef<HTMLElement | null>(null);
   const isChatTimelinePinnedToBottomRef = useRef(true);
@@ -314,6 +335,7 @@ function Home() {
   const selectedChatIdRef = useRef<string | null>(null);
   const selectedChatVersionRef = useRef(0);
   const sendMessageRequestIdRef = useRef(0);
+  const pendingSendChatIdsRef = useRef<Set<string>>(new Set());
   const [pendingApproval, setPendingApproval] =
     useState<PendingApproval | null>(null);
 
@@ -456,6 +478,15 @@ function Home() {
       ),
     [messages],
   );
+  const showProjectListSkeleton = isProjectsLoading && projects.length === 0;
+  const showTimelineSkeleton =
+    Boolean(selectedChatId) &&
+    isMessagesLoading &&
+    visibleMessages.length === 0;
+  const showActivityCard =
+    Boolean(selectedChatId) &&
+    !showTimelineSkeleton &&
+    (isSendingMessage || isChatRunning);
 
   useEffect(() => {
     void refreshProjects();
@@ -488,6 +519,11 @@ function Home() {
       cancelAnimationFrame(scrollSaveAnimationFrameRef.current);
       scrollSaveAnimationFrameRef.current = null;
     }
+    setIsSendingMessage(
+      Boolean(
+        selectedChatId && pendingSendChatIdsRef.current.has(selectedChatId),
+      ),
+    );
 
     if (!selectedChatId) {
       setMessages([]);
@@ -498,6 +534,9 @@ function Home() {
       setFileSearchQuery("");
       setFileSearchResults([]);
       setSkills([]);
+      setIsMessagesLoading(false);
+      setIsChatContextLoading(false);
+      setIsFileSearchLoading(false);
       return;
     }
 
@@ -509,7 +548,7 @@ function Home() {
     setMessages([]);
     setMessagesChatId(null);
     const chatContextController = new AbortController();
-    void refreshMessages(selectedChatId);
+    void refreshMessages(selectedChatId, { showLoading: true });
     void refreshSelectedChat(selectedChatId);
     void refreshChatContext(selectedChatId, chatContextController.signal);
 
@@ -573,7 +612,7 @@ function Home() {
       shouldIgnoreNextChatTimelineScrollRef.current = true;
       timeline.scrollTop = timeline.scrollHeight;
     }
-  }, [messagesChatId, selectedChatId, visibleMessages]);
+  }, [messagesChatId, selectedChatId, showActivityCard, visibleMessages]);
 
   useEffect(() => {
     return () => {
@@ -607,11 +646,13 @@ function Home() {
 
     if (!selectedChatId || !fileSearchQuery.trim()) {
       setFileSearchResults([]);
+      setIsFileSearchLoading(false);
       return;
     }
 
     const controller = new AbortController();
     const query = fileSearchQuery.trim();
+    setIsFileSearchLoading(true);
     const timeout = setTimeout(() => {
       void fetchJson<{ files: CodexFileRecord[] }>(
         `/api/chats/${selectedChatId}?fileQuery=${encodeURIComponent(query)}`,
@@ -629,6 +670,14 @@ function Home() {
         .catch((err: Error) => {
           if (err.name !== "AbortError") {
             setError(err.message);
+          }
+        })
+        .finally(() => {
+          if (
+            !controller.signal.aborted &&
+            fileSearchRequestIdRef.current === requestId
+          ) {
+            setIsFileSearchLoading(false);
           }
         });
     }, 160);
@@ -649,72 +698,95 @@ function Home() {
     setSelectedChatId(selectedWorktreeChats[0]?.id ?? null);
   }, [selectedChatId, selectedWorktreeChats]);
 
-  async function refreshProjects() {
-    const data = await fetchJson<{ projects: ProjectRecord[] }>(
-      "/api/projects",
-    );
-    setProjects(data.projects);
-    const projectDataEntries = await Promise.all(
-      data.projects.map(
-        async (project) =>
-          [
-            project.id,
-            await loadProjectData(project.id, { sync: true }),
-          ] as const,
-      ),
-    );
-    const nextChatsByProject = Object.fromEntries(
-      projectDataEntries.map(([projectId, projectData]) => [
-        projectId,
-        projectData.chats,
-      ]),
-    );
-    const nextWorktreesByProject = Object.fromEntries(
-      projectDataEntries.map(([projectId, projectData]) => [
-        projectId,
-        projectData.worktrees,
-      ]),
-    );
-    setChatsByProject(nextChatsByProject);
-    setWorktreesByProject(nextWorktreesByProject);
-    const fallbackProjectId = selectedProjectId ?? data.projects[0]?.id ?? null;
-    const fallbackWorktree = firstProjectWorktree(
-      fallbackProjectId,
-      nextWorktreesByProject,
-    );
-    setSelectedProjectId((current) => {
-      const nextProjectId = current ?? data.projects[0]?.id ?? null;
-      if (nextProjectId) {
-        setExpandedProjectIds((expanded) => {
-          const next = new Set(expanded);
-          next.add(nextProjectId);
-          return next;
-        });
+  function setProjectLoading(projectId: string, isLoading: boolean) {
+    setLoadingProjectIds((current) => {
+      const next = new Set(current);
+      if (isLoading) {
+        next.add(projectId);
+      } else {
+        next.delete(projectId);
       }
-      return nextProjectId;
+      return next;
     });
-    setSelectedWorktreePath((current) => {
-      if (
-        fallbackProjectId &&
-        current &&
-        (nextWorktreesByProject[fallbackProjectId] ?? []).some(
-          (worktree) => worktree.path === current,
-        )
-      ) {
-        return current;
-      }
-      return fallbackWorktree?.path ?? null;
-    });
-    setSelectedChatId((current) =>
-      Object.values(nextChatsByProject)
-        .flat()
-        .some((chat) => chat.id === current)
-        ? current
-        : (fallbackWorktree?.chatId ?? null),
-    );
+  }
+
+  async function refreshProjects(): Promise<boolean> {
+    setIsProjectsLoading(true);
+    try {
+      const data = await fetchJson<{ projects: ProjectRecord[] }>(
+        "/api/projects",
+      );
+      setProjects(data.projects);
+      const projectDataEntries = await Promise.all(
+        data.projects.map(
+          async (project) =>
+            [
+              project.id,
+              await loadProjectData(project.id, { sync: true }),
+            ] as const,
+        ),
+      );
+      const nextChatsByProject = Object.fromEntries(
+        projectDataEntries.map(([projectId, projectData]) => [
+          projectId,
+          projectData.chats,
+        ]),
+      );
+      const nextWorktreesByProject = Object.fromEntries(
+        projectDataEntries.map(([projectId, projectData]) => [
+          projectId,
+          projectData.worktrees,
+        ]),
+      );
+      setChatsByProject(nextChatsByProject);
+      setWorktreesByProject(nextWorktreesByProject);
+      const fallbackProjectId =
+        selectedProjectId ?? data.projects[0]?.id ?? null;
+      const fallbackWorktree = firstProjectWorktree(
+        fallbackProjectId,
+        nextWorktreesByProject,
+      );
+      setSelectedProjectId((current) => {
+        const nextProjectId = current ?? data.projects[0]?.id ?? null;
+        if (nextProjectId) {
+          setExpandedProjectIds((expanded) => {
+            const next = new Set(expanded);
+            next.add(nextProjectId);
+            return next;
+          });
+        }
+        return nextProjectId;
+      });
+      setSelectedWorktreePath((current) => {
+        if (
+          fallbackProjectId &&
+          current &&
+          (nextWorktreesByProject[fallbackProjectId] ?? []).some(
+            (worktree) => worktree.path === current,
+          )
+        ) {
+          return current;
+        }
+        return fallbackWorktree?.path ?? null;
+      });
+      setSelectedChatId((current) =>
+        Object.values(nextChatsByProject)
+          .flat()
+          .some((chat) => chat.id === current)
+          ? current
+          : (fallbackWorktree?.chatId ?? null),
+      );
+      return true;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      return false;
+    } finally {
+      setIsProjectsLoading(false);
+    }
   }
 
   async function refreshModels() {
+    setIsModelsLoading(true);
     try {
       const data = await fetchJson<{ models: CodexModelRecord[] }>(
         "/api/models",
@@ -732,10 +804,13 @@ function Home() {
       });
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setIsModelsLoading(false);
     }
   }
 
   async function refreshChatContext(chatId: string, signal?: AbortSignal) {
+    setIsChatContextLoading(true);
     try {
       const data = await fetchJson<{ skills: CodexSkillRecord[] }>(
         `/api/chats/${chatId}?context=skills`,
@@ -750,13 +825,20 @@ function Home() {
         return;
       }
       setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      if (!signal?.aborted) {
+        setIsChatContextLoading(false);
+      }
     }
   }
 
   async function loadProjectData(
     projectId: string,
     options: { sync?: boolean } = {},
-  ) {
+  ): Promise<{
+    chats: ChatRecord[];
+    worktrees: ProjectWorktreeRecord[];
+  }> {
     return await fetchJson<{
       chats: ChatRecord[];
       worktrees: ProjectWorktreeRecord[];
@@ -766,34 +848,43 @@ function Home() {
   async function refreshChats(
     projectId: string,
     options: { sync?: boolean; updateSelection?: boolean } = {},
-  ) {
-    const projectData = await loadProjectData(projectId, options);
-    setChatsByProject((current) => ({
-      ...current,
-      [projectId]: projectData.chats,
-    }));
-    setWorktreesByProject((current) => ({
-      ...current,
-      [projectId]: projectData.worktrees,
-    }));
-    if (options.updateSelection === false) {
-      return;
+  ): Promise<boolean> {
+    setProjectLoading(projectId, true);
+    try {
+      const projectData = await loadProjectData(projectId, options);
+      setChatsByProject((current) => ({
+        ...current,
+        [projectId]: projectData.chats,
+      }));
+      setWorktreesByProject((current) => ({
+        ...current,
+        [projectId]: projectData.worktrees,
+      }));
+      if (options.updateSelection === false) {
+        return true;
+      }
+      const fallbackWorktree = firstProjectWorktree(projectId, {
+        ...worktreesByProject,
+        [projectId]: projectData.worktrees,
+      });
+      setSelectedWorktreePath((current) =>
+        current &&
+        projectData.worktrees.some((worktree) => worktree.path === current)
+          ? current
+          : (fallbackWorktree?.path ?? null),
+      );
+      setSelectedChatId((current) =>
+        projectData.chats.some((chat) => chat.id === current)
+          ? current
+          : (fallbackWorktree?.chatId ?? null),
+      );
+      return true;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      return false;
+    } finally {
+      setProjectLoading(projectId, false);
     }
-    const fallbackWorktree = firstProjectWorktree(projectId, {
-      ...worktreesByProject,
-      [projectId]: projectData.worktrees,
-    });
-    setSelectedWorktreePath((current) =>
-      current &&
-      projectData.worktrees.some((worktree) => worktree.path === current)
-        ? current
-        : (fallbackWorktree?.path ?? null),
-    );
-    setSelectedChatId((current) =>
-      projectData.chats.some((chat) => chat.id === current)
-        ? current
-        : (fallbackWorktree?.chatId ?? null),
-    );
   }
 
   async function refreshSelectedChat(chatId: string) {
@@ -822,15 +913,30 @@ function Home() {
     }));
   }
 
-  async function refreshMessages(chatId: string) {
-    const data = await fetchJson<{ messages: ChatMessageRecord[] }>(
-      `/api/chats/${chatId}/messages`,
-    );
-    if (selectedChatIdRef.current !== chatId) {
-      return;
+  async function refreshMessages(
+    chatId: string,
+    options: { showLoading?: boolean } = {},
+  ) {
+    if (options.showLoading) {
+      setIsMessagesLoading(true);
     }
-    setMessages(data.messages);
-    setMessagesChatId(chatId);
+    try {
+      const data = await fetchJson<{ messages: ChatMessageRecord[] }>(
+        `/api/chats/${chatId}/messages`,
+      );
+      if (selectedChatIdRef.current === chatId) {
+        setMessages(data.messages);
+        setMessagesChatId(chatId);
+      }
+    } catch (err) {
+      if (selectedChatIdRef.current === chatId) {
+        setError(err instanceof Error ? err.message : String(err));
+      }
+    } finally {
+      if (options.showLoading && selectedChatIdRef.current === chatId) {
+        setIsMessagesLoading(false);
+      }
+    }
   }
 
   function saveChatScrollPosition(chatId: string) {
@@ -886,7 +992,10 @@ function Home() {
       );
       setProjectPath("");
       setIsAddProjectOpen(false);
-      await refreshProjects();
+      const didRefresh = await refreshProjects();
+      if (!didRefresh) {
+        return;
+      }
       setSelectedProjectId(data.project.id);
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
@@ -902,6 +1011,7 @@ function Home() {
 
     setError(null);
     createChatInFlightRef.current = true;
+    setCreatingProjectId(projectId);
     setIsBusy(true);
     try {
       const data = await fetchJson<{ chat: ChatRecord }>(
@@ -913,13 +1023,17 @@ function Home() {
       );
       setSelectedProjectId(projectId);
       setExpandedProjectIds((current) => new Set(current).add(projectId));
-      await refreshChats(projectId, { sync: true });
+      const didRefresh = await refreshChats(projectId, { sync: true });
+      if (!didRefresh) {
+        return;
+      }
       setSelectedWorktreePath(data.chat.worktreePath);
       setSelectedChatId(data.chat.id);
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
       createChatInFlightRef.current = false;
+      setCreatingProjectId(null);
       setIsBusy(false);
     }
   }
@@ -984,7 +1098,12 @@ function Home() {
 
   async function sendMessage(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    if (!selectedChatId || !composerText.trim()) {
+    if (
+      !selectedChatId ||
+      !composerText.trim() ||
+      isSendingMessage ||
+      pendingSendChatIdsRef.current.has(selectedChatId)
+    ) {
       return;
     }
     setError(null);
@@ -1008,6 +1127,8 @@ function Home() {
       name: skill.name,
       path: skill.path,
     }));
+    pendingSendChatIdsRef.current.add(requestChatId);
+    setIsSendingMessage(true);
     try {
       await fetchJson(`/api/chats/${requestChatId}/messages`, {
         method: "POST",
@@ -1032,6 +1153,14 @@ function Home() {
       }
       setComposerText(text);
       setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      pendingSendChatIdsRef.current.delete(requestChatId);
+      if (
+        isCurrentSendRequest() ||
+        selectedChatIdRef.current === requestChatId
+      ) {
+        setIsSendingMessage(false);
+      }
     }
   }
 
@@ -1048,7 +1177,12 @@ function Home() {
     ) {
       return;
     }
-    if (!selectedChatId || !composerText.trim() || isChatRunning) {
+    if (
+      !selectedChatId ||
+      !composerText.trim() ||
+      isChatRunning ||
+      isSendingMessage
+    ) {
       return;
     }
     event.preventDefault();
@@ -1060,12 +1194,15 @@ function Home() {
       return;
     }
     setError(null);
+    setIsInterrupting(true);
     try {
       await fetchJson(`/api/chats/${selectedChatId}/interrupt`, {
         method: "POST",
       });
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setIsInterrupting(false);
     }
   }
 
@@ -1136,9 +1273,10 @@ function Home() {
             </h1>
           </div>
           <Badge
-            className="max-w-24 truncate group-data-[state=collapsed]/sidebar:hidden"
+            className="max-w-28 truncate group-data-[state=collapsed]/sidebar:hidden"
             variant={status === "Ready" ? "success" : "warning"}
           >
+            {status !== "Ready" && <LoadingSpinner className="size-3" />}
             {status}
           </Badge>
         </SidebarHeader>
@@ -1157,7 +1295,11 @@ function Home() {
             </SidebarGroupHeader>
             <SidebarGroupContent>
               <SidebarMenu>
-                {projects.length === 0 ? (
+                {showProjectListSkeleton ? (
+                  <li className="px-2 py-1 group-data-[state=collapsed]/sidebar:hidden">
+                    <ProjectListSkeleton />
+                  </li>
+                ) : projects.length === 0 ? (
                   <li className="px-2 py-4 group-data-[state=collapsed]/sidebar:hidden">
                     <div className="rounded-[var(--radius-md)] border border-dashed border-sidebar-border bg-[var(--surface-card)] px-3 py-3 text-[length:var(--font-size-sm)] text-muted-foreground">
                       Add a Git project to begin.
@@ -1170,6 +1312,9 @@ function Home() {
                     );
                     const projectWorktrees =
                       worktreesByProject[project.id] ?? [];
+                    const isProjectDataLoading =
+                      loadingProjectIds.has(project.id) &&
+                      worktreesByProject[project.id] === undefined;
 
                     return (
                       <SidebarMenuItem key={project.id}>
@@ -1204,12 +1349,20 @@ function Home() {
                             type="button"
                             variant="ghost"
                           >
-                            <MessageSquarePlus className="size-4" />
+                            {creatingProjectId === project.id ? (
+                              <LoadingSpinner className="size-4" />
+                            ) : (
+                              <MessageSquarePlus className="size-4" />
+                            )}
                           </Button>
                         </div>
                         {isProjectExpanded && (
                           <SidebarMenuSub>
-                            {projectWorktrees.length === 0 ? (
+                            {isProjectDataLoading ? (
+                              <li className="px-2 py-1.5">
+                                <WorktreeListSkeleton />
+                              </li>
+                            ) : projectWorktrees.length === 0 ? (
                               <li className="px-2 py-1.5 text-[length:var(--font-size-xs)] text-[var(--text-tertiary)]">
                                 No worktrees
                               </li>
@@ -1325,6 +1478,7 @@ function Home() {
                 Cancel
               </Button>
               <Button disabled={isBusy || !projectPath.trim()} type="submit">
+                {isBusy && <LoadingSpinner />}
                 Add project
               </Button>
             </DialogFooter>
@@ -1404,6 +1558,7 @@ function Home() {
                 type="submit"
                 variant="destructive"
               >
+                {isBusy && <LoadingSpinner />}
                 Delete
               </Button>
             </DialogFooter>
@@ -1485,17 +1640,25 @@ function Home() {
         {selectedWorktree && (
           <ChatHistoryBar
             chats={selectedWorktreeChats}
+            isLoading={Boolean(
+              selectedProjectId &&
+              loadingProjectIds.has(selectedProjectId) &&
+              selectedWorktreeChats.length === 0,
+            )}
             selectedChatId={selectedChatId}
             onSelectChat={setSelectedChatId}
           />
         )}
 
         <section
+          aria-busy={isMessagesLoading || isSendingMessage || isChatRunning}
           className="min-h-0 flex-1 overflow-y-auto px-4 py-4"
           ref={chatTimelineRef}
           onScroll={scheduleSelectedChatScrollPositionSave}
         >
-          {visibleMessages.length === 0 ? (
+          {showTimelineSkeleton ? (
+            <TimelineSkeleton />
+          ) : visibleMessages.length === 0 && !showActivityCard ? (
             <EmptyTimeline
               hasChat={Boolean(selectedChat)}
               hasWorktree={Boolean(selectedWorktree)}
@@ -1507,6 +1670,17 @@ function Home() {
               {visibleMessages.map((message) => (
                 <MessageCard key={message.id} message={message} />
               ))}
+              {showActivityCard && (
+                <ActivityCard
+                  label={
+                    isSendingMessage ? "Sending message" : "Codex is working"
+                  }
+                >
+                  {isSendingMessage
+                    ? "Waiting for the session to accept the turn."
+                    : "New output will appear here as it arrives."}
+                </ActivityCard>
+              )}
             </div>
           )}
         </section>
@@ -1569,31 +1743,54 @@ function Home() {
                 />
               </div>
               <Button
-                aria-label={isChatRunning ? "Stop turn" : "Send message"}
+                aria-label={
+                  isChatRunning
+                    ? "Stop turn"
+                    : isSendingMessage
+                      ? "Sending message"
+                      : "Send message"
+                }
                 className="size-10"
                 disabled={
                   isChatRunning
-                    ? !selectedChat?.activeTurnId
-                    : !selectedChatId || !composerText.trim()
+                    ? !selectedChat?.activeTurnId || isInterrupting
+                    : isSendingMessage ||
+                      !selectedChatId ||
+                      !composerText.trim()
                 }
                 onClick={isChatRunning ? interruptChat : undefined}
                 size="icon"
-                title={isChatRunning ? "Stop turn" : "Send"}
+                title={
+                  isChatRunning
+                    ? "Stop turn"
+                    : isSendingMessage
+                      ? "Sending"
+                      : "Send"
+                }
                 type={isChatRunning ? "button" : "submit"}
                 variant={isChatRunning ? "destructive" : "default"}
               >
-                {isChatRunning ? <Square /> : <Send />}
+                {isSendingMessage || isInterrupting ? (
+                  <LoadingSpinner />
+                ) : isChatRunning ? (
+                  <Square />
+                ) : (
+                  <Send />
+                )}
               </Button>
             </div>
             <div className="flex min-h-8 flex-wrap items-center gap-2 border-t border-[var(--border-divider)] px-1 pt-2">
               <Combobox
                 aria-label="Select model"
                 className="w-36 max-w-full sm:w-40"
-                disabled={models.length === 0 || isChatRunning}
-                emptyMessage="No models"
+                disabled={
+                  isModelsLoading || models.length === 0 || isChatRunning
+                }
+                emptyMessage={isModelsLoading ? "Loading models" : "No models"}
                 icon={<Bot className="size-3.5" />}
+                isLoading={isModelsLoading}
                 options={modelOptions}
-                placeholder="Model"
+                placeholder={isModelsLoading ? "Loading" : "Model"}
                 searchPlaceholder="Search models"
                 side="top"
                 triggerClassName="w-full justify-between"
@@ -1620,9 +1817,14 @@ function Home() {
                 className="w-32 max-w-full"
                 disabled={!selectedChatId || isChatRunning}
                 emptyMessage={
-                  fileSearchQuery.trim() ? "No files" : "Type to search"
+                  isFileSearchLoading
+                    ? "Searching files"
+                    : fileSearchQuery.trim()
+                      ? "No files"
+                      : "Type to search"
                 }
                 icon={<FileText className="size-3.5" />}
+                isLoading={isFileSearchLoading}
                 options={fileOptions}
                 placeholder="Files"
                 query={fileSearchQuery}
@@ -1638,11 +1840,16 @@ function Home() {
                 aria-label="Select skill"
                 align="end"
                 className="w-32 max-w-full"
-                disabled={!selectedChatId || isChatRunning}
-                emptyMessage="No skills"
+                disabled={
+                  !selectedChatId || isChatRunning || isChatContextLoading
+                }
+                emptyMessage={
+                  isChatContextLoading ? "Loading skills" : "No skills"
+                }
                 icon={<Sparkles className="size-3.5" />}
+                isLoading={isChatContextLoading}
                 options={skillOptions}
-                placeholder="Skills"
+                placeholder={isChatContextLoading ? "Loading" : "Skills"}
                 searchPlaceholder="Search skills"
                 side="top"
                 triggerClassName="w-full justify-between"
@@ -1659,10 +1866,12 @@ function Home() {
 
 function ChatHistoryBar({
   chats,
+  isLoading,
   onSelectChat,
   selectedChatId,
 }: {
   chats: ChatRecord[];
+  isLoading: boolean;
   onSelectChat: (chatId: string) => void;
   selectedChatId: string | null;
 }) {
@@ -1677,7 +1886,9 @@ function ChatHistoryBar({
           className="flex min-w-0 flex-1 gap-1 overflow-x-auto"
           role="tablist"
         >
-          {chats.length === 0 ? (
+          {isLoading ? (
+            <InlineLoading className="px-2 py-1" label="Loading chats" />
+          ) : chats.length === 0 ? (
             <span className="px-2 py-1 text-[length:var(--font-size-xs)] text-[var(--text-tertiary)]">
               No chat history
             </span>


### PR DESCRIPTION
## Summary

- Add reusable loading primitives for the app shell, sidebar, timeline, and in-flight activity states.
- Configure TanStack Router pending UI and wrap the root outlet in React Suspense fallback.
- Add context-specific loading indicators for project/worktree loading, chat messages, model and skill fetching, file search, message send, interrupt, and modal actions.

## Impact

Users now get skeletons and inline progress indicators instead of empty or static UI while app data and chat operations are loading.

## Validation

- `pnpm --filter app-private typecheck`
- `pnpm --filter app-private test`
- `pnpm ready`