### PR TITLE
[codex] Fix mobile chat safe areas

### DIFF
--- a/packages/app/src/routes/__root.tsx
+++ b/packages/app/src/routes/__root.tsx
@@ -17,7 +17,8 @@ export const Route = createRootRoute({
       },
       {
         name: "viewport",
-        content: "width=device-width, initial-scale=1",
+        content:
+          "width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=resizes-content",
       },
       {
         title: "Phantom Serve",

--- a/packages/app/src/routes/index.tsx
+++ b/packages/app/src/routes/index.tsx
@@ -958,7 +958,7 @@ function Home() {
   }
 
   return (
-    <SidebarProvider className="h-screen min-h-0">
+    <SidebarProvider className="app-shell">
       <Sidebar collapsible="offcanvas" variant="inset">
         <SidebarHeader>
           <div className="flex size-8 shrink-0 items-center justify-center rounded-[var(--radius-sm)] bg-[var(--color-gray-900)] text-primary-foreground">
@@ -1342,7 +1342,7 @@ function Home() {
         </section>
 
         <form
-          className="border-t border-border bg-[var(--surface-floating)] p-3 backdrop-blur"
+          className="chat-composer border-t border-border bg-[var(--surface-floating)] backdrop-blur"
           onSubmit={sendMessage}
         >
           <div className="mx-auto flex max-w-[var(--layout-max-content-width)] flex-col gap-2">

--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -156,6 +156,10 @@
   --layout-topbar-height: 56px;
   --layout-panel-min-width: 320px;
   --layout-max-content-width: 1200px;
+  --safe-area-inset-top: env(safe-area-inset-top, 0px);
+  --safe-area-inset-right: env(safe-area-inset-right, 0px);
+  --safe-area-inset-bottom: env(safe-area-inset-bottom, 0px);
+  --safe-area-inset-left: env(safe-area-inset-left, 0px);
 
   --icon-size-xs: 12px;
   --icon-size-sm: 14px;
@@ -241,6 +245,39 @@ body {
   line-height: var(--line-height-normal);
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
+}
+
+.app-shell {
+  height: 100dvh;
+  min-height: 0;
+  overflow: hidden;
+  padding-block-start: var(--safe-area-inset-top);
+  padding-inline-end: var(--safe-area-inset-right);
+  padding-inline-start: var(--safe-area-inset-left);
+}
+
+.chat-composer {
+  flex-shrink: 0;
+  padding-block-start: var(--space-3);
+  padding-block-end: calc(var(--space-3) + var(--safe-area-inset-bottom));
+  padding-inline: var(--space-3);
+}
+
+@media (max-width: 767px) {
+  aside[data-variant] {
+    top: var(--safe-area-inset-top);
+    bottom: var(--safe-area-inset-bottom);
+    left: var(--safe-area-inset-left);
+    height: calc(
+      100dvh - var(--safe-area-inset-top) - var(--safe-area-inset-bottom)
+    );
+  }
+}
+
+@supports not (height: 100dvh) {
+  .app-shell {
+    height: 100vh;
+  }
 }
 
 button,


### PR DESCRIPTION
## Summary

- Use a `100dvh` app shell for the chat view instead of `h-screen`/`100vh` sizing.
- Add viewport settings for display cutouts and virtual keyboard content resizing.
- Apply safe-area insets to the app shell, bottom chat composer, and mobile fixed sidebar bounds.

## Root Cause

The mobile chat view used viewport sizing and bottom padding that did not account for browser safe areas or virtual keyboard resizing. On phones and tablets with home indicators or cutouts, the bottom composer could extend into unsafe screen regions.

## Validation

- `pnpm ready`
- Subagent review loop: first pass found 2 layout issues, both fixed; second pass found no actionable findings.

## Notes

There is no browser-level regression test for mobile safe-area or virtual-keyboard behavior yet.