### PR TITLE
[codex] Hide prunable worktrees from list

### DIFF
--- a/packages/app/src/server/services.test.ts
+++ b/packages/app/src/server/services.test.ts
@@ -209,6 +209,10 @@ describe("ServeServices", () => {
 
     const worktrees = await services.listProjectWorktrees("proj_1");
 
+    deepStrictEqual(coreMocks.listWorktrees.mock.calls[0], [
+      "/repo",
+      { includePrunable: false },
+    ]);
     deepStrictEqual(
       worktrees.map((worktree) => ({
         name: worktree.name,

--- a/packages/app/src/server/services.ts
+++ b/packages/app/src/server/services.ts
@@ -238,7 +238,9 @@ export class ServeServices {
 
     let result;
     try {
-      result = await listWorktrees(project.rootPath);
+      result = await listWorktrees(project.rootPath, {
+        includePrunable: false,
+      });
     } catch {
       return projectWorktreesFromPersistedChats(
         state,

--- a/packages/cli/src/handlers/list.test.ts
+++ b/packages/cli/src/handlers/list.test.ts
@@ -126,6 +126,7 @@ describe("listHandler", () => {
     strictEqual(getGitRootMock.mock.calls.length, 1);
     strictEqual(listWorktreesCoreMock.mock.calls.length, 1);
     strictEqual(listWorktreesCoreMock.mock.calls[0][0], "/test/repo");
+    strictEqual(listWorktreesCoreMock.mock.calls[0][1]?.includePrunable, false);
     strictEqual(consoleLogMock.mock.calls.length, 3);
     strictEqual(consoleLogMock.mock.calls[0][0], "main (.)");
     strictEqual(
@@ -164,6 +165,7 @@ describe("listHandler", () => {
     strictEqual(getGitRootMock.mock.calls.length, 1);
     strictEqual(listWorktreesCoreMock.mock.calls.length, 1);
     strictEqual(listWorktreesCoreMock.mock.calls[0][1]?.excludeDefault, true);
+    strictEqual(listWorktreesCoreMock.mock.calls[0][1]?.includePrunable, false);
     strictEqual(consoleLogMock.mock.calls.length, 1);
     strictEqual(
       consoleLogMock.mock.calls[0][0],

--- a/packages/cli/src/handlers/list.ts
+++ b/packages/cli/src/handlers/list.ts
@@ -46,7 +46,10 @@ export async function listHandler(args: string[] = []): Promise<void> {
         output.log(selectResult.value.name);
       }
     } else {
-      const result = await listWorktreesCore(gitRoot, { excludeDefault });
+      const result = await listWorktreesCore(gitRoot, {
+        excludeDefault,
+        includePrunable: false,
+      });
 
       if (isErr(result)) {
         exitWithError("Failed to list worktrees", exitCodes.generalError);

--- a/packages/core/src/worktree/list.test.ts
+++ b/packages/core/src/worktree/list.test.ts
@@ -230,6 +230,127 @@ describe("listWorktrees", () => {
     cwdMock.mockRestore();
   });
 
+  it("includes prunable worktrees by default for validation and cleanup flows", async () => {
+    resetMocks();
+    const cwdMock = mockCwd();
+    gitListWorktreesMock.mockResolvedValue([
+      {
+        path: "/test/repo",
+        branch: "main",
+        head: "abc123",
+        isLocked: false,
+        isPrunable: false,
+      },
+      {
+        path: "/test/repo/.git/phantom/worktrees/stale-feature",
+        branch: "stale-feature",
+        head: "def456",
+        isLocked: false,
+        isPrunable: true,
+      },
+      {
+        path: "/test/repo/.git/phantom/worktrees/active-feature",
+        branch: "active-feature",
+        head: "ghi789",
+        isLocked: false,
+        isPrunable: false,
+      },
+    ]);
+    getStatusMock.mockResolvedValue(cleanStatus());
+
+    const result = await listWorktrees("/test/repo");
+
+    ok(result.ok);
+    if (result.ok) {
+      deepStrictEqual(
+        normalizeWorktrees(result.value.worktrees),
+        normalizeWorktrees([
+          {
+            name: "main",
+            path: "/test/repo",
+            pathToDisplay: ".",
+            branch: "main",
+            isClean: true,
+          },
+          {
+            name: "stale-feature",
+            path: "/test/repo/.git/phantom/worktrees/stale-feature",
+            pathToDisplay: ".git/phantom/worktrees/stale-feature",
+            branch: "stale-feature",
+            isClean: true,
+          },
+          {
+            name: "active-feature",
+            path: "/test/repo/.git/phantom/worktrees/active-feature",
+            pathToDisplay: ".git/phantom/worktrees/active-feature",
+            branch: "active-feature",
+            isClean: true,
+          },
+        ]),
+      );
+    }
+
+    cwdMock.mockRestore();
+  });
+
+  it("excludes prunable worktrees from display-oriented lists", async () => {
+    resetMocks();
+    const cwdMock = mockCwd();
+    gitListWorktreesMock.mockResolvedValue([
+      {
+        path: "/test/repo",
+        branch: "main",
+        head: "abc123",
+        isLocked: false,
+        isPrunable: false,
+      },
+      {
+        path: "/test/repo/.git/phantom/worktrees/stale-feature",
+        branch: "stale-feature",
+        head: "def456",
+        isLocked: false,
+        isPrunable: true,
+      },
+      {
+        path: "/test/repo/.git/phantom/worktrees/active-feature",
+        branch: "active-feature",
+        head: "ghi789",
+        isLocked: false,
+        isPrunable: false,
+      },
+    ]);
+    getStatusMock.mockResolvedValue(cleanStatus());
+
+    const result = await listWorktrees("/test/repo", {
+      includePrunable: false,
+    });
+
+    ok(result.ok);
+    if (result.ok) {
+      deepStrictEqual(
+        normalizeWorktrees(result.value.worktrees),
+        normalizeWorktrees([
+          {
+            name: "main",
+            path: "/test/repo",
+            pathToDisplay: ".",
+            branch: "main",
+            isClean: true,
+          },
+          {
+            name: "active-feature",
+            path: "/test/repo/.git/phantom/worktrees/active-feature",
+            pathToDisplay: ".git/phantom/worktrees/active-feature",
+            branch: "active-feature",
+            isClean: true,
+          },
+        ]),
+      );
+    }
+
+    cwdMock.mockRestore();
+  });
+
   it("includes non-phantom worktrees and sibling paths", async () => {
     resetMocks();
     const cwdMock = mockCwd();

--- a/packages/core/src/worktree/list.ts
+++ b/packages/core/src/worktree/list.ts
@@ -22,6 +22,7 @@ export interface ListWorktreesSuccess {
 
 export interface ListWorktreesOptions {
   excludeDefault?: boolean;
+  includePrunable?: boolean;
 }
 
 export async function getWorktreeBranch(worktreePath: string): Promise<string> {
@@ -75,14 +76,18 @@ export async function listWorktrees(
 ): Promise<Result<ListWorktreesSuccess, never>> {
   try {
     const gitWorktrees = await gitListWorktrees(gitRoot);
+    const includePrunable = options.includePrunable ?? true;
+    const availableGitWorktrees = includePrunable
+      ? gitWorktrees
+      : gitWorktrees.filter((worktree) => !worktree.isPrunable);
     const excludeDefault = options.excludeDefault ?? false;
     const filteredWorktrees = excludeDefault
-      ? gitWorktrees.filter((worktree) => worktree.path !== gitRoot)
-      : gitWorktrees;
+      ? availableGitWorktrees.filter((worktree) => worktree.path !== gitRoot)
+      : availableGitWorktrees;
 
     if (filteredWorktrees.length === 0) {
       const message =
-        excludeDefault && gitWorktrees.length > 0
+        excludeDefault && availableGitWorktrees.length > 0
           ? "No sub worktrees found"
           : "No worktrees found";
       return ok({

--- a/packages/core/src/worktree/select.ts
+++ b/packages/core/src/worktree/select.ts
@@ -18,6 +18,7 @@ export async function selectWorktreeWithFzf(
 ): Promise<Result<SelectWorktreeResult | null, Error>> {
   const listResult = await listWorktrees(gitRoot, {
     excludeDefault: options.excludeDefault,
+    includePrunable: false,
   });
 
   if (isErr(listResult)) {

--- a/packages/git/src/libs/list-worktrees.test.ts
+++ b/packages/git/src/libs/list-worktrees.test.ts
@@ -52,4 +52,52 @@ describe("listWorktrees", () => {
       },
     ]);
   });
+
+  it("parses prunable and locked annotations with reasons", async () => {
+    resetMocks();
+    executeGitCommandMock.mockResolvedValue({
+      stdout: [
+        "worktree /repo",
+        "HEAD abc1234",
+        "branch refs/heads/main",
+        "",
+        "worktree /repo/.git/phantom/worktrees/stale",
+        "HEAD def5678",
+        "branch refs/heads/stale",
+        "prunable gitdir file points to non-existent location",
+        "",
+        "worktree /repo/.git/phantom/worktrees/locked",
+        "HEAD ghi9012",
+        "branch refs/heads/locked",
+        "locked moving between machines",
+      ].join("\n"),
+      stderr: "",
+    });
+
+    const result = await listWorktrees("/repo");
+
+    deepStrictEqual(result, [
+      {
+        path: "/repo",
+        head: "abc1234",
+        branch: "main",
+        isLocked: false,
+        isPrunable: false,
+      },
+      {
+        path: "/repo/.git/phantom/worktrees/stale",
+        head: "def5678",
+        branch: "stale",
+        isLocked: false,
+        isPrunable: true,
+      },
+      {
+        path: "/repo/.git/phantom/worktrees/locked",
+        head: "ghi9012",
+        branch: "locked",
+        isLocked: true,
+        isPrunable: false,
+      },
+    ]);
+  });
 });

--- a/packages/git/src/libs/list-worktrees.ts
+++ b/packages/git/src/libs/list-worktrees.ts
@@ -38,9 +38,9 @@ export async function listWorktrees(gitRoot: string): Promise<GitWorktree[]> {
         : fullBranch;
     } else if (line === "detached") {
       currentWorktree.branch = "(detached HEAD)";
-    } else if (line === "locked") {
+    } else if (line.startsWith("locked")) {
       currentWorktree.isLocked = true;
-    } else if (line === "prunable") {
+    } else if (line.startsWith("prunable")) {
       currentWorktree.isPrunable = true;
     }
   }

--- a/packages/mcp/src/tools/list-worktrees.test.ts
+++ b/packages/mcp/src/tools/list-worktrees.test.ts
@@ -98,7 +98,10 @@ describe("listWorktreesTool", () => {
 
     strictEqual(getGitRootMock.mock.calls.length, 1);
     strictEqual(listWorktreesMock.mock.calls.length, 1);
-    deepStrictEqual(listWorktreesMock.mock.calls[0], [gitRoot]);
+    deepStrictEqual(listWorktreesMock.mock.calls[0], [
+      gitRoot,
+      { includePrunable: false },
+    ]);
 
     strictEqual(result.content.length, 1);
     strictEqual(result.content[0].type, "text");

--- a/packages/mcp/src/tools/list-worktrees.ts
+++ b/packages/mcp/src/tools/list-worktrees.ts
@@ -12,7 +12,7 @@ export const listWorktreesTool: Tool<typeof schema> = {
   inputSchema: schema,
   handler: async () => {
     const gitRoot = await getGitRoot();
-    const result = await listWorktrees(gitRoot);
+    const result = await listWorktrees(gitRoot, { includePrunable: false });
 
     if (!isOk(result)) {
       throw new Error("Failed to list worktrees");


### PR DESCRIPTION
## Summary

- Parse `git worktree list --porcelain` `prunable <reason>` and `locked <reason>` annotations correctly.
- Add `includePrunable` list behavior so validation and cleanup flows still see stale Git worktree registrations.
- Hide prunable worktrees only from display-oriented surfaces: Serve project lists, CLI list/fzf selection, and the MCP list tool.
- Add regression coverage for porcelain parsing, default inclusion, display filtering, and caller options.

## Why

Git can leave stale worktree metadata behind when a worktree directory is removed outside Phantom. Those entries are marked prunable, but Phantom was still surfacing them in user-facing worktree lists. The fix keeps stale registrations available to internal validation/cleanup paths while hiding them from list UIs.

## Validation

- `pnpm --filter @phantompane/git test`
- `pnpm --filter @phantompane/core test`
- `pnpm --filter @phantompane/cli-private test`
- `pnpm --filter @phantompane/mcp test`
- `pnpm --filter app-private test`
- `pnpm ready`