### PR TITLE
[codex] Reset stale serve chat state

### DIFF
--- a/packages/app/src/routeTree.gen.ts
+++ b/packages/app/src/routeTree.gen.ts
@@ -19,11 +19,11 @@ import { Route as ApiProjectsProjectIdRouteImport } from './routes/api/projects/
 import { Route as ApiChatsChatIdRouteImport } from './routes/api/chats/$chatId'
 import { Route as ApiProjectsProjectIdWorktreesRouteImport } from './routes/api/projects/$projectId/worktrees'
 import { Route as ApiProjectsProjectIdChatsRouteImport } from './routes/api/projects/$projectId/chats'
-import { Route as ApiProjectsProjectIdWorktreesSyncRouteImport } from './routes/api/projects/$projectId/worktrees/sync'
 import { Route as ApiChatsChatIdSteerRouteImport } from './routes/api/chats/$chatId/steer'
 import { Route as ApiChatsChatIdMessagesRouteImport } from './routes/api/chats/$chatId/messages'
 import { Route as ApiChatsChatIdInterruptRouteImport } from './routes/api/chats/$chatId/interrupt'
 import { Route as ApiChatsChatIdEventsRouteImport } from './routes/api/chats/$chatId/events'
+import { Route as ApiProjectsProjectIdWorktreesSyncRouteImport } from './routes/api/projects/$projectId/worktrees/sync'
 import { Route as ApiChatsChatIdApprovalsRequestIdRouteImport } from './routes/api/chats/$chatId/approvals/$requestId'
 
 const IndexRoute = IndexRouteImport.update({
@@ -78,12 +78,6 @@ const ApiProjectsProjectIdChatsRoute =
     path: '/chats',
     getParentRoute: () => ApiProjectsProjectIdRoute,
   } as any)
-const ApiProjectsProjectIdWorktreesSyncRoute =
-  ApiProjectsProjectIdWorktreesSyncRouteImport.update({
-    id: '/sync',
-    path: '/sync',
-    getParentRoute: () => ApiProjectsProjectIdWorktreesRoute,
-  } as any)
 const ApiChatsChatIdSteerRoute = ApiChatsChatIdSteerRouteImport.update({
   id: '/steer',
   path: '/steer',
@@ -104,6 +98,12 @@ const ApiChatsChatIdEventsRoute = ApiChatsChatIdEventsRouteImport.update({
   path: '/events',
   getParentRoute: () => ApiChatsChatIdRoute,
 } as any)
+const ApiProjectsProjectIdWorktreesSyncRoute =
+  ApiProjectsProjectIdWorktreesSyncRouteImport.update({
+    id: '/sync',
+    path: '/sync',
+    getParentRoute: () => ApiProjectsProjectIdWorktreesRoute,
+  } as any)
 const ApiChatsChatIdApprovalsRequestIdRoute =
   ApiChatsChatIdApprovalsRequestIdRouteImport.update({
     id: '/approvals/$requestId',
@@ -126,8 +126,8 @@ export interface FileRoutesByFullPath {
   '/api/chats/$chatId/steer': typeof ApiChatsChatIdSteerRoute
   '/api/projects/$projectId/chats': typeof ApiProjectsProjectIdChatsRoute
   '/api/projects/$projectId/worktrees': typeof ApiProjectsProjectIdWorktreesRouteWithChildren
-  '/api/projects/$projectId/worktrees/sync': typeof ApiProjectsProjectIdWorktreesSyncRoute
   '/api/chats/$chatId/approvals/$requestId': typeof ApiChatsChatIdApprovalsRequestIdRoute
+  '/api/projects/$projectId/worktrees/sync': typeof ApiProjectsProjectIdWorktreesSyncRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -144,8 +144,8 @@ export interface FileRoutesByTo {
   '/api/chats/$chatId/steer': typeof ApiChatsChatIdSteerRoute
   '/api/projects/$projectId/chats': typeof ApiProjectsProjectIdChatsRoute
   '/api/projects/$projectId/worktrees': typeof ApiProjectsProjectIdWorktreesRouteWithChildren
-  '/api/projects/$projectId/worktrees/sync': typeof ApiProjectsProjectIdWorktreesSyncRoute
   '/api/chats/$chatId/approvals/$requestId': typeof ApiChatsChatIdApprovalsRequestIdRoute
+  '/api/projects/$projectId/worktrees/sync': typeof ApiProjectsProjectIdWorktreesSyncRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -163,8 +163,8 @@ export interface FileRoutesById {
   '/api/chats/$chatId/steer': typeof ApiChatsChatIdSteerRoute
   '/api/projects/$projectId/chats': typeof ApiProjectsProjectIdChatsRoute
   '/api/projects/$projectId/worktrees': typeof ApiProjectsProjectIdWorktreesRouteWithChildren
-  '/api/projects/$projectId/worktrees/sync': typeof ApiProjectsProjectIdWorktreesSyncRoute
   '/api/chats/$chatId/approvals/$requestId': typeof ApiChatsChatIdApprovalsRequestIdRoute
+  '/api/projects/$projectId/worktrees/sync': typeof ApiProjectsProjectIdWorktreesSyncRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -183,8 +183,8 @@ export interface FileRouteTypes {
     | '/api/chats/$chatId/steer'
     | '/api/projects/$projectId/chats'
     | '/api/projects/$projectId/worktrees'
-    | '/api/projects/$projectId/worktrees/sync'
     | '/api/chats/$chatId/approvals/$requestId'
+    | '/api/projects/$projectId/worktrees/sync'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -201,8 +201,8 @@ export interface FileRouteTypes {
     | '/api/chats/$chatId/steer'
     | '/api/projects/$projectId/chats'
     | '/api/projects/$projectId/worktrees'
-    | '/api/projects/$projectId/worktrees/sync'
     | '/api/chats/$chatId/approvals/$requestId'
+    | '/api/projects/$projectId/worktrees/sync'
   id:
     | '__root__'
     | '/'
@@ -219,8 +219,8 @@ export interface FileRouteTypes {
     | '/api/chats/$chatId/steer'
     | '/api/projects/$projectId/chats'
     | '/api/projects/$projectId/worktrees'
-    | '/api/projects/$projectId/worktrees/sync'
     | '/api/chats/$chatId/approvals/$requestId'
+    | '/api/projects/$projectId/worktrees/sync'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -298,13 +298,6 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiProjectsProjectIdWorktreesRouteImport
       parentRoute: typeof ApiProjectsProjectIdRoute
     }
-    '/api/projects/$projectId/worktrees/sync': {
-      id: '/api/projects/$projectId/worktrees/sync'
-      path: '/sync'
-      fullPath: '/api/projects/$projectId/worktrees/sync'
-      preLoaderRoute: typeof ApiProjectsProjectIdWorktreesSyncRouteImport
-      parentRoute: typeof ApiProjectsProjectIdWorktreesRoute
-    }
     '/api/projects/$projectId/chats': {
       id: '/api/projects/$projectId/chats'
       path: '/chats'
@@ -340,6 +333,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiChatsChatIdEventsRouteImport
       parentRoute: typeof ApiChatsChatIdRoute
     }
+    '/api/projects/$projectId/worktrees/sync': {
+      id: '/api/projects/$projectId/worktrees/sync'
+      path: '/sync'
+      fullPath: '/api/projects/$projectId/worktrees/sync'
+      preLoaderRoute: typeof ApiProjectsProjectIdWorktreesSyncRouteImport
+      parentRoute: typeof ApiProjectsProjectIdWorktreesRoute
+    }
     '/api/chats/$chatId/approvals/$requestId': {
       id: '/api/chats/$chatId/approvals/$requestId'
       path: '/approvals/$requestId'
@@ -348,11 +348,6 @@ declare module '@tanstack/react-router' {
       parentRoute: typeof ApiChatsChatIdRoute
     }
   }
-}
-
-interface ApiProjectsProjectIdRouteChildren {
-  ApiProjectsProjectIdChatsRoute: typeof ApiProjectsProjectIdChatsRoute
-  ApiProjectsProjectIdWorktreesRoute: typeof ApiProjectsProjectIdWorktreesRouteWithChildren
 }
 
 interface ApiProjectsProjectIdWorktreesRouteChildren {
@@ -370,9 +365,15 @@ const ApiProjectsProjectIdWorktreesRouteWithChildren =
     ApiProjectsProjectIdWorktreesRouteChildren,
   )
 
+interface ApiProjectsProjectIdRouteChildren {
+  ApiProjectsProjectIdChatsRoute: typeof ApiProjectsProjectIdChatsRoute
+  ApiProjectsProjectIdWorktreesRoute: typeof ApiProjectsProjectIdWorktreesRouteWithChildren
+}
+
 const ApiProjectsProjectIdRouteChildren: ApiProjectsProjectIdRouteChildren = {
   ApiProjectsProjectIdChatsRoute: ApiProjectsProjectIdChatsRoute,
-  ApiProjectsProjectIdWorktreesRoute: ApiProjectsProjectIdWorktreesRouteWithChildren,
+  ApiProjectsProjectIdWorktreesRoute:
+    ApiProjectsProjectIdWorktreesRouteWithChildren,
 }
 
 const ApiProjectsProjectIdRouteWithChildren =

--- a/packages/app/src/server/services.test.ts
+++ b/packages/app/src/server/services.test.ts
@@ -153,6 +153,15 @@ async function createHarness(state: ServeState): Promise<{
   return { codex, services, store };
 }
 
+function markChatActiveInCurrentProcess(
+  services: ServeServices,
+  chatId: string,
+): void {
+  (
+    services as unknown as { activeTurnChatIds: Set<string> }
+  ).activeTurnChatIds.add(chatId);
+}
+
 class ImportRaceStore extends ServeStateStore {
   private hasInjectedState = false;
 
@@ -542,6 +551,7 @@ describe("ServeServices", () => {
       ],
     };
     const { services, store } = await createHarness(state);
+    markChatActiveInCurrentProcess(services, "chat_running");
     coreMocks.listWorktrees
       .mockResolvedValueOnce({
         ok: true,
@@ -871,6 +881,23 @@ describe("ServeServices", () => {
       },
     ]);
     strictEqual(coreMocks.listWorktrees.mock.calls.length, 0);
+  });
+
+  it("resets stale transient chat state when listing chats", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "running", activeTurnId: "turn_stale" })],
+    };
+    const { services, store } = await createHarness(state);
+
+    const chats = await services.listChats("proj_1");
+
+    strictEqual(chats[0]?.status, "idle");
+    strictEqual(chats[0]?.activeTurnId, null);
+    const savedState = await store.load();
+    strictEqual(savedState.chats[0]?.status, "idle");
+    strictEqual(savedState.chats[0]?.activeTurnId, null);
   });
 
   it("imports existing Codex chat history for project worktrees", async () => {
@@ -1682,6 +1709,8 @@ describe("ServeServices", () => {
       (
         services as unknown as { pendingChatTurns: Set<string> }
       ).pendingChatTurns.add("chat_1");
+    } else {
+      markChatActiveInCurrentProcess(services, "chat_1");
     }
     coreMocks.createContext.mockResolvedValueOnce({
       gitRoot: "/repo",
@@ -2001,6 +2030,75 @@ describe("ServeServices", () => {
     strictEqual(savedState.selectedChatId, null);
   });
 
+  it("does not let stale transient chat state block worktree deletion", async () => {
+    const worktreePath = "/repo/.git/phantom/worktrees/worktree";
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [
+        createChat({
+          branchName: "worktree",
+          status: "running",
+          activeTurnId: "turn_stale",
+          worktreeName: "worktree",
+          worktreePath,
+        }),
+      ],
+      messages: [
+        {
+          id: "msg_stale",
+          chatId: "chat_1",
+          role: "event" as const,
+          text: "turn started",
+          createdAt: timestamp,
+        },
+      ],
+      selectedChatId: "chat_1",
+    };
+    const { services, store } = await createHarness(state);
+    coreMocks.createContext.mockResolvedValueOnce({
+      gitRoot: "/repo",
+      worktreesDirectory: "/repo/.git/phantom/worktrees",
+      preferences: {},
+      config: {},
+    });
+    coreMocks.listWorktrees.mockResolvedValueOnce({
+      ok: true,
+      value: {
+        worktrees: [
+          {
+            name: "worktree",
+            path: worktreePath,
+            pathToDisplay: ".git/phantom/worktrees/worktree",
+            branch: "worktree",
+            isClean: true,
+          },
+        ],
+      },
+    });
+    coreMocks.deleteWorktree.mockResolvedValueOnce({
+      ok: true,
+      value: { message: "Deleted worktree 'worktree'" },
+    });
+
+    const result = await services.deleteProjectWorktree("proj_1", {
+      name: "worktree",
+    });
+
+    deepStrictEqual(result, { message: "Deleted worktree 'worktree'" });
+    deepStrictEqual(coreMocks.deleteWorktree.mock.calls[0], [
+      "/repo",
+      "/repo/.git/phantom/worktrees",
+      "worktree",
+      { force: undefined, keepBranch: false, path: worktreePath },
+      undefined,
+    ]);
+    const savedState = await store.load();
+    deepStrictEqual(savedState.chats, []);
+    deepStrictEqual(savedState.messages, []);
+    strictEqual(savedState.selectedChatId, null);
+  });
+
   it("does not delete a worktree with an active chat", async () => {
     const worktreePath = "/repo/.git/phantom/worktrees/worktree";
     const state = {
@@ -2017,6 +2115,7 @@ describe("ServeServices", () => {
       ],
     };
     const { services } = await createHarness(state);
+    markChatActiveInCurrentProcess(services, "chat_1");
     coreMocks.createContext.mockResolvedValueOnce({
       gitRoot: "/repo",
       worktreesDirectory: "/repo/.git/phantom/worktrees",
@@ -2862,6 +2961,7 @@ describe("ServeServices", () => {
       ],
     };
     const { codex, services, store } = await createHarness(state);
+    markChatActiveInCurrentProcess(services, "chat_1");
 
     await rejects(
       services.sendMessage("chat_1", { text: "continue" }),
@@ -2882,6 +2982,7 @@ describe("ServeServices", () => {
       chats: [createChat({ status: "running", activeTurnId: "turn_1" })],
     };
     const { codex, services, store } = await createHarness(state);
+    markChatActiveInCurrentProcess(services, "chat_1");
     codex.resumeThread.mockResolvedValueOnce({});
     codex.steerTurn.mockRejectedValueOnce(new Error("steer rejected"));
 

--- a/packages/app/src/server/services.ts
+++ b/packages/app/src/server/services.ts
@@ -125,6 +125,7 @@ export class ServeServices {
     PendingTurnEventBuffer
   >();
   private readonly pendingChatTurns = new Set<string>();
+  private readonly activeTurnChatIds = new Set<string>();
 
   constructor(options: ServeServicesOptions = {}) {
     this.eventHub = options.eventHub ?? new EventHub();
@@ -143,6 +144,7 @@ export class ServeServices {
   }
 
   async getHealth() {
+    await this.resetStaleTransientChatState();
     const state = await this.store.load();
     return {
       ok: true,
@@ -154,6 +156,7 @@ export class ServeServices {
   }
 
   async listProjects(): Promise<ProjectRecord[]> {
+    await this.resetStaleTransientChatState();
     const state = await this.store.load();
     return state.projects;
   }
@@ -230,6 +233,7 @@ export class ServeServices {
   }
 
   async listChats(projectId: string): Promise<ChatRecord[]> {
+    await this.resetStaleTransientChatState();
     const state = await this.store.load();
     return state.chats.filter((chat) => chat.projectId === projectId);
   }
@@ -238,6 +242,7 @@ export class ServeServices {
     projectId: string,
     options: { sync?: boolean } = {},
   ): Promise<ProjectWorktreeRecord[]> {
+    await this.resetStaleTransientChatState();
     const state = await this.store.load();
     const project = this.requireProject(state, projectId);
     const worktreesDirectory = await getProjectWorktreesDirectory(
@@ -439,6 +444,7 @@ export class ServeServices {
     projectId: string,
     input: SyncProjectWorktreeBranchInput,
   ): Promise<SyncProjectWorktreeBranchResult> {
+    await this.resetStaleTransientChatState();
     const worktreeName = input.name.trim();
     if (!worktreeName) {
       throw new Error("Worktree name is required");
@@ -604,6 +610,7 @@ export class ServeServices {
     projectId: string,
     input: DeleteProjectWorktreeInput,
   ): Promise<DeleteProjectWorktreeResult> {
+    await this.resetStaleTransientChatState();
     const worktreeName = input.name.trim();
     if (!worktreeName) {
       throw new Error("Worktree name is required");
@@ -685,11 +692,13 @@ export class ServeServices {
   }
 
   async getChat(chatId: string): Promise<ChatRecord> {
+    await this.resetStaleTransientChatState();
     const state = await this.store.load();
     return this.requireChat(state, chatId);
   }
 
   async getMessages(chatId: string): Promise<ChatMessageRecord[]> {
+    await this.resetStaleTransientChatState();
     const state = await this.store.load();
     this.requireChat(state, chatId);
     return state.messages.filter((message) => message.chatId === chatId);
@@ -714,6 +723,7 @@ export class ServeServices {
     input: SendMessageInput,
     options: { requireActiveTurn: boolean },
   ): Promise<ChatRecord> {
+    await this.resetStaleTransientChatState();
     const text = input.text.trim();
     if (!text) {
       throw new Error("Message text cannot be empty");
@@ -793,6 +803,7 @@ export class ServeServices {
             : await this.codex.startTurn(threadId, text, chat.worktreePath);
           const turnId = extractTurnId(turnResult);
           if (turnId) {
+            this.activeTurnChatIds.add(chatId);
             nextStatus = "running";
             nextActiveTurnId = turnId;
           }
@@ -860,6 +871,7 @@ export class ServeServices {
   }
 
   async interruptChat(chatId: string): Promise<void> {
+    await this.resetStaleTransientChatState();
     const chat = await this.getChat(chatId);
     if (!chat.codexThreadId || !chat.activeTurnId) {
       throw new Error("Chat does not have an active Codex turn");
@@ -872,6 +884,7 @@ export class ServeServices {
     requestId: string,
     input: ApprovalInput,
   ): Promise<void> {
+    await this.resetStaleTransientChatState();
     const chat = await this.getChat(chatId);
     const pendingApproval = this.approvalRequests.get(requestId);
     if (!pendingApproval) {
@@ -1038,6 +1051,7 @@ export class ServeServices {
     this.approvalRequests.clear();
     this.pendingTurnEvents.clear();
     this.pendingChatTurns.clear();
+    this.activeTurnChatIds.clear();
 
     const affectedChatIds: string[] = [];
     await this.store.update((state) => ({
@@ -1285,6 +1299,7 @@ export class ServeServices {
     params: unknown,
   ): Promise<boolean> {
     if (method === "turn/started") {
+      this.activeTurnChatIds.add(chatId);
       await this.updateChatStatus(
         chatId,
         "running",
@@ -1296,6 +1311,7 @@ export class ServeServices {
       const turn = getParamObject(params)?.turn as
         | { status?: string }
         | undefined;
+      this.activeTurnChatIds.delete(chatId);
       await this.updateChatStatus(
         chatId,
         turn?.status === "failed" ? "failed" : "idle",
@@ -1318,6 +1334,54 @@ export class ServeServices {
       await this.updateChatStatus(chatId, "running", undefined);
     }
     return true;
+  }
+
+  private async resetStaleTransientChatState(): Promise<void> {
+    const state = await this.store.load();
+    if (!state.chats.some((chat) => this.isStaleTransientChat(chat))) {
+      return;
+    }
+
+    const timestamp = createTimestamp();
+    await this.store.update((nextState) => ({
+      ...nextState,
+      chats: nextState.chats.map((chat) =>
+        this.isStaleTransientChat(chat)
+          ? {
+              ...chat,
+              status: "idle",
+              activeTurnId: null,
+              updatedAt: timestamp,
+            }
+          : chat,
+      ),
+    }));
+  }
+
+  private isStaleTransientChat(chat: ChatRecord): boolean {
+    return Boolean(
+      (chat.status === "running" ||
+        chat.status === "waitingForApproval" ||
+        chat.activeTurnId) &&
+      !this.isChatActiveInCurrentProcess(chat),
+    );
+  }
+
+  private isChatActiveInCurrentProcess(chat: ChatRecord): boolean {
+    return Boolean(
+      this.pendingChatTurns.has(chat.id) ||
+      this.activeTurnChatIds.has(chat.id) ||
+      this.hasApprovalRequestForChat(chat.id),
+    );
+  }
+
+  private hasApprovalRequestForChat(chatId: string): boolean {
+    for (const approvalRequest of this.approvalRequests.values()) {
+      if (approvalRequest.chatId === chatId) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private deleteApprovalRequestByServerId(


### PR DESCRIPTION
## Summary

- Track active Codex turns owned by the current Serve process instead of trusting persisted `running` state alone.
- Reset stale transient chat state before Serve APIs read or mutate chats, so completed or orphaned sessions no longer block worktree deletion.
- Add service tests covering stale state cleanup and deletion after a stale running turn.

## Root Cause

Serve persisted `status: "running"` and `activeTurnId`, but if the Serve process exited or restarted after the chat had already ended, that transient state could remain in `state.json`. Worktree deletion treated the stale persisted state as an active chat and refused deletion.

## Validation

- `pnpm --filter app-private test -- services.test.ts`
- `pnpm ready`
- Manually started the dev server and confirmed the app loaded at `http://localhost:3001/`.