### PR TITLE
[codex] fix mobile chat enter handling

### DIFF
--- a/packages/app/src/lib/composer-keyboard.test.ts
+++ b/packages/app/src/lib/composer-keyboard.test.ts
@@ -1,9 +1,31 @@
 import { describe, expect, it } from "vitest";
 import { shouldSubmitComposerOnEnter } from "./composer-keyboard";
 
-function createEnvironment(options: { virtualKeyboardHeight?: number } = {}) {
+function createEnvironment(
+  options: {
+    coarsePointer?: boolean;
+    finePointer?: boolean;
+    hover?: boolean;
+    maxTouchPoints?: number;
+    mobileUserAgentData?: boolean;
+    userAgent?: string;
+    virtualKeyboardHeight?: number;
+  } = {},
+) {
   return {
+    matchMedia: (query: string) => {
+      const matches =
+        (query === "(pointer: coarse)" && options.coarsePointer) ||
+        (query === "(any-pointer: fine)" && options.finePointer) ||
+        (query === "(hover: hover)" && options.hover);
+      return { matches: Boolean(matches) };
+    },
     navigator: {
+      maxTouchPoints: options.maxTouchPoints ?? 0,
+      userAgent: options.userAgent ?? "",
+      userAgentData: {
+        mobile: options.mobileUserAgentData ?? false,
+      },
       virtualKeyboard: {
         boundingRect: {
           height: options.virtualKeyboardHeight ?? 0,
@@ -87,6 +109,31 @@ describe("shouldSubmitComposerOnEnter", () => {
       shouldSubmitComposerOnEnter(
         { code: "Enter", key: "Enter" },
         createEnvironment({ virtualKeyboardHeight: 280 }),
+      ),
+    ).toBe(false);
+  });
+
+  it("does not submit Enter on Android Chrome software keyboard events", () => {
+    expect(
+      shouldSubmitComposerOnEnter(
+        { code: "Enter", key: "Enter" },
+        createEnvironment({
+          maxTouchPoints: 5,
+          userAgent:
+            "Mozilla/5.0 (Linux; Android 15) AppleWebKit/537.36 Chrome/126.0 Mobile Safari/537.36",
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("does not submit Enter on coarse touch-only environments", () => {
+    expect(
+      shouldSubmitComposerOnEnter(
+        { code: "Enter", key: "Enter" },
+        createEnvironment({
+          coarsePointer: true,
+          maxTouchPoints: 5,
+        }),
       ),
     ).toBe(false);
   });

--- a/packages/app/src/lib/composer-keyboard.test.ts
+++ b/packages/app/src/lib/composer-keyboard.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { shouldSubmitComposerOnEnter } from "./composer-keyboard";
+
+function createEnvironment(options: { virtualKeyboardHeight?: number } = {}) {
+  return {
+    navigator: {
+      virtualKeyboard: {
+        boundingRect: {
+          height: options.virtualKeyboardHeight ?? 0,
+        },
+      },
+    },
+  };
+}
+
+describe("shouldSubmitComposerOnEnter", () => {
+  it("submits bare Enter from a hardware keyboard", () => {
+    expect(
+      shouldSubmitComposerOnEnter(
+        { code: "Enter", key: "Enter" },
+        createEnvironment(),
+      ),
+    ).toBe(true);
+    expect(
+      shouldSubmitComposerOnEnter(
+        { code: "NumpadEnter", key: "Enter" },
+        createEnvironment(),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not submit Enter without a hardware key code", () => {
+    expect(
+      shouldSubmitComposerOnEnter({ key: "Enter" }, createEnvironment()),
+    ).toBe(false);
+    expect(
+      shouldSubmitComposerOnEnter(
+        { code: "Unidentified", key: "Enter" },
+        createEnvironment(),
+      ),
+    ).toBe(false);
+  });
+
+  it("does not submit modified Enter or IME composition", () => {
+    const environment = createEnvironment();
+
+    expect(
+      shouldSubmitComposerOnEnter(
+        { code: "Enter", key: "Enter", shiftKey: true },
+        environment,
+      ),
+    ).toBe(false);
+    expect(
+      shouldSubmitComposerOnEnter(
+        { altKey: true, code: "Enter", key: "Enter" },
+        environment,
+      ),
+    ).toBe(false);
+    expect(
+      shouldSubmitComposerOnEnter(
+        { code: "Enter", ctrlKey: true, key: "Enter" },
+        environment,
+      ),
+    ).toBe(false);
+    expect(
+      shouldSubmitComposerOnEnter(
+        { code: "Enter", key: "Enter", metaKey: true },
+        environment,
+      ),
+    ).toBe(false);
+    expect(
+      shouldSubmitComposerOnEnter(
+        { code: "Enter", key: "Enter", isComposing: true },
+        environment,
+      ),
+    ).toBe(false);
+    expect(
+      shouldSubmitComposerOnEnter(
+        { code: "Enter", key: "Enter", keyCode: 229 },
+        environment,
+      ),
+    ).toBe(false);
+  });
+
+  it("does not submit while the VirtualKeyboard API reports an active software keyboard", () => {
+    expect(
+      shouldSubmitComposerOnEnter(
+        { code: "Enter", key: "Enter" },
+        createEnvironment({ virtualKeyboardHeight: 280 }),
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/app/src/lib/composer-keyboard.ts
+++ b/packages/app/src/lib/composer-keyboard.ts
@@ -10,8 +10,13 @@ type ComposerEnterKeyEvent = {
 };
 
 type ComposerEnterKeyEnvironment = {
+  matchMedia?: (query: string) => { matches: boolean };
   navigator?: {
     maxTouchPoints?: number;
+    userAgent?: string;
+    userAgentData?: {
+      mobile?: boolean;
+    };
     virtualKeyboard?: {
       boundingRect?: {
         height?: number;
@@ -37,7 +42,8 @@ export function shouldSubmitComposerOnEnter(
   }
 
   return (
-    isHardwareEnterKey(event) && !isKnownSoftwareKeyboardActive(environment)
+    isHardwareEnterKey(event) &&
+    !isLikelyMobileTextEntryEnvironment(environment)
   );
 }
 
@@ -45,10 +51,33 @@ function isHardwareEnterKey(event: ComposerEnterKeyEvent): boolean {
   return event.code === "Enter" || event.code === "NumpadEnter";
 }
 
-function isKnownSoftwareKeyboardActive(
+function isLikelyMobileTextEntryEnvironment(
   environment: ComposerEnterKeyEnvironment,
 ): boolean {
   const virtualKeyboardHeight =
     environment.navigator?.virtualKeyboard?.boundingRect?.height ?? 0;
-  return virtualKeyboardHeight > 0;
+  if (virtualKeyboardHeight > 0) {
+    return true;
+  }
+
+  if (environment.navigator?.userAgentData?.mobile) {
+    return true;
+  }
+
+  const userAgent = environment.navigator?.userAgent ?? "";
+  if (/(Android|iPhone|iPad|iPod|Mobile|Windows Phone)/i.test(userAgent)) {
+    return true;
+  }
+
+  const maxTouchPoints = environment.navigator?.maxTouchPoints ?? 0;
+  if (maxTouchPoints === 0 || !environment.matchMedia) {
+    return false;
+  }
+
+  const hasCoarsePrimaryPointer =
+    environment.matchMedia("(pointer: coarse)").matches;
+  const hasFinePointer = environment.matchMedia("(any-pointer: fine)").matches;
+  const hasHover = environment.matchMedia("(hover: hover)").matches;
+
+  return hasCoarsePrimaryPointer && !hasFinePointer && !hasHover;
 }

--- a/packages/app/src/lib/composer-keyboard.ts
+++ b/packages/app/src/lib/composer-keyboard.ts
@@ -1,0 +1,54 @@
+type ComposerEnterKeyEvent = {
+  altKey?: boolean;
+  code?: string;
+  ctrlKey?: boolean;
+  isComposing?: boolean;
+  key: string;
+  keyCode?: number;
+  metaKey?: boolean;
+  shiftKey?: boolean;
+};
+
+type ComposerEnterKeyEnvironment = {
+  navigator?: {
+    maxTouchPoints?: number;
+    virtualKeyboard?: {
+      boundingRect?: {
+        height?: number;
+      };
+    };
+  };
+};
+
+export function shouldSubmitComposerOnEnter(
+  event: ComposerEnterKeyEvent,
+  environment: ComposerEnterKeyEnvironment = globalThis,
+): boolean {
+  const isImeComposing = event.isComposing || event.keyCode === 229;
+  if (
+    event.key !== "Enter" ||
+    event.shiftKey ||
+    event.metaKey ||
+    event.ctrlKey ||
+    event.altKey ||
+    isImeComposing
+  ) {
+    return false;
+  }
+
+  return (
+    isHardwareEnterKey(event) && !isKnownSoftwareKeyboardActive(environment)
+  );
+}
+
+function isHardwareEnterKey(event: ComposerEnterKeyEvent): boolean {
+  return event.code === "Enter" || event.code === "NumpadEnter";
+}
+
+function isKnownSoftwareKeyboardActive(
+  environment: ComposerEnterKeyEnvironment,
+): boolean {
+  const virtualKeyboardHeight =
+    environment.navigator?.virtualKeyboard?.boundingRect?.height ?? 0;
+  return virtualKeyboardHeight > 0;
+}

--- a/packages/app/src/routes/index.tsx
+++ b/packages/app/src/routes/index.tsx
@@ -77,6 +77,7 @@ import {
   SidebarTrigger,
 } from "../components/ui/sidebar";
 import { Textarea } from "../components/ui/textarea";
+import { shouldSubmitComposerOnEnter } from "../lib/composer-keyboard";
 import { cn } from "../lib/utils";
 import type {
   ChatMessageRecord,
@@ -1263,15 +1264,17 @@ function Home() {
   }
 
   function handleComposerKeyDown(event: KeyboardEvent<HTMLTextAreaElement>) {
-    const isImeComposing =
-      event.nativeEvent.isComposing || event.keyCode === 229;
     if (
-      event.key !== "Enter" ||
-      event.shiftKey ||
-      event.metaKey ||
-      event.ctrlKey ||
-      event.altKey ||
-      isImeComposing
+      !shouldSubmitComposerOnEnter({
+        altKey: event.altKey,
+        code: event.code,
+        ctrlKey: event.ctrlKey,
+        isComposing: event.nativeEvent.isComposing,
+        key: event.key,
+        keyCode: event.keyCode,
+        metaKey: event.metaKey,
+        shiftKey: event.shiftKey,
+      })
     ) {
       return;
     }
@@ -1945,6 +1948,7 @@ function Home() {
                 <Textarea
                   className="min-h-12 border-0 bg-transparent px-2 py-2 shadow-none focus-visible:shadow-none"
                   disabled={!selectedChatId}
+                  enterKeyHint="enter"
                   id="composer"
                   placeholder={
                     selectedChatId


### PR DESCRIPTION
## Summary
- Restrict chat composer Enter-to-send to desktop/hardware-keyboard style environments.
- Prevent Android Chrome and other mobile/touch software-keyboard Enter events from submitting, even when the browser reports `KeyboardEvent.code` as `Enter`.
- Add focused unit coverage for physical Enter/NumpadEnter, missing/unidentified key codes, modifier keys, IME composition, VirtualKeyboard-active cases, Android Chrome mobile UA, and coarse touch-only environments.

## Why
On smartphone software keyboards, pressing Enter/Return was submitting the chat instead of inserting a line break. Mobile users do not have a reliable Shift+Enter equivalent, so this caused accidental sends and made multi-line messages difficult to compose.

## Review loop
- Ran an implementation review loop with explorer subagents.
- Addressed findings around device-wide mobile detection and viewport-resize heuristics.
- After Android Chrome manual testing showed software keyboard events can still report `code: "Enter"`, updated the logic to block Enter-to-send in likely mobile text-entry environments.

## Validation
- Manual Android Chrome software-keyboard test
- `pnpm --filter app-private test`
- `pnpm --filter app-private typecheck`
- `pnpm ready`