### PR TITLE
[codex] Fix stale worktrees in sidebar

### DIFF
--- a/packages/app/src/routes/index.tsx
+++ b/packages/app/src/routes/index.tsx
@@ -857,20 +857,29 @@ function Home() {
         ...current,
         [projectId]: projectData.chats,
       }));
-      setWorktreesByProject((current) => ({
-        ...current,
-        [projectId]: projectData.worktrees,
-      }));
-      if (options.updateSelection === false) {
+      if (options.sync) {
+        setWorktreesByProject((current) => ({
+          ...current,
+          [projectId]: projectData.worktrees,
+        }));
+      }
+      if ((options.updateSelection ?? options.sync === true) === false) {
         return true;
       }
-      const fallbackWorktree = firstProjectWorktree(projectId, {
-        ...worktreesByProject,
-        [projectId]: projectData.worktrees,
-      });
+      const nextWorktreesByProject = options.sync
+        ? {
+            ...worktreesByProject,
+            [projectId]: projectData.worktrees,
+          }
+        : worktreesByProject;
+      const fallbackWorktree = firstProjectWorktree(
+        projectId,
+        nextWorktreesByProject,
+      );
+      const nextProjectWorktrees = nextWorktreesByProject[projectId] ?? [];
       setSelectedWorktreePath((current) =>
         current &&
-        projectData.worktrees.some((worktree) => worktree.path === current)
+        nextProjectWorktrees.some((worktree) => worktree.path === current)
           ? current
           : (fallbackWorktree?.path ?? null),
       );

--- a/packages/app/src/server/services.test.ts
+++ b/packages/app/src/server/services.test.ts
@@ -270,25 +270,491 @@ describe("ServeServices", () => {
     };
     const { services, store } = await createHarness(state);
     const saveSpy = vi.spyOn(store, "save");
-    coreMocks.listWorktrees.mockResolvedValueOnce({
-      ok: true,
-      value: {
-        worktrees: [
-          {
-            name: "main",
-            path: "/repo",
-            pathToDisplay: ".",
-            branch: "main",
-            isClean: true,
-          },
-        ],
-      },
-    });
+    coreMocks.listWorktrees
+      .mockResolvedValueOnce({
+        ok: true,
+        value: {
+          worktrees: [
+            {
+              name: "main",
+              path: "/repo",
+              pathToDisplay: ".",
+              branch: "main",
+              isClean: true,
+            },
+          ],
+        },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        value: {
+          worktrees: [
+            {
+              name: "main",
+              path: "/repo",
+              pathToDisplay: ".",
+              branch: "main",
+              isClean: true,
+            },
+          ],
+        },
+      });
 
     const worktrees = await services.listProjectWorktrees("proj_1");
 
     strictEqual(worktrees[0]?.chatId, "chat_1");
     strictEqual(saveSpy.mock.calls.length, 0);
+  });
+
+  it("removes persisted chats for worktrees missing from a live sync", async () => {
+    const staleWorktreePath = "/repo/.git/phantom/worktrees/deleted";
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [
+        createChat({ worktreeName: "main", worktreePath: "/repo" }),
+        createChat({
+          id: "chat_stale",
+          branchName: "deleted",
+          title: "Deleted worktree",
+          worktreeName: "deleted",
+          worktreePath: staleWorktreePath,
+        }),
+      ],
+      messages: [
+        {
+          id: "msg_stale",
+          chatId: "chat_stale",
+          role: "user" as const,
+          text: "stale",
+          createdAt: timestamp,
+        },
+      ],
+      selectedChatId: "chat_stale",
+    };
+    const { services, store } = await createHarness(state);
+    coreMocks.listWorktrees
+      .mockResolvedValueOnce({
+        ok: true,
+        value: {
+          worktrees: [
+            {
+              name: "main",
+              path: "/repo",
+              pathToDisplay: ".",
+              branch: "main",
+              isClean: true,
+            },
+          ],
+        },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        value: {
+          worktrees: [
+            {
+              name: "main",
+              path: "/repo",
+              pathToDisplay: ".",
+              branch: "main",
+              isClean: true,
+            },
+          ],
+        },
+      });
+
+    const worktrees = await services.listProjectWorktrees("proj_1");
+
+    deepStrictEqual(
+      worktrees.map((worktree) => worktree.path),
+      ["/repo"],
+    );
+    const savedState = await store.load();
+    deepStrictEqual(
+      savedState.chats.map((chat) => chat.id),
+      ["chat_1"],
+    );
+    deepStrictEqual(savedState.messages, []);
+    strictEqual(savedState.selectedChatId, null);
+  });
+
+  it("does not prune persisted chats when a live sync omits the main worktree", async () => {
+    const featureWorktreePath = "/repo/.git/phantom/worktrees/feature";
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [
+        createChat({ worktreeName: "main", worktreePath: "/repo" }),
+        createChat({
+          id: "chat_feature",
+          branchName: "feature",
+          title: "Feature",
+          worktreeName: "feature",
+          worktreePath: featureWorktreePath,
+        }),
+      ],
+    };
+    const { services, store } = await createHarness(state);
+    coreMocks.listWorktrees
+      .mockResolvedValueOnce({
+        ok: true,
+        value: {
+          worktrees: [
+            {
+              name: "feature",
+              path: featureWorktreePath,
+              pathToDisplay: ".git/phantom/worktrees/feature",
+              branch: "feature",
+              isClean: true,
+            },
+          ],
+        },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        value: {
+          worktrees: [
+            {
+              name: "feature",
+              path: featureWorktreePath,
+              pathToDisplay: ".git/phantom/worktrees/feature",
+              branch: "feature",
+              isClean: true,
+            },
+          ],
+        },
+      });
+
+    await services.listProjectWorktrees("proj_1");
+
+    const savedState = await store.load();
+    deepStrictEqual(
+      savedState.chats.map((chat) => chat.id),
+      ["chat_1", "chat_feature"],
+    );
+  });
+
+  it("does not prune chats for worktrees that are known but hidden from display", async () => {
+    const prunableWorktreePath = "/repo/.git/phantom/worktrees/prunable";
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [
+        createChat({ worktreeName: "main", worktreePath: "/repo" }),
+        createChat({
+          id: "chat_prunable",
+          branchName: "prunable",
+          title: "Temporarily unavailable",
+          worktreeName: "prunable",
+          worktreePath: prunableWorktreePath,
+        }),
+      ],
+      messages: [
+        {
+          id: "msg_prunable",
+          chatId: "chat_prunable",
+          role: "user" as const,
+          text: "keep this too",
+          createdAt: timestamp,
+        },
+      ],
+    };
+    const { services, store } = await createHarness(state);
+    coreMocks.listWorktrees
+      .mockResolvedValueOnce({
+        ok: true,
+        value: {
+          worktrees: [
+            {
+              name: "main",
+              path: "/repo",
+              pathToDisplay: ".",
+              branch: "main",
+              isClean: true,
+            },
+          ],
+        },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        value: {
+          worktrees: [
+            {
+              name: "main",
+              path: "/repo",
+              pathToDisplay: ".",
+              branch: "main",
+              isClean: true,
+            },
+            {
+              name: "prunable",
+              path: prunableWorktreePath,
+              pathToDisplay: ".git/phantom/worktrees/prunable",
+              branch: "prunable",
+              isClean: true,
+            },
+          ],
+        },
+      });
+
+    const worktrees = await services.listProjectWorktrees("proj_1");
+
+    deepStrictEqual(
+      worktrees.map((worktree) => worktree.path),
+      ["/repo"],
+    );
+    const savedState = await store.load();
+    deepStrictEqual(
+      savedState.chats.map((chat) => chat.id),
+      ["chat_1", "chat_prunable"],
+    );
+    deepStrictEqual(
+      savedState.messages.map((message) => message.id),
+      ["msg_prunable"],
+    );
+  });
+
+  it("does not prune active chats for worktrees missing from a live sync", async () => {
+    const staleWorktreePath = "/repo/.git/phantom/worktrees/running";
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [
+        createChat({ worktreeName: "main", worktreePath: "/repo" }),
+        createChat({
+          id: "chat_running",
+          activeTurnId: "turn_1",
+          branchName: "running",
+          status: "running",
+          title: "Running worktree",
+          worktreeName: "running",
+          worktreePath: staleWorktreePath,
+        }),
+      ],
+      messages: [
+        {
+          id: "msg_running",
+          chatId: "chat_running",
+          role: "user" as const,
+          text: "keep this",
+          createdAt: timestamp,
+        },
+      ],
+    };
+    const { services, store } = await createHarness(state);
+    coreMocks.listWorktrees
+      .mockResolvedValueOnce({
+        ok: true,
+        value: {
+          worktrees: [
+            {
+              name: "main",
+              path: "/repo",
+              pathToDisplay: ".",
+              branch: "main",
+              isClean: true,
+            },
+          ],
+        },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        value: {
+          worktrees: [
+            {
+              name: "main",
+              path: "/repo",
+              pathToDisplay: ".",
+              branch: "main",
+              isClean: true,
+            },
+          ],
+        },
+      });
+
+    await services.listProjectWorktrees("proj_1");
+
+    const savedState = await store.load();
+    deepStrictEqual(
+      savedState.chats.map((chat) => chat.id),
+      ["chat_1", "chat_running"],
+    );
+    deepStrictEqual(
+      savedState.messages.map((message) => message.id),
+      ["msg_running"],
+    );
+  });
+
+  it("does not prune a missing-worktree chat that becomes active during sync", async () => {
+    const staleWorktreePath = "/repo/.git/phantom/worktrees/running";
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [
+        createChat({ worktreeName: "main", worktreePath: "/repo" }),
+        createChat({
+          id: "chat_running",
+          branchName: "running",
+          title: "Running worktree",
+          worktreeName: "running",
+          worktreePath: staleWorktreePath,
+        }),
+      ],
+      messages: [
+        {
+          id: "msg_running",
+          chatId: "chat_running",
+          role: "user" as const,
+          text: "keep this",
+          createdAt: timestamp,
+        },
+      ],
+    };
+    const store = new ImportRaceStore(
+      await createTemporaryDirectory(),
+      (currentState) => ({
+        ...currentState,
+        chats: currentState.chats.map((chat) =>
+          chat.id === "chat_running"
+            ? {
+                ...chat,
+                activeTurnId: "turn_1",
+                status: "running",
+              }
+            : chat,
+        ),
+      }),
+    );
+    await store.save(state);
+    const codex = new FakeCodexBridge();
+    const services = new ServeServices({
+      codex: codex as unknown as CodexBridge,
+      codexHome: await createTemporaryDirectory(),
+      store,
+    });
+    coreMocks.listWorktrees
+      .mockResolvedValueOnce({
+        ok: true,
+        value: {
+          worktrees: [
+            {
+              name: "main",
+              path: "/repo",
+              pathToDisplay: ".",
+              branch: "main",
+              isClean: true,
+            },
+          ],
+        },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        value: {
+          worktrees: [
+            {
+              name: "main",
+              path: "/repo",
+              pathToDisplay: ".",
+              branch: "main",
+              isClean: true,
+            },
+          ],
+        },
+      });
+
+    await services.listProjectWorktrees("proj_1");
+
+    const savedState = await store.load();
+    deepStrictEqual(
+      savedState.chats.map((chat) => [chat.id, chat.status]),
+      [
+        ["chat_1", "idle"],
+        ["chat_running", "running"],
+      ],
+    );
+    deepStrictEqual(
+      savedState.messages.map((message) => message.id),
+      ["msg_running"],
+    );
+  });
+
+  it("does not prune chats created after the live worktree snapshot", async () => {
+    const staleWorktreePath = "/repo/.git/phantom/worktrees/deleted";
+    const concurrentWorktreePath = "/repo/.git/phantom/worktrees/concurrent";
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [
+        createChat({ worktreeName: "main", worktreePath: "/repo" }),
+        createChat({
+          id: "chat_stale",
+          branchName: "deleted",
+          title: "Deleted worktree",
+          worktreeName: "deleted",
+          worktreePath: staleWorktreePath,
+        }),
+      ],
+    };
+    const store = new ImportRaceStore(
+      await createTemporaryDirectory(),
+      (currentState) => ({
+        ...currentState,
+        chats: [
+          ...currentState.chats,
+          createChat({
+            id: "chat_concurrent",
+            branchName: "concurrent",
+            title: "Concurrent worktree",
+            worktreeName: "concurrent",
+            worktreePath: concurrentWorktreePath,
+          }),
+        ],
+      }),
+    );
+    await store.save(state);
+    const codex = new FakeCodexBridge();
+    const services = new ServeServices({
+      codex: codex as unknown as CodexBridge,
+      codexHome: await createTemporaryDirectory(),
+      store,
+    });
+    coreMocks.listWorktrees
+      .mockResolvedValueOnce({
+        ok: true,
+        value: {
+          worktrees: [
+            {
+              name: "main",
+              path: "/repo",
+              pathToDisplay: ".",
+              branch: "main",
+              isClean: true,
+            },
+          ],
+        },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        value: {
+          worktrees: [
+            {
+              name: "main",
+              path: "/repo",
+              pathToDisplay: ".",
+              branch: "main",
+              isClean: true,
+            },
+          ],
+        },
+      });
+
+    await services.listProjectWorktrees("proj_1");
+
+    const savedState = await store.load();
+    deepStrictEqual(
+      savedState.chats.map((chat) => chat.id),
+      ["chat_1", "chat_concurrent"],
+    );
   });
 
   it("pins the main worktree above managed worktrees", async () => {

--- a/packages/app/src/server/services.ts
+++ b/packages/app/src/server/services.ts
@@ -275,6 +275,15 @@ export class ServeServices {
     }
 
     const { worktrees } = result.value;
+    const displayWorktreePaths = new Set(
+      worktrees.map((worktree) => worktree.path),
+    );
+    const knownWorktreePaths = await getKnownProjectWorktreePaths(
+      project.rootPath,
+    );
+    const canPruneMissingWorktreeChats = Boolean(
+      knownWorktreePaths?.has(project.rootPath),
+    );
     const timestamp = createTimestamp();
     const importedSessions = await listCodexSessionsForWorktrees({
       codexHome: this.codexHome,
@@ -289,6 +298,8 @@ export class ServeServices {
     if (
       shouldSyncProjectWorktreeChats({
         importedSessions,
+        canPruneMissingWorktreeChats,
+        knownWorktreePaths,
         projectId,
         state,
         worktrees,
@@ -331,18 +342,35 @@ export class ServeServices {
         const importableMessages = importableSessions.flatMap(
           (session) => session.messages,
         );
-
-        if (chatsToAdd.length === 0 && importableSessions.length === 0) {
-          return nextState;
-        }
+        const initialMissingWorktreeChatIds = new Set(
+          state.chats
+            .filter(
+              (chat) =>
+                canPruneMissingWorktreeChats &&
+                chat.projectId === projectId &&
+                !knownWorktreePaths?.has(chat.worktreePath),
+            )
+            .map((chat) => chat.id),
+        );
         const chatsToRemove = nextState.chats.filter(
           (chat) =>
-            !shouldPreserveChatDuringImport(
+            !shouldPreserveChatDuringWorktreeSync(
               chat,
               projectId,
+              displayWorktreePaths,
+              knownWorktreePaths,
+              initialMissingWorktreeChatIds,
+              this.pendingChatTurns,
               importableSessions,
             ),
         );
+        if (
+          chatsToAdd.length === 0 &&
+          importableSessions.length === 0 &&
+          chatsToRemove.length === 0
+        ) {
+          return nextState;
+        }
         const chatIdsToRemove = new Set(chatsToRemove.map((chat) => chat.id));
         const selectedReplacement = findImportedReplacement(
           nextState.selectedChatId,
@@ -366,7 +394,7 @@ export class ServeServices {
           selectedChatId:
             nextState.selectedChatId &&
             chatIdsToRemove.has(nextState.selectedChatId)
-              ? (selectedReplacement?.chat.id ?? nextState.selectedChatId)
+              ? (selectedReplacement?.chat.id ?? null)
               : nextState.selectedChatId,
         };
       });
@@ -1561,6 +1589,20 @@ async function getProjectWorktreesDirectory(
   }
 }
 
+async function getKnownProjectWorktreePaths(
+  projectRootPath: string,
+): Promise<Set<string> | null> {
+  try {
+    const result = await listWorktrees(projectRootPath);
+    if (!result.ok) {
+      return null;
+    }
+    return new Set(result.value.worktrees.map((worktree) => worktree.path));
+  } catch {
+    return null;
+  }
+}
+
 function isPathInsideDirectory(path: string, directory: string): boolean {
   const relativePath = relative(directory, path);
   return Boolean(
@@ -1570,11 +1612,15 @@ function isPathInsideDirectory(path: string, directory: string): boolean {
 
 function shouldSyncProjectWorktreeChats({
   importedSessions,
+  canPruneMissingWorktreeChats,
+  knownWorktreePaths,
   projectId,
   state,
   worktrees,
 }: {
   importedSessions: ImportedCodexSession[];
+  canPruneMissingWorktreeChats: boolean;
+  knownWorktreePaths: ReadonlySet<string> | null;
   projectId: string;
   state: ServeState;
   worktrees: Array<{ path: string }>;
@@ -1588,6 +1634,12 @@ function shouldSyncProjectWorktreeChats({
     importedSessions.map((session) => session.chat.worktreePath),
   );
   return (
+    (canPruneMissingWorktreeChats &&
+      state.chats.some(
+        (chat) =>
+          chat.projectId === projectId &&
+          !knownWorktreePaths?.has(chat.worktreePath),
+      )) ||
     worktrees.some(
       (worktree) =>
         !existingChatsByPath.has(worktree.path) &&
@@ -1672,6 +1724,45 @@ function mergeImportedSessionsForProject(
       ...importableSessions.flatMap((session) => session.messages),
     ],
   };
+}
+
+function shouldPreserveChatDuringWorktreeSync(
+  chat: ChatRecord,
+  projectId: string,
+  displayWorktreePaths: ReadonlySet<string>,
+  knownWorktreePaths: ReadonlySet<string> | null,
+  initialMissingWorktreeChatIds: ReadonlySet<string>,
+  pendingChatTurns: ReadonlySet<string>,
+  importedSessions: ImportedCodexSession[],
+): boolean {
+  if (chat.projectId !== projectId) {
+    return true;
+  }
+  if (displayWorktreePaths.has(chat.worktreePath)) {
+    return shouldPreserveChatDuringImport(chat, projectId, importedSessions);
+  }
+  if (knownWorktreePaths?.has(chat.worktreePath)) {
+    return true;
+  }
+  if (knownWorktreePaths) {
+    return (
+      !initialMissingWorktreeChatIds.has(chat.id) ||
+      isChatActive(chat, pendingChatTurns)
+    );
+  }
+  return true;
+}
+
+function isChatActive(
+  chat: ChatRecord,
+  pendingChatTurns: ReadonlySet<string>,
+): boolean {
+  return Boolean(
+    pendingChatTurns.has(chat.id) ||
+    chat.activeTurnId ||
+    chat.status === "running" ||
+    chat.status === "waitingForApproval",
+  );
 }
 
 function shouldPreserveChatDuringImport(


### PR DESCRIPTION
## Summary

- Prune persisted Serve chats/messages for worktrees that are missing from a successful live worktree sync.
- Avoid replacing the sidebar worktree list from non-sync chat refreshes.
- Add coverage for stale persisted worktree chat cleanup.

## Root Cause

Deleted worktrees could reappear because saved chat state remained after a worktree was removed externally. Later lightweight chat refreshes could rebuild the sidebar worktree list from that stale persisted state instead of the live `git worktree list` result.

## Validation

- `pnpm --filter app-private test -- services.test.ts`
- `pnpm ready`