### PR TITLE
[codex] persist web workspace state in url

### DIFF
--- a/packages/web/src/routes/home-url-state.test.ts
+++ b/packages/web/src/routes/home-url-state.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+  findValidatedSelectedChat,
+  getSelectableReasoningEfforts,
+  isShareableFileSearchQuery,
+} from "./home-url-state";
+
+describe("isShareableFileSearchQuery", () => {
+  it("allows simple file search text", () => {
+    expect(isShareableFileSearchQuery("button component")).toBe(true);
+  });
+
+  it("rejects path-like and encoded path-like queries", () => {
+    expect(isShareableFileSearchQuery("/Users/alice/project")).toBe(false);
+    expect(isShareableFileSearchQuery("C:\\Users\\alice")).toBe(false);
+    expect(isShareableFileSearchQuery("src%252Froutes")).toBe(false);
+    expect(isShareableFileSearchQuery("%u002FUsers%u002Falice")).toBe(false);
+  });
+});
+
+describe("findValidatedSelectedChat", () => {
+  const chats = [
+    { id: "chat-1", projectId: "project-1" },
+    { id: "chat-2", projectId: "project-2" },
+  ];
+
+  it("accepts a selected chat from the requested project", () => {
+    expect(findValidatedSelectedChat(chats, "chat-1", "project-1")).toBe(
+      chats[0],
+    );
+  });
+
+  it("rejects a selected chat from a different requested project", () => {
+    expect(findValidatedSelectedChat(chats, "chat-1", "project-2")).toBeNull();
+  });
+
+  it("accepts an existing chat when the URL has no project parameter", () => {
+    expect(findValidatedSelectedChat(chats, "chat-1", null)).toBe(chats[0]);
+  });
+});
+
+describe("getSelectableReasoningEfforts", () => {
+  it("uses fallback efforts before model metadata is available", () => {
+    expect(getSelectableReasoningEfforts(null)).toEqual([
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+    ]);
+  });
+
+  it("does not invent efforts for models with no advertised support", () => {
+    expect(
+      getSelectableReasoningEfforts({ supportedReasoningEfforts: [] }),
+    ).toEqual([]);
+  });
+});

--- a/packages/web/src/routes/home-url-state.ts
+++ b/packages/web/src/routes/home-url-state.ts
@@ -1,0 +1,72 @@
+export const fallbackReasoningEfforts = ["low", "medium", "high", "xhigh"];
+
+const percentEncodedPathMarkerPattern = /%(?:2f|3a|5c|7e)/i;
+const windowsDrivePathPrefixPattern = /^[A-Za-z]:/;
+
+interface ChatSelectionRecord {
+  id: string;
+  projectId: string;
+}
+
+interface ModelReasoningEffortRecord {
+  supportedReasoningEfforts: string[];
+}
+
+export function isShareableFileSearchQuery(value: string): boolean {
+  let query = value.trim();
+  if (!query) {
+    return false;
+  }
+
+  for (let index = 0; index < 8; index += 1) {
+    if (
+      percentEncodedPathMarkerPattern.test(query) ||
+      query.includes("/") ||
+      query.includes("\\") ||
+      query.startsWith("~") ||
+      windowsDrivePathPrefixPattern.test(query)
+    ) {
+      return false;
+    }
+
+    try {
+      const decodedQuery = decodeURIComponent(query);
+      if (decodedQuery === query) {
+        return true;
+      }
+      query = decodedQuery;
+    } catch {
+      return false;
+    }
+  }
+
+  return false;
+}
+
+export function findValidatedSelectedChat<TChat extends ChatSelectionRecord>(
+  chats: TChat[],
+  selectedChatId: string | null,
+  requestedProjectId: string | null,
+): TChat | null {
+  if (!selectedChatId) {
+    return null;
+  }
+
+  const selectedChat = chats.find((chat) => chat.id === selectedChatId) ?? null;
+  if (
+    selectedChat &&
+    (!requestedProjectId || selectedChat.projectId === requestedProjectId)
+  ) {
+    return selectedChat;
+  }
+
+  return null;
+}
+
+export function getSelectableReasoningEfforts(
+  selectedModel: ModelReasoningEffortRecord | null,
+): string[] {
+  return selectedModel
+    ? selectedModel.supportedReasoningEfforts
+    : fallbackReasoningEfforts;
+}

--- a/packages/web/src/routes/home.tsx
+++ b/packages/web/src/routes/home.tsx
@@ -29,6 +29,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { useSearchParams } from "react-router";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   answerApprovalMutation,
@@ -130,6 +131,14 @@ const chatEventNames = [
 
 const chatScrollStorageKeyPrefix = "phantom.chatScroll:v1:";
 const chatScrollBottomThreshold = 4;
+const searchParamKeys = {
+  chat: "chat",
+  effort: "effort",
+  expandedProject: "expandedProject",
+  fileQuery: "fileQuery",
+  model: "model",
+  project: "project",
+} as const;
 
 const statusMeta: Record<
   ChatStatus,
@@ -187,6 +196,10 @@ interface StoredChatScrollPosition {
   version: 1;
 }
 
+interface SearchParamUpdateOptions {
+  replace?: boolean;
+}
+
 function firstProjectWorktree(
   projectId: string | null,
   worktreesByProject: Record<string, ProjectWorktreeRecord[]>,
@@ -199,6 +212,69 @@ function firstProjectWorktree(
 
 function getWorktreeExpansionKey(projectId: string, worktreePath: string) {
   return `${projectId}:${worktreePath}`;
+}
+
+function readNullableSearchParam(
+  searchParams: URLSearchParams,
+  key: string,
+): string | null {
+  const value = searchParams.get(key)?.trim();
+  return value ? value : null;
+}
+
+function readSearchParamSet(
+  searchParams: URLSearchParams,
+  key: string,
+): Set<string> {
+  const values = searchParams
+    .getAll(key)
+    .flatMap((value) => value.split(","))
+    .map((value) => value.trim())
+    .filter(Boolean);
+  return new Set(values);
+}
+
+function writeNullableSearchParam(
+  searchParams: URLSearchParams,
+  key: string,
+  value: string | null,
+): void {
+  if (value) {
+    searchParams.set(key, value);
+  } else {
+    searchParams.delete(key);
+  }
+}
+
+function writeSearchParamSet(
+  searchParams: URLSearchParams,
+  key: string,
+  values: Set<string>,
+): void {
+  searchParams.delete(key);
+  const sortedValues = [...values].sort();
+  if (sortedValues.length > 0) {
+    searchParams.set(key, sortedValues.join(","));
+  }
+}
+
+function addExpandedProjectSearchParam(
+  searchParams: URLSearchParams,
+  projectId: string | null,
+): void {
+  if (!projectId) {
+    return;
+  }
+  const expandedProjectIds = readSearchParamSet(
+    searchParams,
+    searchParamKeys.expandedProject,
+  );
+  expandedProjectIds.add(projectId);
+  writeSearchParamSet(
+    searchParams,
+    searchParamKeys.expandedProject,
+    expandedProjectIds,
+  );
 }
 
 function formatLeadingEllipsisPath(path: string, maxLength = 44): string {
@@ -290,26 +366,38 @@ function isChatTimelineScrolledToBottom(timeline: HTMLElement): boolean {
 }
 
 export function HomeRoute() {
-  const [projects, setProjects] = useState<ProjectRecord[]>([]);
-  const [selectedProjectId, setSelectedProjectId] = useState<string | null>(
-    null,
+  const [searchParams, setSearchParams] = useSearchParams();
+  const requestedProjectId = readNullableSearchParam(
+    searchParams,
+    searchParamKeys.project,
   );
+  const selectedChatId = readNullableSearchParam(
+    searchParams,
+    searchParamKeys.chat,
+  );
+  const selectedModelId = readNullableSearchParam(
+    searchParams,
+    searchParamKeys.model,
+  );
+  const selectedEffort = readNullableSearchParam(
+    searchParams,
+    searchParamKeys.effort,
+  );
+  const fileSearchQuery = searchParams.get(searchParamKeys.fileQuery) ?? "";
+  const expandedProjectIds = useMemo(
+    () => readSearchParamSet(searchParams, searchParamKeys.expandedProject),
+    [searchParams],
+  );
+  const [projects, setProjects] = useState<ProjectRecord[]>([]);
   const [chatsByProject, setChatsByProject] = useState<
     Record<string, ChatRecord[]>
   >({});
   const [worktreesByProject, setWorktreesByProject] = useState<
     Record<string, ProjectWorktreeRecord[]>
   >({});
-  const [expandedProjectIds, setExpandedProjectIds] = useState<Set<string>>(
-    () => new Set(),
-  );
   const [expandedWorktreeKeys, setExpandedWorktreeKeys] = useState<Set<string>>(
     () => new Set(),
   );
-  const [selectedWorktreePath, setSelectedWorktreePath] = useState<
-    string | null
-  >(null);
-  const [selectedChatId, setSelectedChatId] = useState<string | null>(null);
   const [messages, setMessages] = useState<ChatMessageRecord[]>([]);
   const [messagesChatId, setMessagesChatId] = useState<string | null>(null);
   const [isAddProjectOpen, setIsAddProjectOpen] = useState(false);
@@ -322,13 +410,10 @@ export function HomeRoute() {
   const [deleteWorktreeForce, setDeleteWorktreeForce] = useState(false);
   const [composerText, setComposerText] = useState("");
   const [models, setModels] = useState<CodexModelRecord[]>([]);
-  const [selectedModelId, setSelectedModelId] = useState<string | null>(null);
-  const [selectedEffort, setSelectedEffort] = useState<string | null>(null);
   const [skills, setSkills] = useState<CodexSkillRecord[]>([]);
   const [selectedSkillPaths, setSelectedSkillPaths] = useState<Set<string>>(
     () => new Set(),
   );
-  const [fileSearchQuery, setFileSearchQuery] = useState("");
   const fileSearchRequestIdRef = useRef(0);
   const [fileSearchResults, setFileSearchResults] = useState<CodexFileRecord[]>(
     [],
@@ -417,10 +502,72 @@ export function HomeRoute() {
     }) => answerApprovalMutation(chatId, requestId, decision),
   });
 
-  const selectedProject = useMemo(
-    () => projects.find((project) => project.id === selectedProjectId) ?? null,
-    [projects, selectedProjectId],
-  );
+  function updateSearchParams(
+    updater: (nextSearchParams: URLSearchParams) => void,
+    options: SearchParamUpdateOptions = {},
+  ) {
+    setSearchParams(
+      (currentSearchParams) => {
+        const nextSearchParams = new URLSearchParams(currentSearchParams);
+        updater(nextSearchParams);
+        return nextSearchParams;
+      },
+      { replace: options.replace ?? false },
+    );
+  }
+
+  function updateWorkspaceSearchParams(
+    selection: {
+      chatId?: string | null;
+      clearFileQuery?: boolean;
+      projectId?: string | null;
+    },
+    options: SearchParamUpdateOptions = {},
+  ) {
+    updateSearchParams((nextSearchParams) => {
+      if ("projectId" in selection) {
+        writeNullableSearchParam(
+          nextSearchParams,
+          searchParamKeys.project,
+          selection.projectId ?? null,
+        );
+        addExpandedProjectSearchParam(
+          nextSearchParams,
+          selection.projectId ?? null,
+        );
+      }
+      if ("chatId" in selection) {
+        writeNullableSearchParam(
+          nextSearchParams,
+          searchParamKeys.chat,
+          selection.chatId ?? null,
+        );
+      }
+      if (selection.clearFileQuery) {
+        nextSearchParams.delete(searchParamKeys.fileQuery);
+      }
+    }, options);
+  }
+
+  function setSearchParamValue(
+    key: string,
+    value: string | null,
+    options: SearchParamUpdateOptions = {},
+  ) {
+    updateSearchParams((nextSearchParams) => {
+      writeNullableSearchParam(nextSearchParams, key, value);
+    }, options);
+  }
+
+  function setFileSearchQuery(value: string) {
+    setSearchParamValue(
+      searchParamKeys.fileQuery,
+      value.trim() ? value : null,
+      {
+        replace: true,
+      },
+    );
+  }
 
   const selectedChat = useMemo(
     () =>
@@ -428,6 +575,11 @@ export function HomeRoute() {
         .flat()
         .find((chat) => chat.id === selectedChatId) ?? null,
     [chatsByProject, selectedChatId],
+  );
+  const selectedProjectId = selectedChat?.projectId ?? requestedProjectId;
+  const selectedProject = useMemo(
+    () => projects.find((project) => project.id === selectedProjectId) ?? null,
+    [projects, selectedProjectId],
   );
   const isChatRunning = Boolean(selectedChat?.activeTurnId);
 
@@ -533,15 +685,19 @@ export function HomeRoute() {
   }, [deleteWorktreeTarget, worktreesByProject]);
 
   const selectedWorktree = useMemo(() => {
-    if (!selectedProjectId || !selectedWorktreePath) {
+    if (!selectedProjectId) {
       return null;
     }
-    return (
-      (worktreesByProject[selectedProjectId] ?? []).find(
-        (worktree) => worktree.path === selectedWorktreePath,
-      ) ?? null
-    );
-  }, [selectedProjectId, selectedWorktreePath, worktreesByProject]);
+    const projectWorktrees = worktreesByProject[selectedProjectId] ?? [];
+    if (selectedChat) {
+      return (
+        projectWorktrees.find(
+          (worktree) => worktree.path === selectedChat.worktreePath,
+        ) ?? null
+      );
+    }
+    return projectWorktrees[0] ?? null;
+  }, [selectedChat, selectedProjectId, worktreesByProject]);
 
   const chatsByWorktreeByProject = useMemo(() => {
     const nextChatsByWorktreeByProject: Record<
@@ -602,14 +758,8 @@ export function HomeRoute() {
   useEffect(() => {
     selectedProjectIdRef.current = selectedProjectId;
     if (!selectedProjectId) {
-      setSelectedChatId(null);
       return;
     }
-    setExpandedProjectIds((current) => {
-      const next = new Set(current);
-      next.add(selectedProjectId);
-      return next;
-    });
     void refreshChats(selectedProjectId, { sync: true });
   }, [selectedProjectId]);
 
@@ -634,7 +784,6 @@ export function HomeRoute() {
       setPendingApproval(null);
       setSelectedFiles([]);
       setSelectedSkillPaths(new Set());
-      setFileSearchQuery("");
       setFileSearchResults([]);
       setSkills([]);
       setIsMessagesLoading(false);
@@ -645,7 +794,6 @@ export function HomeRoute() {
 
     setSelectedFiles([]);
     setSelectedSkillPaths(new Set());
-    setFileSearchQuery("");
     setFileSearchResults([]);
     setSkills([]);
     setMessages([]);
@@ -742,7 +890,20 @@ export function HomeRoute() {
   }, []);
 
   useEffect(() => {
+    if (
+      selectedModelId &&
+      models.length > 0 &&
+      !models.some((model) => model.id === selectedModelId)
+    ) {
+      setSearchParamValue(searchParamKeys.model, null, { replace: true });
+    }
+  }, [models, selectedModelId]);
+
+  useEffect(() => {
     if (!selectedEffort || selectedEffort === "auto") {
+      if (selectedEffort === "auto") {
+        setSearchParamValue(searchParamKeys.effort, null, { replace: true });
+      }
       return;
     }
     const supportedEfforts = selectedModel?.supportedReasoningEfforts ?? [];
@@ -750,7 +911,7 @@ export function HomeRoute() {
       supportedEfforts.length > 0 &&
       !supportedEfforts.includes(selectedEffort)
     ) {
-      setSelectedEffort(null);
+      setSearchParamValue(searchParamKeys.effort, null, { replace: true });
     }
   }, [selectedEffort, selectedModel]);
 
@@ -809,7 +970,10 @@ export function HomeRoute() {
     ) {
       return;
     }
-    setSelectedChatId(selectedWorktreeChats[0]?.id ?? null);
+    updateWorkspaceSearchParams(
+      { chatId: selectedWorktreeChats[0]?.id ?? null },
+      { replace: true },
+    );
   }, [selectedChatId, selectedWorktreeChats]);
 
   function setProjectLoading(projectId: string, isLoading: boolean) {
@@ -852,41 +1016,27 @@ export function HomeRoute() {
       );
       setChatsByProject(nextChatsByProject);
       setWorktreesByProject(nextWorktreesByProject);
+      const requestedChat = selectedChatId
+        ? (Object.values(nextChatsByProject)
+            .flat()
+            .find((chat) => chat.id === selectedChatId) ?? null)
+        : null;
       const fallbackProjectId =
-        selectedProjectId ?? data.projects[0]?.id ?? null;
+        requestedChat?.projectId ??
+        (selectedProjectId &&
+        data.projects.some((project) => project.id === selectedProjectId)
+          ? selectedProjectId
+          : (data.projects[0]?.id ?? null));
       const fallbackWorktree = firstProjectWorktree(
         fallbackProjectId,
         nextWorktreesByProject,
       );
-      setSelectedProjectId((current) => {
-        const nextProjectId = current ?? data.projects[0]?.id ?? null;
-        if (nextProjectId) {
-          setExpandedProjectIds((expanded) => {
-            const next = new Set(expanded);
-            next.add(nextProjectId);
-            return next;
-          });
-        }
-        return nextProjectId;
-      });
-      setSelectedWorktreePath((current) => {
-        if (
-          fallbackProjectId &&
-          current &&
-          (nextWorktreesByProject[fallbackProjectId] ?? []).some(
-            (worktree) => worktree.path === current,
-          )
-        ) {
-          return current;
-        }
-        return fallbackWorktree?.path ?? null;
-      });
-      setSelectedChatId((current) =>
-        Object.values(nextChatsByProject)
-          .flat()
-          .some((chat) => chat.id === current)
-          ? current
-          : (fallbackWorktree?.chatId ?? null),
+      updateWorkspaceSearchParams(
+        {
+          projectId: fallbackProjectId,
+          chatId: requestedChat?.id ?? fallbackWorktree?.chatId ?? null,
+        },
+        { replace: true },
       );
       return true;
     } catch (err) {
@@ -902,16 +1052,6 @@ export function HomeRoute() {
     try {
       const data = await queryClient.fetchQuery(modelsQueryOptions());
       setModels(data.models);
-      setSelectedModelId((current) => {
-        if (current && data.models.some((model) => model.id === current)) {
-          return current;
-        }
-        return (
-          data.models.find((model) => model.isDefault)?.id ??
-          data.models[0]?.id ??
-          null
-        );
-      });
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
@@ -983,17 +1123,17 @@ export function HomeRoute() {
         projectId,
         nextWorktreesByProject,
       );
-      const nextProjectWorktrees = nextWorktreesByProject[projectId] ?? [];
-      setSelectedWorktreePath((current) =>
-        current &&
-        nextProjectWorktrees.some((worktree) => worktree.path === current)
-          ? current
-          : (fallbackWorktree?.path ?? null),
-      );
-      setSelectedChatId((current) =>
-        projectData.chats.some((chat) => chat.id === current)
-          ? current
-          : (fallbackWorktree?.chatId ?? null),
+      const nextChatId = projectData.chats.some(
+        (chat) => chat.id === selectedChatId,
+      )
+        ? selectedChatId
+        : (fallbackWorktree?.chatId ?? null);
+      updateWorkspaceSearchParams(
+        {
+          projectId,
+          chatId: nextChatId,
+        },
+        { replace: true },
       );
       return true;
     } catch (err) {
@@ -1106,7 +1246,10 @@ export function HomeRoute() {
       if (!didRefresh) {
         return;
       }
-      setSelectedProjectId(data.project.id);
+      updateWorkspaceSearchParams({
+        projectId: data.project.id,
+        chatId: null,
+      });
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
@@ -1128,8 +1271,6 @@ export function HomeRoute() {
       void queryClient.invalidateQueries({
         queryKey: queryKeys.projectData(projectId, true),
       });
-      setSelectedProjectId(projectId);
-      setExpandedProjectIds((current) => new Set(current).add(projectId));
       setExpandedWorktreeKeys((current) =>
         new Set(current).add(
           getWorktreeExpansionKey(projectId, data.chat.worktreePath),
@@ -1139,8 +1280,10 @@ export function HomeRoute() {
       if (!didRefresh) {
         return;
       }
-      setSelectedWorktreePath(data.chat.worktreePath);
-      setSelectedChatId(data.chat.id);
+      updateWorkspaceSearchParams({
+        projectId,
+        chatId: data.chat.id,
+      });
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
@@ -1395,14 +1538,21 @@ export function HomeRoute() {
   }
 
   function toggleProject(projectId: string) {
-    setExpandedProjectIds((current) => {
-      const next = new Set(current);
+    updateSearchParams((nextSearchParams) => {
+      const next = readSearchParamSet(
+        nextSearchParams,
+        searchParamKeys.expandedProject,
+      );
       if (next.has(projectId)) {
         next.delete(projectId);
       } else {
         next.add(projectId);
       }
-      return next;
+      writeSearchParamSet(
+        nextSearchParams,
+        searchParamKeys.expandedProject,
+        next,
+      );
     });
   }
 
@@ -1420,10 +1570,11 @@ export function HomeRoute() {
   }
 
   function selectWorktree(projectId: string, worktree: ProjectWorktreeRecord) {
-    setSelectedProjectId(projectId);
-    setSelectedWorktreePath(worktree.path);
-    setSelectedChatId(worktree.chatId);
-    setExpandedProjectIds((current) => new Set(current).add(projectId));
+    updateWorkspaceSearchParams({
+      projectId,
+      chatId: worktree.chatId,
+      clearFileQuery: true,
+    });
   }
 
   function selectChat(
@@ -1431,10 +1582,11 @@ export function HomeRoute() {
     worktree: ProjectWorktreeRecord,
     chatId: string,
   ) {
-    setSelectedProjectId(projectId);
-    setSelectedWorktreePath(worktree.path);
-    setSelectedChatId(chatId);
-    setExpandedProjectIds((current) => new Set(current).add(projectId));
+    updateWorkspaceSearchParams({
+      projectId,
+      chatId,
+      clearFileQuery: true,
+    });
     setExpandedWorktreeKeys((current) =>
       new Set(current).add(getWorktreeExpansionKey(projectId, worktree.path)),
     );
@@ -1566,7 +1718,8 @@ export function HomeRoute() {
                             ) : (
                               projectWorktrees.map((worktree) => {
                                 const isSelectedWorktree =
-                                  worktree.path === selectedWorktreePath;
+                                  selectedProjectId === project.id &&
+                                  selectedWorktree?.path === worktree.path;
                                 const worktreeChats =
                                   chatsByWorktreeByProject[project.id]?.get(
                                     worktree.path,
@@ -2078,7 +2231,9 @@ export function HomeRoute() {
                 side="top"
                 triggerClassName="w-full justify-between"
                 value={selectedModel?.id ?? null}
-                onValueChange={setSelectedModelId}
+                onValueChange={(value) =>
+                  setSearchParamValue(searchParamKeys.model, value)
+                }
               />
               <Combobox
                 aria-label="Select reasoning effort"
@@ -2092,7 +2247,10 @@ export function HomeRoute() {
                 triggerClassName="w-full justify-between"
                 value={selectedEffort ?? "auto"}
                 onValueChange={(value) =>
-                  setSelectedEffort(value === "auto" ? null : value)
+                  setSearchParamValue(
+                    searchParamKeys.effort,
+                    value === "auto" ? null : value,
+                  )
                 }
               />
               <Combobox

--- a/packages/web/src/routes/home.tsx
+++ b/packages/web/src/routes/home.tsx
@@ -101,6 +101,11 @@ import {
 import { Textarea } from "../components/ui/textarea";
 import { shouldSubmitComposerOnEnter } from "../lib/composer-keyboard";
 import { cn } from "../lib/utils";
+import {
+  findValidatedSelectedChat,
+  getSelectableReasoningEfforts,
+  isShareableFileSearchQuery,
+} from "./home-url-state";
 import type {
   ChatMessageRecord,
   ChatRecord,
@@ -198,6 +203,11 @@ interface StoredChatScrollPosition {
 
 interface SearchParamUpdateOptions {
   replace?: boolean;
+}
+
+interface TransientFileSearchQuery {
+  query: string;
+  workspaceSelectionKey: string;
 }
 
 function firstProjectWorktree(
@@ -367,6 +377,8 @@ function isChatTimelineScrolledToBottom(timeline: HTMLElement): boolean {
 
 export function HomeRoute() {
   const [searchParams, setSearchParams] = useSearchParams();
+  const searchParamsRef = useRef(searchParams);
+  searchParamsRef.current = searchParams;
   const requestedProjectId = readNullableSearchParam(
     searchParams,
     searchParamKeys.project,
@@ -375,6 +387,9 @@ export function HomeRoute() {
     searchParams,
     searchParamKeys.chat,
   );
+  const workspaceSelectionKey = `${requestedProjectId ?? ""}\u0000${selectedChatId ?? ""}`;
+  const workspaceSelectionKeyRef = useRef(workspaceSelectionKey);
+  workspaceSelectionKeyRef.current = workspaceSelectionKey;
   const selectedModelId = readNullableSearchParam(
     searchParams,
     searchParamKeys.model,
@@ -383,7 +398,11 @@ export function HomeRoute() {
     searchParams,
     searchParamKeys.effort,
   );
-  const fileSearchQuery = searchParams.get(searchParamKeys.fileQuery) ?? "";
+  const rawUrlFileSearchQuery =
+    searchParams.get(searchParamKeys.fileQuery) ?? "";
+  const urlFileSearchQuery = isShareableFileSearchQuery(rawUrlFileSearchQuery)
+    ? rawUrlFileSearchQuery
+    : "";
   const expandedProjectIds = useMemo(
     () => readSearchParamSet(searchParams, searchParamKeys.expandedProject),
     [searchParams],
@@ -414,6 +433,14 @@ export function HomeRoute() {
   const [selectedSkillPaths, setSelectedSkillPaths] = useState<Set<string>>(
     () => new Set(),
   );
+  const [transientFileSearchQuery, setTransientFileSearchQuery] =
+    useState<TransientFileSearchQuery | null>(null);
+  const fileSearchQuery =
+    urlFileSearchQuery ||
+    (transientFileSearchQuery?.workspaceSelectionKey === workspaceSelectionKey
+      ? transientFileSearchQuery.query
+      : "");
+  const fileSearchQueryRef = useRef(fileSearchQuery);
   const fileSearchRequestIdRef = useRef(0);
   const [fileSearchResults, setFileSearchResults] = useState<CodexFileRecord[]>(
     [],
@@ -506,14 +533,10 @@ export function HomeRoute() {
     updater: (nextSearchParams: URLSearchParams) => void,
     options: SearchParamUpdateOptions = {},
   ) {
-    setSearchParams(
-      (currentSearchParams) => {
-        const nextSearchParams = new URLSearchParams(currentSearchParams);
-        updater(nextSearchParams);
-        return nextSearchParams;
-      },
-      { replace: options.replace ?? false },
-    );
+    const nextSearchParams = new URLSearchParams(searchParamsRef.current);
+    updater(nextSearchParams);
+    searchParamsRef.current = nextSearchParams;
+    setSearchParams(nextSearchParams, { replace: options.replace ?? false });
   }
 
   function updateWorkspaceSearchParams(
@@ -524,6 +547,9 @@ export function HomeRoute() {
     },
     options: SearchParamUpdateOptions = {},
   ) {
+    if (selection.clearFileQuery) {
+      setTransientFileSearchQuery(null);
+    }
     updateSearchParams((nextSearchParams) => {
       if ("projectId" in selection) {
         writeNullableSearchParam(
@@ -560,26 +586,52 @@ export function HomeRoute() {
   }
 
   function setFileSearchQuery(value: string) {
-    setSearchParamValue(
-      searchParamKeys.fileQuery,
-      value.trim() ? value : null,
-      {
-        replace: true,
-      },
-    );
+    const nextFileSearchQuery = value.trim() ? value : null;
+    if (!nextFileSearchQuery) {
+      setTransientFileSearchQuery(null);
+      setSearchParamValue(searchParamKeys.fileQuery, null, { replace: true });
+      return;
+    }
+
+    if (!isShareableFileSearchQuery(nextFileSearchQuery)) {
+      setTransientFileSearchQuery({
+        query: value,
+        workspaceSelectionKey,
+      });
+      setSearchParamValue(searchParamKeys.fileQuery, null, { replace: true });
+      return;
+    }
+
+    setTransientFileSearchQuery(null);
+    setSearchParamValue(searchParamKeys.fileQuery, nextFileSearchQuery, {
+      replace: true,
+    });
   }
 
   const selectedChat = useMemo(
     () =>
-      Object.values(chatsByProject)
-        .flat()
-        .find((chat) => chat.id === selectedChatId) ?? null,
-    [chatsByProject, selectedChatId],
+      findValidatedSelectedChat(
+        Object.values(chatsByProject).flat(),
+        selectedChatId,
+        requestedProjectId,
+      ),
+    [chatsByProject, requestedProjectId, selectedChatId],
   );
+  const isSelectedChatValidated = !selectedChatId || Boolean(selectedChat);
+  const hasSelectedChat = Boolean(selectedChat);
+  const validatedSelectedChatId = selectedChat?.id ?? null;
   const selectedProjectId = selectedChat?.projectId ?? requestedProjectId;
+  selectedChatIdRef.current = selectedChatId;
+  selectedProjectIdRef.current = selectedProjectId;
+  fileSearchQueryRef.current = fileSearchQuery;
   const selectedProject = useMemo(
     () => projects.find((project) => project.id === selectedProjectId) ?? null,
     [projects, selectedProjectId],
+  );
+  const hasLoadedSelectedProjectData = Boolean(
+    selectedProjectId &&
+    chatsByProject[selectedProjectId] !== undefined &&
+    worktreesByProject[selectedProjectId] !== undefined,
   );
   const isChatRunning = Boolean(selectedChat?.activeTurnId);
 
@@ -591,6 +643,10 @@ export function HomeRoute() {
       null,
     [models, selectedModelId],
   );
+  const selectedModelSupportedEfforts = useMemo(
+    () => getSelectableReasoningEfforts(selectedModel),
+    [selectedModel],
+  );
 
   const selectedSkills = useMemo(
     () => skills.filter((skill) => selectedSkillPaths.has(skill.path)),
@@ -599,8 +655,7 @@ export function HomeRoute() {
   const hasSelectedContext =
     selectedFiles.length > 0 || selectedSkills.length > 0;
   const canSendMessage =
-    Boolean(selectedChatId) &&
-    Boolean(composerText.trim() || hasSelectedContext);
+    hasSelectedChat && Boolean(composerText.trim() || hasSelectedContext);
 
   const modelOptions = useMemo<ComboboxOption[]>(
     () =>
@@ -614,9 +669,6 @@ export function HomeRoute() {
   );
 
   const effortOptions = useMemo<ComboboxOption[]>(() => {
-    const supportedEfforts = selectedModel?.supportedReasoningEfforts.length
-      ? selectedModel.supportedReasoningEfforts
-      : ["low", "medium", "high", "xhigh"];
     return [
       {
         value: "auto",
@@ -625,12 +677,12 @@ export function HomeRoute() {
           ? `Default: ${selectedModel.defaultReasoningEffort}`
           : "Use model default",
       },
-      ...supportedEfforts.map((effort) => ({
+      ...selectedModelSupportedEfforts.map((effort) => ({
         value: effort,
         label: formatReasoningEffort(effort),
       })),
     ];
-  }, [selectedModel]);
+  }, [selectedModel, selectedModelSupportedEfforts]);
 
   const skillOptions = useMemo<ComboboxOption[]>(
     () =>
@@ -756,15 +808,25 @@ export function HomeRoute() {
   }, []);
 
   useEffect(() => {
-    selectedProjectIdRef.current = selectedProjectId;
+    if (
+      rawUrlFileSearchQuery &&
+      !isShareableFileSearchQuery(rawUrlFileSearchQuery)
+    ) {
+      setSearchParamValue(searchParamKeys.fileQuery, null, { replace: true });
+    }
+  }, [rawUrlFileSearchQuery]);
+
+  useEffect(() => {
     if (!selectedProjectId) {
       return;
     }
-    void refreshChats(selectedProjectId, { sync: true });
-  }, [selectedProjectId]);
+    void refreshChats(selectedProjectId, {
+      sync: true,
+      updateSelection: isSelectedChatValidated,
+    });
+  }, [isSelectedChatValidated, selectedProjectId]);
 
   useEffect(() => {
-    selectedChatIdRef.current = selectedChatId;
     selectedChatVersionRef.current += 1;
     isChatTimelinePinnedToBottomRef.current = true;
     scrollRestoredChatIdRef.current = null;
@@ -777,6 +839,20 @@ export function HomeRoute() {
         selectedChatId && pendingSendChatIdsRef.current.has(selectedChatId),
       ),
     );
+
+    if (!isSelectedChatValidated) {
+      setMessages([]);
+      setMessagesChatId(null);
+      setPendingApproval(null);
+      setSelectedFiles([]);
+      setSelectedSkillPaths(new Set());
+      setFileSearchResults([]);
+      setSkills([]);
+      setIsMessagesLoading(false);
+      setIsChatContextLoading(false);
+      setIsFileSearchLoading(false);
+      return;
+    }
 
     if (!selectedChatId) {
       setMessages([]);
@@ -844,7 +920,7 @@ export function HomeRoute() {
       }
       source.close();
     };
-  }, [selectedChatId, selectedProjectId]);
+  }, [isSelectedChatValidated, selectedChatId, selectedProjectId]);
 
   useLayoutEffect(() => {
     if (!selectedChatId || messagesChatId !== selectedChatId) {
@@ -906,20 +982,24 @@ export function HomeRoute() {
       }
       return;
     }
-    const supportedEfforts = selectedModel?.supportedReasoningEfforts ?? [];
-    if (
-      supportedEfforts.length > 0 &&
-      !supportedEfforts.includes(selectedEffort)
-    ) {
+    if (models.length === 0 || !selectedModel) {
+      return;
+    }
+    if (!selectedModelSupportedEfforts.includes(selectedEffort)) {
       setSearchParamValue(searchParamKeys.effort, null, { replace: true });
     }
-  }, [selectedEffort, selectedModel]);
+  }, [
+    models.length,
+    selectedEffort,
+    selectedModel,
+    selectedModelSupportedEfforts,
+  ]);
 
   useEffect(() => {
     const requestId = fileSearchRequestIdRef.current + 1;
     fileSearchRequestIdRef.current = requestId;
 
-    if (!selectedChatId || !fileSearchQuery.trim()) {
+    if (!validatedSelectedChatId || !fileSearchQuery.trim()) {
       setFileSearchResults([]);
       setIsFileSearchLoading(false);
       return;
@@ -931,7 +1011,11 @@ export function HomeRoute() {
     const timeout = setTimeout(() => {
       void queryClient
         .fetchQuery(
-          fileSearchQueryOptions(selectedChatId, query, controller.signal),
+          fileSearchQueryOptions(
+            validatedSelectedChatId,
+            query,
+            controller.signal,
+          ),
         )
         .then((data) => {
           if (
@@ -961,20 +1045,57 @@ export function HomeRoute() {
       clearTimeout(timeout);
       controller.abort();
     };
-  }, [fileSearchQuery, selectedChatId]);
+  }, [fileSearchQuery, validatedSelectedChatId]);
 
   useEffect(() => {
     if (
+      !isSelectedChatValidated ||
       selectedWorktreeChats.length === 0 ||
       selectedWorktreeChats.some((chat) => chat.id === selectedChatId)
     ) {
       return;
     }
     updateWorkspaceSearchParams(
-      { chatId: selectedWorktreeChats[0]?.id ?? null },
+      {
+        chatId: selectedWorktreeChats[0]?.id ?? null,
+        clearFileQuery: Boolean(fileSearchQuery.trim()),
+      },
       { replace: true },
     );
-  }, [selectedChatId, selectedWorktreeChats]);
+  }, [
+    fileSearchQuery,
+    isSelectedChatValidated,
+    selectedChatId,
+    selectedWorktreeChats,
+  ]);
+
+  useEffect(() => {
+    if (
+      !selectedChatId ||
+      isSelectedChatValidated ||
+      !selectedProjectId ||
+      !hasLoadedSelectedProjectData
+    ) {
+      return;
+    }
+    const fallbackChatId =
+      firstProjectWorktree(selectedProjectId, worktreesByProject)?.chatId ??
+      null;
+    updateWorkspaceSearchParams(
+      {
+        chatId: fallbackChatId,
+        clearFileQuery: Boolean(fileSearchQuery.trim()),
+      },
+      { replace: true },
+    );
+  }, [
+    fileSearchQuery,
+    hasLoadedSelectedProjectData,
+    isSelectedChatValidated,
+    selectedChatId,
+    selectedProjectId,
+    worktreesByProject,
+  ]);
 
   function setProjectLoading(projectId: string, isLoading: boolean) {
     setLoadingProjectIds((current) => {
@@ -989,6 +1110,7 @@ export function HomeRoute() {
   }
 
   async function refreshProjects(): Promise<boolean> {
+    const requestWorkspaceSelectionKey = workspaceSelectionKeyRef.current;
     setIsProjectsLoading(true);
     try {
       const data = await queryClient.fetchQuery(projectsQueryOptions());
@@ -1016,25 +1138,35 @@ export function HomeRoute() {
       );
       setChatsByProject(nextChatsByProject);
       setWorktreesByProject(nextWorktreesByProject);
-      const requestedChat = selectedChatId
-        ? (Object.values(nextChatsByProject)
-            .flat()
-            .find((chat) => chat.id === selectedChatId) ?? null)
-        : null;
+      if (workspaceSelectionKeyRef.current !== requestWorkspaceSelectionKey) {
+        return true;
+      }
+      const currentSelectedChatId = selectedChatIdRef.current;
+      const currentSelectedProjectId = selectedProjectIdRef.current;
+      const currentFileSearchQuery = fileSearchQueryRef.current;
+      const requestedChat = findValidatedSelectedChat(
+        Object.values(nextChatsByProject).flat(),
+        currentSelectedChatId,
+        currentSelectedProjectId,
+      );
       const fallbackProjectId =
         requestedChat?.projectId ??
-        (selectedProjectId &&
-        data.projects.some((project) => project.id === selectedProjectId)
-          ? selectedProjectId
+        (currentSelectedProjectId &&
+        data.projects.some((project) => project.id === currentSelectedProjectId)
+          ? currentSelectedProjectId
           : (data.projects[0]?.id ?? null));
       const fallbackWorktree = firstProjectWorktree(
         fallbackProjectId,
         nextWorktreesByProject,
       );
+      const nextChatId = requestedChat?.id ?? fallbackWorktree?.chatId ?? null;
       updateWorkspaceSearchParams(
         {
           projectId: fallbackProjectId,
-          chatId: requestedChat?.id ?? fallbackWorktree?.chatId ?? null,
+          chatId: nextChatId,
+          clearFileQuery:
+            Boolean(currentFileSearchQuery.trim()) &&
+            currentSelectedChatId !== nextChatId,
         },
         { replace: true },
       );
@@ -1097,6 +1229,7 @@ export function HomeRoute() {
     projectId: string,
     options: { sync?: boolean; updateSelection?: boolean } = {},
   ): Promise<boolean> {
+    const requestWorkspaceSelectionKey = workspaceSelectionKeyRef.current;
     setProjectLoading(projectId, true);
     try {
       const projectData = await loadProjectData(projectId, options);
@@ -1113,6 +1246,12 @@ export function HomeRoute() {
       if ((options.updateSelection ?? options.sync === true) === false) {
         return true;
       }
+      if (selectedProjectIdRef.current !== projectId) {
+        return true;
+      }
+      if (workspaceSelectionKeyRef.current !== requestWorkspaceSelectionKey) {
+        return true;
+      }
       const nextWorktreesByProject = options.sync
         ? {
             ...worktreesByProject,
@@ -1123,15 +1262,20 @@ export function HomeRoute() {
         projectId,
         nextWorktreesByProject,
       );
+      const currentSelectedChatId = selectedChatIdRef.current;
+      const currentFileSearchQuery = fileSearchQueryRef.current;
       const nextChatId = projectData.chats.some(
-        (chat) => chat.id === selectedChatId,
+        (chat) => chat.id === currentSelectedChatId,
       )
-        ? selectedChatId
+        ? currentSelectedChatId
         : (fallbackWorktree?.chatId ?? null);
       updateWorkspaceSearchParams(
         {
           projectId,
           chatId: nextChatId,
+          clearFileQuery:
+            Boolean(currentFileSearchQuery.trim()) &&
+            currentSelectedChatId !== nextChatId,
         },
         { replace: true },
       );
@@ -1236,6 +1380,7 @@ export function HomeRoute() {
     }
 
     setError(null);
+    const requestWorkspaceSelectionKey = workspaceSelectionKeyRef.current;
     setIsBusy(true);
     try {
       const data = await addProjectRequest.mutateAsync(trimmedProjectPath);
@@ -1244,6 +1389,9 @@ export function HomeRoute() {
       setIsAddProjectOpen(false);
       const didRefresh = await refreshProjects();
       if (!didRefresh) {
+        return;
+      }
+      if (workspaceSelectionKeyRef.current !== requestWorkspaceSelectionKey) {
         return;
       }
       updateWorkspaceSearchParams({
@@ -1263,6 +1411,7 @@ export function HomeRoute() {
     }
 
     setError(null);
+    const requestWorkspaceSelectionKey = workspaceSelectionKeyRef.current;
     createChatInFlightRef.current = true;
     setCreatingProjectId(projectId);
     setIsBusy(true);
@@ -1276,13 +1425,20 @@ export function HomeRoute() {
           getWorktreeExpansionKey(projectId, data.chat.worktreePath),
         ),
       );
-      const didRefresh = await refreshChats(projectId, { sync: true });
+      const didRefresh = await refreshChats(projectId, {
+        sync: true,
+        updateSelection: false,
+      });
       if (!didRefresh) {
+        return;
+      }
+      if (workspaceSelectionKeyRef.current !== requestWorkspaceSelectionKey) {
         return;
       }
       updateWorkspaceSearchParams({
         projectId,
         chatId: data.chat.id,
+        clearFileQuery: true,
       });
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
@@ -1415,7 +1571,12 @@ export function HomeRoute() {
           });
     setComposerText("");
     const turnModel = selectedModel?.id ?? selectedModel?.model;
-    const turnEffort = selectedEffort === "auto" ? null : selectedEffort;
+    const turnEffort =
+      selectedModel &&
+      selectedEffort &&
+      selectedModelSupportedEfforts.includes(selectedEffort)
+        ? selectedEffort
+        : null;
     const files = selectedFiles.map((file) => ({
       name: file.relativePath,
       path: file.path,
@@ -2166,11 +2327,11 @@ export function HomeRoute() {
                 </Label>
                 <Textarea
                   className="min-h-12 border-0 bg-transparent px-2 py-2 shadow-none focus-visible:shadow-none"
-                  disabled={!selectedChatId}
+                  disabled={!hasSelectedChat}
                   enterKeyHint="enter"
                   id="composer"
                   placeholder={
-                    selectedChatId
+                    hasSelectedChat
                       ? "Ask Codex to work in this worktree"
                       : "Create or select a worktree to start"
                   }
@@ -2256,7 +2417,7 @@ export function HomeRoute() {
               <Combobox
                 aria-label="Attach file"
                 className="w-32 max-w-full"
-                disabled={!selectedChatId || isChatRunning}
+                disabled={!hasSelectedChat || isChatRunning}
                 emptyMessage={
                   isFileSearchLoading
                     ? "Searching files"
@@ -2282,7 +2443,7 @@ export function HomeRoute() {
                 align="end"
                 className="w-32 max-w-full"
                 disabled={
-                  !selectedChatId || isChatRunning || isChatContextLoading
+                  !hasSelectedChat || isChatRunning || isChatContextLoading
                 }
                 emptyMessage={
                   isChatContextLoading ? "Loading skills" : "No skills"


### PR DESCRIPTION
## Summary

- Move restorable web workspace selection state for project, chat, model, effort, file search, and expanded projects into URL search params.
- Derive the selected worktree from validated project/chat data instead of storing local worktree paths in the URL.
- Harden URL restoration against stale async selection writes, invalid project/chat pairs, unsafe fileQuery values, and unsupported reasoning effort params.
- Add unit coverage for URL-state validation helpers.

## Impact

Reloading or sharing the web app URL can now restore the active project/chat view and relevant composer controls without relying on local component state. Local worktree paths are not exposed as URL state, and path-like file searches stay transient.

## Validation

- `pnpm --filter @phantompane/web typecheck`
- `pnpm --filter @phantompane/web test`
- `pnpm ready`
- `pnpm --filter @phantompane/web build`