### PR TITLE
[codex] prevent worktree click expanding chats

### DIFF
--- a/packages/app/src/routes/index.tsx
+++ b/packages/app/src/routes/index.tsx
@@ -729,23 +729,6 @@ function Home() {
     setSelectedChatId(selectedWorktreeChats[0]?.id ?? null);
   }, [selectedChatId, selectedWorktreeChats]);
 
-  useEffect(() => {
-    if (!selectedProjectId || !selectedWorktreePath || !selectedChatId) {
-      return;
-    }
-
-    setExpandedWorktreeKeys((current) => {
-      const selectedWorktreeKey = getWorktreeExpansionKey(
-        selectedProjectId,
-        selectedWorktreePath,
-      );
-      if (current.has(selectedWorktreeKey)) {
-        return current;
-      }
-      return new Set(current).add(selectedWorktreeKey);
-    });
-  }, [selectedChatId, selectedProjectId, selectedWorktreePath]);
-
   function setProjectLoading(projectId: string, isLoading: boolean) {
     setLoadingProjectIds((current) => {
       const next = new Set(current);
@@ -1352,9 +1335,6 @@ function Home() {
     setSelectedWorktreePath(worktree.path);
     setSelectedChatId(worktree.chatId);
     setExpandedProjectIds((current) => new Set(current).add(projectId));
-    setExpandedWorktreeKeys((current) =>
-      new Set(current).add(getWorktreeExpansionKey(projectId, worktree.path)),
-    );
   }
 
   function selectChat(


### PR DESCRIPTION
## Summary

- Prevent selecting a worktree in the sidebar from expanding its chat history list.
- Keep chat history expansion tied to the explicit chevron toggle, while preserving project expansion and chat selection behavior.

## Root Cause

Selecting a worktree also added that worktree to the expanded chat-list state, and a selected-chat effect re-expanded the selected worktree whenever a chat was selected.

## Validation

- `pnpm ready`