### PR TITLE
Speed up Phantom Serve history loading

### DIFF
--- a/packages/codex/src/bridge.test.ts
+++ b/packages/codex/src/bridge.test.ts
@@ -133,6 +133,50 @@ describe("CodexBridge", () => {
     });
   });
 
+  it("requests thread metadata and thread contents", async () => {
+    const { bridge, proc } = createBridge();
+    await initializeBridge(bridge, proc);
+
+    const threads = bridge.listThreads({
+      archived: false,
+      cwd: ["/repo", "/repo/.git/phantom/worktrees/feature"],
+      limit: 100,
+      sortDirection: "desc",
+      sortKey: "updated_at",
+      useStateDbOnly: true,
+    });
+
+    await vi.waitFor(() =>
+      expect(findWrite(proc, "thread/list")).toBeDefined(),
+    );
+    const listRequest = findWrite(proc, "thread/list");
+    expect(listRequest?.params).toEqual({
+      archived: false,
+      cursor: null,
+      cwd: ["/repo", "/repo/.git/phantom/worktrees/feature"],
+      limit: 100,
+      searchTerm: undefined,
+      sortDirection: "desc",
+      sortKey: "updated_at",
+      sourceKinds: undefined,
+      useStateDbOnly: true,
+    });
+    proc.send({ id: listRequest?.id, result: { threads: [] } });
+    await expect(threads).resolves.toEqual({ threads: [] });
+
+    const thread = bridge.readThread("thread_1", { includeTurns: true });
+    await vi.waitFor(() =>
+      expect(findWrite(proc, "thread/read")).toBeDefined(),
+    );
+    const readRequest = findWrite(proc, "thread/read");
+    expect(readRequest?.params).toEqual({
+      threadId: "thread_1",
+      includeTurns: true,
+    });
+    proc.send({ id: readRequest?.id, result: { thread: { id: "thread_1" } } });
+    await expect(thread).resolves.toEqual({ thread: { id: "thread_1" } });
+  });
+
   it("passes model, effort, file mentions, and skills to new turns", async () => {
     const { bridge, proc } = createBridge();
     await initializeBridge(bridge, proc);

--- a/packages/codex/src/bridge.ts
+++ b/packages/codex/src/bridge.ts
@@ -37,6 +37,22 @@ export interface CodexTurnOptions {
   skills?: CodexTurnContextItem[];
 }
 
+export interface CodexThreadListOptions {
+  archived?: boolean | null;
+  cursor?: string | null;
+  cwd?: string | string[];
+  limit?: number;
+  searchTerm?: string;
+  sortDirection?: "asc" | "desc";
+  sortKey?: "created_at" | "updated_at";
+  sourceKinds?: string[];
+  useStateDbOnly?: boolean;
+}
+
+export interface CodexThreadReadOptions {
+  includeTurns?: boolean;
+}
+
 interface PendingRequest {
   resolve: (value: unknown) => void;
   reject: (error: Error) => void;
@@ -158,6 +174,30 @@ export class CodexBridge {
       query,
       roots,
       cancellationToken: null,
+    });
+  }
+
+  async listThreads(options: CodexThreadListOptions = {}): Promise<unknown> {
+    return this.request("thread/list", {
+      archived: options.archived,
+      cursor: options.cursor ?? null,
+      cwd: options.cwd,
+      limit: options.limit,
+      searchTerm: options.searchTerm,
+      sortDirection: options.sortDirection,
+      sortKey: options.sortKey,
+      sourceKinds: options.sourceKinds,
+      useStateDbOnly: options.useStateDbOnly,
+    });
+  }
+
+  async readThread(
+    threadId: string,
+    options: CodexThreadReadOptions = {},
+  ): Promise<unknown> {
+    return this.request("thread/read", {
+      threadId,
+      includeTurns: options.includeTurns,
     });
   }
 

--- a/packages/server/src/rpc.ts
+++ b/packages/server/src/rpc.ts
@@ -45,10 +45,6 @@ const approvalSchema = z.object({
   decision: z.enum(["accept", "acceptForSession", "decline", "cancel"]),
 });
 
-const projectChatsQuerySchema = z.object({
-  sync: z.string().optional(),
-});
-
 const chatQuerySchema = z.object({
   context: z.string().optional(),
   fileQuery: z.string().optional(),
@@ -165,25 +161,26 @@ export const rpcRoutes = new Hono()
       return handleApiError(c, error);
     }
   })
-  .get(
-    "/projects/:projectId/chats",
-    query(projectChatsQuerySchema),
-    async (c) => {
-      try {
-        const services = getServeServices();
-        const projectId = c.req.param("projectId");
-        const requestQuery = c.req.valid("query");
-        const shouldSync = requestQuery.sync === "1";
-        const worktrees = await services.listProjectWorktrees(projectId, {
-          sync: shouldSync,
-        });
-        const chats = await services.listChats(projectId);
-        return c.json({ chats, worktrees }, 200);
-      } catch (error) {
-        return handleApiError(c, error);
-      }
-    },
-  )
+  .get("/projects/:projectId/worktrees", async (c) => {
+    try {
+      const worktrees = await getServeServices().listProjectWorktrees(
+        c.req.param("projectId"),
+      );
+      return c.json({ worktrees }, 200);
+    } catch (error) {
+      return handleApiError(c, error);
+    }
+  })
+  .get("/projects/:projectId/chats", async (c) => {
+    try {
+      const chats = await getServeServices().listChats(
+        c.req.param("projectId"),
+      );
+      return c.json({ chats }, 200);
+    } catch (error) {
+      return handleApiError(c, error);
+    }
+  })
   .post("/projects/:projectId/chats", jsonBody(createChatSchema), async (c) => {
     try {
       const body = c.req.valid("json");

--- a/packages/server/src/services.test.ts
+++ b/packages/server/src/services.test.ts
@@ -36,8 +36,10 @@ class FakeCodexBridge {
   readonly processExitHandlers: Array<(error: Error) => void> = [];
   readonly serverRequestHandlers: Array<(message: CodexMessage) => void> = [];
   readonly interruptTurn = vi.fn();
+  readonly listThreads = vi.fn();
   readonly listModels = vi.fn();
   readonly listSkills = vi.fn();
+  readonly readThread = vi.fn();
   readonly readAccount = vi.fn();
   readonly respondToServerRequest = vi.fn();
   readonly resumeThread = vi.fn();
@@ -81,7 +83,7 @@ class FakeCodexBridge {
 }
 
 afterEach(async () => {
-  vi.clearAllMocks();
+  vi.resetAllMocks();
   await Promise.all(
     temporaryDirectories
       .splice(0)
@@ -183,21 +185,8 @@ class ImportRaceStore extends ServeStateStore {
   }
 }
 
-async function writeCodexSession(
-  codexHome: string,
-  lines: Array<Record<string, unknown>>,
-  fileName = "rollout-2026-04-25T00-00-00-019dc000-0000-7000-8000-000000000001.jsonl",
-): Promise<void> {
-  const directory = join(codexHome, "archived_sessions");
-  await mkdir(directory, { recursive: true });
-  await writeFile(
-    join(directory, fileName),
-    `${lines.map((line) => JSON.stringify(line)).join("\n")}\n`,
-  );
-}
-
 describe("ServeServices", () => {
-  it("lists project worktrees with phantom list data and creates missing chat records", async () => {
+  it("lists project worktrees with phantom list data without creating chat records", async () => {
     const state = {
       ...createTestState(),
       projects: [createProject()],
@@ -238,6 +227,7 @@ describe("ServeServices", () => {
         pathToDisplay: worktree.pathToDisplay,
         isClean: worktree.isClean,
         isMainWorktree: worktree.isMainWorktree,
+        chatId: worktree.chatId,
         chatStatus: worktree.chatStatus,
       })),
       [
@@ -247,7 +237,8 @@ describe("ServeServices", () => {
           pathToDisplay: ".",
           isClean: true,
           isMainWorktree: true,
-          chatStatus: "idle",
+          chatId: null,
+          chatStatus: null,
         },
         {
           name: "feature/list",
@@ -255,20 +246,18 @@ describe("ServeServices", () => {
           pathToDisplay: ".git/phantom/worktrees/feature/list",
           isClean: false,
           isMainWorktree: false,
-          chatStatus: "idle",
+          chatId: null,
+          chatStatus: null,
         },
       ],
     );
     strictEqual(
-      worktrees.every((worktree) => worktree.chatId),
+      worktrees.every((worktree) => !worktree.chatId),
       true,
     );
 
     const savedState = await store.load();
-    deepStrictEqual(
-      savedState.chats.map((chat) => chat.worktreePath),
-      ["/repo", "/repo/.git/phantom/worktrees/feature/list"],
-    );
+    deepStrictEqual(savedState.chats, []);
   });
 
   it("does not persist state when worktree sync has no changes", async () => {
@@ -373,6 +362,7 @@ describe("ServeServices", () => {
       });
 
     const worktrees = await services.listProjectWorktrees("proj_1");
+    await services.listChats("proj_1");
 
     deepStrictEqual(
       worktrees.map((worktree) => worktree.path),
@@ -434,7 +424,7 @@ describe("ServeServices", () => {
         },
       });
 
-    await services.listProjectWorktrees("proj_1");
+    await services.listChats("proj_1");
 
     const savedState = await store.load();
     deepStrictEqual(
@@ -582,7 +572,7 @@ describe("ServeServices", () => {
         },
       });
 
-    await services.listProjectWorktrees("proj_1");
+    await services.listChats("proj_1");
 
     const savedState = await store.load();
     deepStrictEqual(
@@ -672,7 +662,7 @@ describe("ServeServices", () => {
         },
       });
 
-    await services.listProjectWorktrees("proj_1");
+    await services.listChats("proj_1");
 
     const savedState = await store.load();
     deepStrictEqual(
@@ -758,7 +748,7 @@ describe("ServeServices", () => {
         },
       });
 
-    await services.listProjectWorktrees("proj_1");
+    await services.listChats("proj_1");
 
     const savedState = await store.load();
     deepStrictEqual(
@@ -862,9 +852,7 @@ describe("ServeServices", () => {
     };
     const { services } = await createHarness(state);
 
-    const worktrees = await services.listProjectWorktrees("proj_1", {
-      sync: false,
-    });
+    const worktrees = await services.listProjectWorktrees("proj_1");
 
     deepStrictEqual(worktrees, [
       {
@@ -880,7 +868,7 @@ describe("ServeServices", () => {
         chatTitle: "Persisted feature",
       },
     ]);
-    strictEqual(coreMocks.listWorktrees.mock.calls.length, 0);
+    strictEqual(coreMocks.listWorktrees.mock.calls.length, 1);
   });
 
   it("resets stale transient chat state when listing chats", async () => {
@@ -900,7 +888,9 @@ describe("ServeServices", () => {
     strictEqual(savedState.chats[0]?.activeTurnId, null);
   });
 
-  it("imports existing Codex chat history for project worktrees", async () => {
+  it("syncs Codex thread metadata for project chats and reads messages lazily", async () => {
+    const threadId = "019dc000-0000-7000-8000-000000000001";
+    const worktreePath = "/repo/.git/phantom/worktrees/feature/list";
     const state = {
       ...createTestState(),
       projects: [createProject()],
@@ -908,57 +898,17 @@ describe("ServeServices", () => {
     const store = new ServeStateStore(await createTemporaryDirectory());
     await store.save(state);
     const codex = new FakeCodexBridge();
-    const codexHome = await createTemporaryDirectory();
-    await writeCodexSession(codexHome, [
-      {
-        timestamp: "2026-04-25T00:00:00.000Z",
-        type: "session_meta",
-        payload: {
-          id: "019dc000-0000-7000-8000-000000000001",
-          timestamp: "2026-04-25T00:00:00.000Z",
-          cwd: "/repo/.git/phantom/worktrees/feature/list",
-          source: "vscode",
-        },
-      },
-      {
-        timestamp: "2026-04-25T00:01:00.000Z",
-        type: "event_msg",
-        payload: {
-          type: "thread_name_updated",
-          thread_name: "Existing work",
-        },
-      },
-      {
-        timestamp: "2026-04-25T00:02:00.000Z",
-        type: "response_item",
-        payload: {
-          type: "message",
-          role: "user",
-          content: [{ type: "input_text", text: "Please update the page" }],
-        },
-      },
-      {
-        timestamp: "2026-04-25T00:03:00.000Z",
-        type: "response_item",
-        payload: {
-          type: "message",
-          role: "assistant",
-          content: [{ type: "output_text", text: "I updated the page." }],
-        },
-      },
-    ]);
     const services = new ServeServices({
       codex: codex as unknown as CodexBridge,
-      codexHome,
       store,
     });
-    coreMocks.listWorktrees.mockResolvedValueOnce({
+    coreMocks.listWorktrees.mockResolvedValue({
       ok: true,
       value: {
         worktrees: [
           {
             name: "feature/list",
-            path: "/repo/.git/phantom/worktrees/feature/list",
+            path: worktreePath,
             pathToDisplay: ".git/phantom/worktrees/feature/list",
             branch: "feature/list",
             isClean: true,
@@ -966,27 +916,183 @@ describe("ServeServices", () => {
         ],
       },
     });
+    codex.listThreads.mockResolvedValueOnce({
+      threads: [
+        {
+          id: threadId,
+          cwd: worktreePath,
+          title: "Existing work",
+          createdAt: "2026-04-25T00:00:00.000Z",
+          updatedAt: "2026-04-25T00:03:00.000Z",
+        },
+      ],
+    });
+    codex.readThread.mockResolvedValueOnce({
+      thread: {
+        turns: [
+          {
+            id: "turn_1",
+            createdAt: "2026-04-25T00:02:00.000Z",
+            items: [
+              { type: "userMessage", text: "Please update the page" },
+              { type: "agentMessage", text: "I updated the page." },
+            ],
+          },
+        ],
+      },
+    });
 
+    const chats = await services.listChats("proj_1");
     const worktrees = await services.listProjectWorktrees("proj_1");
+    const messages = await services.getMessages(chats[0]!.id);
 
+    deepStrictEqual(codex.listThreads.mock.calls[0]?.[0], {
+      archived: false,
+      cursor: null,
+      cwd: [worktreePath],
+      limit: 100,
+      sourceKinds: ["cli", "vscode", "appServer"],
+      sortDirection: "desc",
+      sortKey: "updated_at",
+      useStateDbOnly: true,
+    });
     strictEqual(worktrees[0]?.chatTitle, "Existing work");
     strictEqual(worktrees[0]?.chatStatus, "idle");
-    const savedState = await store.load();
-    strictEqual(savedState.chats.length, 1);
-    strictEqual(
-      savedState.chats[0]?.codexThreadId,
-      "019dc000-0000-7000-8000-000000000001",
-    );
+    strictEqual(chats[0]?.codexThreadId, threadId);
     deepStrictEqual(
-      savedState.messages.map((message) => [message.role, message.text]),
+      messages.map((message) => [message.role, message.text]),
       [
         ["user", "Please update the page"],
         ["assistant", "I updated the page."],
       ],
     );
+    const savedState = await store.load();
+    strictEqual(savedState.chats.length, 1);
+    deepStrictEqual(savedState.messages, []);
   });
 
-  it("preserves local chats that already match imported Codex threads", async () => {
+  it("keeps duplicate local messages that have not appeared in thread history yet", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat()],
+      messages: [
+        {
+          id: "msg_imported_duplicate",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "repeat",
+          createdAt: "2026-04-25T00:00:00.000Z",
+        },
+        {
+          id: "msg_pending_duplicate",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "repeat",
+          createdAt: "2026-04-25T00:01:00.000Z",
+        },
+      ],
+    };
+    const { codex, services } = await createHarness(state);
+    codex.readThread.mockResolvedValueOnce({
+      thread: {
+        turns: [
+          {
+            id: "turn_1",
+            createdAt: "2026-04-25T00:00:00.000Z",
+            items: [{ type: "userMessage", text: "repeat" }],
+          },
+        ],
+      },
+    });
+
+    const messages = await services.getMessages("chat_1");
+
+    deepStrictEqual(
+      messages.map((message) => [message.id, message.role, message.text]),
+      [
+        ["chat_1_codex_turn_1_0", "user", "repeat"],
+        ["msg_pending_duplicate", "user", "repeat"],
+      ],
+    );
+  });
+
+  it("keeps a repeated pending message when only an older Codex message matches", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat()],
+      messages: [
+        {
+          id: "msg_pending_retry",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "retry",
+          createdAt: "2026-04-25T00:01:00.000Z",
+        },
+      ],
+    };
+    const { codex, services } = await createHarness(state);
+    codex.readThread.mockResolvedValueOnce({
+      thread: {
+        turns: [
+          {
+            id: "turn_1",
+            createdAt: "2026-04-25T00:00:00.000Z",
+            items: [{ type: "userMessage", text: "retry" }],
+          },
+        ],
+      },
+    });
+
+    const messages = await services.getMessages("chat_1");
+
+    deepStrictEqual(
+      messages.map((message) => [message.id, message.role, message.text]),
+      [
+        ["chat_1_codex_turn_1_0", "user", "retry"],
+        ["msg_pending_retry", "user", "retry"],
+      ],
+    );
+  });
+
+  it("deduplicates a local message once a matching newer Codex message exists", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat()],
+      messages: [
+        {
+          id: "msg_materialized_retry",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "retry",
+          createdAt: "2026-04-25T00:01:00.000Z",
+        },
+      ],
+    };
+    const { codex, services } = await createHarness(state);
+    codex.readThread.mockResolvedValueOnce({
+      thread: {
+        turns: [
+          {
+            id: "turn_1",
+            createdAt: "2026-04-25T00:02:00.000Z",
+            items: [{ type: "userMessage", text: "retry" }],
+          },
+        ],
+      },
+    });
+
+    const messages = await services.getMessages("chat_1");
+
+    deepStrictEqual(
+      messages.map((message) => [message.id, message.role, message.text]),
+      [["chat_1_codex_turn_1_0", "user", "retry"]],
+    );
+  });
+
+  it("preserves local chats that already match Codex threads", async () => {
     const threadId = "019dc000-0000-7000-8000-000000000001";
     const worktreePath = "/repo/.git/phantom/worktrees/feature/list";
     const state = {
@@ -1017,42 +1123,11 @@ describe("ServeServices", () => {
     const store = new ServeStateStore(await createTemporaryDirectory());
     await store.save(state);
     const codex = new FakeCodexBridge();
-    const codexHome = await createTemporaryDirectory();
-    await writeCodexSession(codexHome, [
-      {
-        timestamp: "2026-04-25T00:00:00.000Z",
-        type: "session_meta",
-        payload: {
-          id: threadId,
-          timestamp: "2026-04-25T00:00:00.000Z",
-          cwd: worktreePath,
-          source: "vscode",
-        },
-      },
-      {
-        timestamp: "2026-04-25T00:01:00.000Z",
-        type: "event_msg",
-        payload: {
-          type: "thread_name_updated",
-          thread_name: "hi",
-        },
-      },
-      {
-        timestamp: "2026-04-25T00:02:00.000Z",
-        type: "response_item",
-        payload: {
-          type: "message",
-          role: "user",
-          content: [{ type: "input_text", text: "hi" }],
-        },
-      },
-    ]);
     const services = new ServeServices({
       codex: codex as unknown as CodexBridge,
-      codexHome,
       store,
     });
-    coreMocks.listWorktrees.mockResolvedValueOnce({
+    coreMocks.listWorktrees.mockResolvedValue({
       ok: true,
       value: {
         worktrees: [
@@ -1066,7 +1141,19 @@ describe("ServeServices", () => {
         ],
       },
     });
+    codex.listThreads.mockResolvedValueOnce({
+      threads: [
+        {
+          id: threadId,
+          cwd: worktreePath,
+          title: "feature/list",
+          createdAt: "2026-04-25T00:00:00.000Z",
+          updatedAt: "2026-04-25T00:02:00.000Z",
+        },
+      ],
+    });
 
+    await services.listChats("proj_1");
     const worktrees = await services.listProjectWorktrees("proj_1");
 
     strictEqual(worktrees[0]?.chatId, "chat_local");
@@ -1081,7 +1168,7 @@ describe("ServeServices", () => {
     );
   });
 
-  it("imports distinct Codex threads when a failed local chat exists for the same worktree", async () => {
+  it("adds distinct Codex threads when a failed local chat exists for the same worktree", async () => {
     const failedThreadId = "019dc000-0000-7000-8000-000000000001";
     const importedThreadId = "019dc000-0000-7000-8000-000000000002";
     const worktreePath = "/repo/.git/phantom/worktrees/feature/list";
@@ -1105,37 +1192,11 @@ describe("ServeServices", () => {
     const store = new ServeStateStore(await createTemporaryDirectory());
     await store.save(state);
     const codex = new FakeCodexBridge();
-    const codexHome = await createTemporaryDirectory();
-    await writeCodexSession(
-      codexHome,
-      [
-        {
-          timestamp: "2026-04-25T00:00:00.000Z",
-          type: "session_meta",
-          payload: {
-            id: importedThreadId,
-            timestamp: "2026-04-25T00:00:00.000Z",
-            cwd: worktreePath,
-            source: "vscode",
-          },
-        },
-        {
-          timestamp: "2026-04-25T00:01:00.000Z",
-          type: "event_msg",
-          payload: {
-            type: "thread_name_updated",
-            thread_name: "imported",
-          },
-        },
-      ],
-      "rollout-2026-04-25T00-00-00-019dc000-0000-7000-8000-000000000002.jsonl",
-    );
     const services = new ServeServices({
       codex: codex as unknown as CodexBridge,
-      codexHome,
       store,
     });
-    coreMocks.listWorktrees.mockResolvedValueOnce({
+    coreMocks.listWorktrees.mockResolvedValue({
       ok: true,
       value: {
         worktrees: [
@@ -1149,8 +1210,19 @@ describe("ServeServices", () => {
         ],
       },
     });
+    codex.listThreads.mockResolvedValueOnce({
+      threads: [
+        {
+          id: importedThreadId,
+          cwd: worktreePath,
+          title: "imported",
+          createdAt: "2026-04-25T00:00:00.000Z",
+          updatedAt: "2026-04-25T00:01:00.000Z",
+        },
+      ],
+    });
 
-    await services.listProjectWorktrees("proj_1");
+    await services.listChats("proj_1");
 
     const savedState = await store.load();
     deepStrictEqual(
@@ -1162,7 +1234,7 @@ describe("ServeServices", () => {
     );
   });
 
-  it("uses the latest existing Codex thread after creating a worktree", async () => {
+  it("starts a Codex thread after creating a worktree", async () => {
     const state = {
       ...createTestState(),
       projects: [createProject()],
@@ -1170,39 +1242,8 @@ describe("ServeServices", () => {
     const store = new ServeStateStore(await createTemporaryDirectory());
     await store.save(state);
     const codex = new FakeCodexBridge();
-    const codexHome = await createTemporaryDirectory();
-    await writeCodexSession(codexHome, [
-      {
-        timestamp: "2026-04-25T00:00:00.000Z",
-        type: "session_meta",
-        payload: {
-          id: "019dc000-0000-7000-8000-000000000002",
-          timestamp: "2026-04-25T00:00:00.000Z",
-          cwd: "/repo/.git/phantom/worktrees/feature",
-          source: "vscode",
-        },
-      },
-      {
-        timestamp: "2026-04-25T00:01:00.000Z",
-        type: "event_msg",
-        payload: {
-          type: "thread_name_updated",
-          thread_name: "Continue feature",
-        },
-      },
-      {
-        timestamp: "2026-04-25T00:02:00.000Z",
-        type: "response_item",
-        payload: {
-          type: "message",
-          role: "user",
-          content: [{ type: "input_text", text: "Continue from here" }],
-        },
-      },
-    ]);
     const services = new ServeServices({
       codex: codex as unknown as CodexBridge,
-      codexHome,
       store,
     });
     coreMocks.runCreateWorktree.mockResolvedValueOnce({
@@ -1212,87 +1253,47 @@ describe("ServeServices", () => {
         path: "/repo/.git/phantom/worktrees/feature",
       },
     });
+    codex.startThread.mockResolvedValueOnce({ thread: { id: "thread_new" } });
 
     const chat = await services.createChat("proj_1", { name: "feature" });
 
-    strictEqual(chat.title, "Continue feature");
-    strictEqual(chat.codexThreadId, "019dc000-0000-7000-8000-000000000002");
-    strictEqual(codex.startThread.mock.calls.length, 0);
+    strictEqual(chat.title, "feature");
+    strictEqual(chat.codexThreadId, "thread_new");
+    deepStrictEqual(codex.startThread.mock.calls[0], [
+      "/repo/.git/phantom/worktrees/feature",
+    ]);
     const savedState = await store.load();
     strictEqual(savedState.selectedChatId, chat.id);
-    deepStrictEqual(
-      savedState.messages.map((message) => [message.role, message.text]),
-      [["user", "Continue from here"]],
-    );
+    deepStrictEqual(savedState.messages, []);
   });
 
-  it("deduplicates imported chats against current state when creating a worktree", async () => {
-    const threadId = "019dc000-0000-7000-8000-000000000002";
+  it("stores a newly created chat without importing existing history", async () => {
     const worktreePath = "/repo/.git/phantom/worktrees/feature";
     const state = {
       ...createTestState(),
       projects: [createProject()],
     };
-    const importedChat = createChat({
-      id: `chat_codex_${threadId}`,
-      codexThreadId: threadId,
-      title: "Continue feature",
-      worktreeName: "feature",
-      worktreePath,
-      branchName: "feature",
-    });
     const store = new ImportRaceStore(
       await createTemporaryDirectory(),
       (currentState) => ({
         ...currentState,
-        chats: [...currentState.chats, importedChat],
-        messages: [
-          ...currentState.messages,
-          {
-            id: `${importedChat.id}_msg_0`,
-            chatId: importedChat.id,
-            role: "user" as const,
-            text: "Continue from here",
-            createdAt: "2026-04-25T00:02:00.000Z",
-          },
+        chats: [
+          ...currentState.chats,
+          createChat({
+            id: "chat_concurrent",
+            codexThreadId: "thread_concurrent",
+            title: "Concurrent feature",
+            worktreeName: "feature",
+            worktreePath,
+            branchName: "feature",
+          }),
         ],
       }),
     );
     await store.save(state);
     const codex = new FakeCodexBridge();
-    const codexHome = await createTemporaryDirectory();
-    await writeCodexSession(codexHome, [
-      {
-        timestamp: "2026-04-25T00:00:00.000Z",
-        type: "session_meta",
-        payload: {
-          id: threadId,
-          timestamp: "2026-04-25T00:00:00.000Z",
-          cwd: worktreePath,
-          source: "vscode",
-        },
-      },
-      {
-        timestamp: "2026-04-25T00:01:00.000Z",
-        type: "event_msg",
-        payload: {
-          type: "thread_name_updated",
-          thread_name: "Continue feature",
-        },
-      },
-      {
-        timestamp: "2026-04-25T00:02:00.000Z",
-        type: "response_item",
-        payload: {
-          type: "message",
-          role: "user",
-          content: [{ type: "input_text", text: "Continue from here" }],
-        },
-      },
-    ]);
     const services = new ServeServices({
       codex: codex as unknown as CodexBridge,
-      codexHome,
       store,
     });
     coreMocks.runCreateWorktree.mockResolvedValueOnce({
@@ -1302,23 +1303,17 @@ describe("ServeServices", () => {
         path: worktreePath,
       },
     });
+    codex.startThread.mockResolvedValueOnce({ thread: { id: "thread_new" } });
 
     const chat = await services.createChat("proj_1", { name: "feature" });
 
-    strictEqual(chat.id, importedChat.id);
+    strictEqual(chat.codexThreadId, "thread_new");
     const savedState = await store.load();
-    strictEqual(
-      savedState.chats.filter((candidate) => candidate.id === importedChat.id)
-        .length,
-      1,
+    deepStrictEqual(
+      savedState.chats.map((candidate) => candidate.codexThreadId),
+      ["thread_concurrent", "thread_new"],
     );
-    strictEqual(
-      savedState.messages.filter(
-        (message) => message.id === `${importedChat.id}_msg_0`,
-      ).length,
-      1,
-    );
-    strictEqual(savedState.selectedChatId, importedChat.id);
+    strictEqual(savedState.selectedChatId, chat.id);
   });
 
   it("rejects approval responses from a different chat", async () => {

--- a/packages/server/src/services.ts
+++ b/packages/server/src/services.ts
@@ -25,12 +25,9 @@ import {
   getCodexBin,
   getParamObject,
   getServerRequestId,
-  listCodexSessionsForWorktree,
-  listCodexSessionsForWorktrees,
   mapCodexMethodToEvent,
   summarizeCodexEvent,
   type CodexMessage,
-  type ImportedCodexSession,
 } from "@phantompane/codex";
 import {
   createRecordId,
@@ -113,11 +110,28 @@ type PendingTurnEvent =
   | { kind: "serverRequest"; message: CodexMessage };
 type ServerRequestId = number | string;
 
+interface ProjectWorktreeSnapshot {
+  branch: string;
+  isClean: boolean;
+  name: string;
+  path: string;
+  pathToDisplay: string;
+}
+
+interface CodexThreadRecord {
+  createdAt: string;
+  id: string;
+  preview: string | null;
+  status: ChatStatus;
+  title: string | null;
+  updatedAt: string;
+  worktreePath: string | null;
+}
+
 export class ServeServices {
   readonly eventHub: EventHub;
   readonly store: ServeStateStore;
   readonly codex: CodexBridge;
-  private readonly codexHome?: string;
   private readonly loadedThreadIds = new Set<string>();
   private readonly approvalRequests = new Map<string, PendingApprovalRequest>();
   private readonly pendingTurnEvents = new Map<
@@ -131,7 +145,6 @@ export class ServeServices {
     this.eventHub = options.eventHub ?? new EventHub();
     this.store = options.store ?? new ServeStateStore();
     this.codex = options.codex ?? new CodexBridge();
-    this.codexHome = options.codexHome;
     this.codex.onNotification((message) => {
       void this.handleCodexNotification(message);
     });
@@ -235,12 +248,118 @@ export class ServeServices {
   async listChats(projectId: string): Promise<ChatRecord[]> {
     await this.resetStaleTransientChatState();
     const state = await this.store.load();
-    return state.chats.filter((chat) => chat.projectId === projectId);
+    const project = this.requireProject(state, projectId);
+    const worktrees = await this.listProjectWorktreeSnapshot(projectId);
+    if (!worktrees) {
+      return sortChatsByUpdatedAt(
+        state.chats.filter((chat) => chat.projectId === projectId),
+      );
+    }
+
+    let codexThreads: CodexThreadRecord[];
+    try {
+      codexThreads = await this.listCodexThreadsForWorktrees(worktrees);
+    } catch {
+      return sortChatsByUpdatedAt(
+        state.chats.filter((chat) => chat.projectId === projectId),
+      );
+    }
+
+    const worktreesByPath = new Map(
+      worktrees.map((worktree) => [worktree.path, worktree]),
+    );
+    const canPruneMissingChats = worktreesByPath.has(project.rootPath);
+    const initialProjectChatIds = new Set(
+      state.chats
+        .filter((chat) => chat.projectId === projectId)
+        .map((chat) => chat.id),
+    );
+    const threadChats = codexThreads
+      .map((thread) =>
+        createChatFromCodexThread(project.id, thread, worktreesByPath),
+      )
+      .filter((chat): chat is ChatRecord => Boolean(chat));
+
+    await this.store.update((nextState) => {
+      const existingProjectChats = nextState.chats.filter(
+        (chat) => chat.projectId === projectId,
+      );
+      const existingChatsByThreadId = new Map(
+        existingProjectChats
+          .filter((chat) => chat.codexThreadId)
+          .map((chat) => [chat.codexThreadId, chat]),
+      );
+      const nextProjectChats = threadChats.map((chat) => {
+        const existingChat = existingChatsByThreadId.get(chat.codexThreadId);
+        if (!existingChat) {
+          return chat;
+        }
+        return {
+          ...chat,
+          id: existingChat.id,
+          status: isChatActive(existingChat, this.pendingChatTurns)
+            ? existingChat.status
+            : chat.status,
+          activeTurnId: isChatActive(existingChat, this.pendingChatTurns)
+            ? existingChat.activeTurnId
+            : null,
+          createdAt: existingChat.createdAt,
+        };
+      });
+      const threadChatIds = new Set(nextProjectChats.map((chat) => chat.id));
+      const threadIds = new Set(
+        threadChats
+          .map((chat) => chat.codexThreadId)
+          .filter((threadId): threadId is string => Boolean(threadId)),
+      );
+      const retainedLocalChats = existingProjectChats.filter(
+        (chat) =>
+          !threadChatIds.has(chat.id) &&
+          (!chat.codexThreadId || !threadIds.has(chat.codexThreadId)) &&
+          (worktreesByPath.has(chat.worktreePath) ||
+            !canPruneMissingChats ||
+            isChatActive(chat, this.pendingChatTurns) ||
+            !initialProjectChatIds.has(chat.id)),
+      );
+      const retainedProjectChats = sortChatsByUpdatedAt([
+        ...nextProjectChats,
+        ...retainedLocalChats,
+      ]);
+      const retainedProjectChatIds = new Set(
+        retainedProjectChats.map((chat) => chat.id),
+      );
+      const removedProjectChatIds = new Set(
+        existingProjectChats
+          .filter((chat) => !retainedProjectChatIds.has(chat.id))
+          .map((chat) => chat.id),
+      );
+      const selectedChatId = removedProjectChatIds.has(
+        nextState.selectedChatId ?? "",
+      )
+        ? null
+        : nextState.selectedChatId;
+
+      return {
+        ...nextState,
+        chats: [
+          ...nextState.chats.filter((chat) => chat.projectId !== projectId),
+          ...retainedProjectChats,
+        ],
+        messages: nextState.messages.filter(
+          (message) => !removedProjectChatIds.has(message.chatId),
+        ),
+        selectedChatId,
+      };
+    });
+
+    const syncedState = await this.store.load();
+    return sortChatsByUpdatedAt(
+      syncedState.chats.filter((chat) => chat.projectId === projectId),
+    );
   }
 
   async listProjectWorktrees(
     projectId: string,
-    options: { sync?: boolean } = {},
   ): Promise<ProjectWorktreeRecord[]> {
     await this.resetStaleTransientChatState();
     const state = await this.store.load();
@@ -248,7 +367,9 @@ export class ServeServices {
     const worktreesDirectory = await getProjectWorktreesDirectory(
       project.rootPath,
     );
-    if (options.sync === false) {
+
+    const worktrees = await this.listProjectWorktreeSnapshot(projectId);
+    if (!worktrees) {
       return projectWorktreesFromPersistedChats(
         state,
         projectId,
@@ -257,157 +378,8 @@ export class ServeServices {
       );
     }
 
-    let result;
-    try {
-      result = await listWorktrees(project.rootPath, {
-        includePrunable: false,
-      });
-    } catch {
-      return projectWorktreesFromPersistedChats(
-        state,
-        projectId,
-        worktreesDirectory,
-        project.rootPath,
-      );
-    }
-    if (!result.ok) {
-      return projectWorktreesFromPersistedChats(
-        state,
-        projectId,
-        worktreesDirectory,
-        project.rootPath,
-      );
-    }
-
-    const { worktrees } = result.value;
-    const displayWorktreePaths = new Set(
-      worktrees.map((worktree) => worktree.path),
-    );
-    const knownWorktreePaths = await getKnownProjectWorktreePaths(
-      project.rootPath,
-    );
-    const canPruneMissingWorktreeChats = Boolean(
-      knownWorktreePaths?.has(project.rootPath),
-    );
-    const timestamp = createTimestamp();
-    const importedSessions = await listCodexSessionsForWorktrees({
-      codexHome: this.codexHome,
-      projectId,
-      worktrees: worktrees.map((worktree) => ({
-        branchName: worktree.branch,
-        worktreeName: worktree.name,
-        worktreePath: worktree.path,
-      })),
-    });
-
-    if (
-      shouldSyncProjectWorktreeChats({
-        importedSessions,
-        canPruneMissingWorktreeChats,
-        knownWorktreePaths,
-        projectId,
-        state,
-        worktrees,
-      })
-    ) {
-      await this.store.update((nextState) => {
-        const existingChatsByPath = new Map(
-          nextState.chats
-            .filter((chat) => chat.projectId === projectId)
-            .map((chat) => [chat.worktreePath, chat]),
-        );
-        const importedWorktreePaths = new Set(
-          importedSessions.map((session) => session.chat.worktreePath),
-        );
-        const chatsToAdd = worktrees
-          .filter(
-            (worktree) =>
-              !existingChatsByPath.has(worktree.path) &&
-              !importedWorktreePaths.has(worktree.path),
-          )
-          .map((worktree) => ({
-            id: createRecordId("chat"),
-            projectId,
-            worktreeName: worktree.name,
-            worktreePath: worktree.path,
-            branchName: worktree.branch,
-            codexThreadId: null,
-            title: worktree.name,
-            status: "idle" as const,
-            activeTurnId: null,
-            createdAt: timestamp,
-            updatedAt: timestamp,
-          }));
-        const importableSessions = importedSessions.filter(
-          (session) =>
-            !nextState.chats.some((chat) =>
-              shouldPreferExistingChatOverImport(chat, session.chat),
-            ),
-        );
-        const importableMessages = importableSessions.flatMap(
-          (session) => session.messages,
-        );
-        const initialMissingWorktreeChatIds = new Set(
-          state.chats
-            .filter(
-              (chat) =>
-                canPruneMissingWorktreeChats &&
-                chat.projectId === projectId &&
-                !knownWorktreePaths?.has(chat.worktreePath),
-            )
-            .map((chat) => chat.id),
-        );
-        const chatsToRemove = nextState.chats.filter(
-          (chat) =>
-            !shouldPreserveChatDuringWorktreeSync(
-              chat,
-              projectId,
-              displayWorktreePaths,
-              knownWorktreePaths,
-              initialMissingWorktreeChatIds,
-              this.pendingChatTurns,
-              importableSessions,
-            ),
-        );
-        if (
-          chatsToAdd.length === 0 &&
-          importableSessions.length === 0 &&
-          chatsToRemove.length === 0
-        ) {
-          return nextState;
-        }
-        const chatIdsToRemove = new Set(chatsToRemove.map((chat) => chat.id));
-        const selectedReplacement = findImportedReplacement(
-          nextState.selectedChatId,
-          chatsToRemove,
-          importableSessions,
-        );
-
-        return {
-          ...nextState,
-          chats: [
-            ...nextState.chats.filter((chat) => !chatIdsToRemove.has(chat.id)),
-            ...importableSessions.map((session) => session.chat),
-            ...chatsToAdd,
-          ],
-          messages: [
-            ...nextState.messages.filter(
-              (message) => !chatIdsToRemove.has(message.chatId),
-            ),
-            ...importableMessages,
-          ],
-          selectedChatId:
-            nextState.selectedChatId &&
-            chatIdsToRemove.has(nextState.selectedChatId)
-              ? (selectedReplacement?.chat.id ?? null)
-              : nextState.selectedChatId,
-        };
-      });
-    }
-
-    const syncedState = await this.store.load();
     const syncedChatsByPath = new Map<string, ChatRecord[]>();
-    for (const chat of syncedState.chats.filter(
+    for (const chat of state.chats.filter(
       (candidate) => candidate.projectId === projectId,
     )) {
       syncedChatsByPath.set(chat.worktreePath, [
@@ -438,6 +410,52 @@ export class ServeServices {
         };
       }),
     );
+  }
+
+  private async listProjectWorktreeSnapshot(
+    projectId: string,
+  ): Promise<ProjectWorktreeSnapshot[] | null> {
+    const state = await this.store.load();
+    const project = this.requireProject(state, projectId);
+    try {
+      const result = await listWorktrees(project.rootPath, {
+        includePrunable: false,
+      });
+      if (!result.ok) {
+        return null;
+      }
+      return result.value.worktrees;
+    } catch {
+      return null;
+    }
+  }
+
+  private async listCodexThreadsForWorktrees(
+    worktrees: ProjectWorktreeSnapshot[],
+  ): Promise<CodexThreadRecord[]> {
+    const cwd = worktrees.map((worktree) => worktree.path);
+    if (cwd.length === 0) {
+      return [];
+    }
+
+    const threads: CodexThreadRecord[] = [];
+    let cursor: string | null = null;
+    do {
+      const result = await this.codex.listThreads({
+        archived: false,
+        cursor,
+        cwd,
+        limit: 100,
+        sourceKinds: ["cli", "vscode", "appServer"],
+        sortDirection: "desc",
+        sortKey: "updated_at",
+        useStateDbOnly: true,
+      });
+      threads.push(...normalizeCodexThreadList(result));
+      cursor = normalizeCodexCursor(result, "nextCursor");
+    } while (cursor);
+
+    return threads;
   }
 
   async syncProjectWorktreeBranch(
@@ -506,56 +524,6 @@ export class ServeServices {
 
     if (!createResult.ok) {
       throw createResult.error;
-    }
-
-    let importedSessions: ImportedCodexSession[];
-    try {
-      importedSessions = await listCodexSessionsForWorktree({
-        branchName: createResult.value.name,
-        codexHome: this.codexHome,
-        projectId,
-        worktreeName: createResult.value.name,
-        worktreePath: createResult.value.path,
-      });
-    } catch (error) {
-      try {
-        await rollbackCreatedWorktree(
-          project.rootPath,
-          createResult.value.path,
-          createResult.value.name,
-        );
-      } catch (rollbackError) {
-        throw new Error(
-          `Failed to import Codex history: ${toErrorMessage(error)}. Rollback failed: ${toErrorMessage(rollbackError)}`,
-        );
-      }
-      throw error instanceof Error ? error : new Error(String(error));
-    }
-    const latestImportedSession = importedSessions[0];
-    if (latestImportedSession) {
-      let selectedImportedChat: ChatRecord = latestImportedSession.chat;
-      await this.store.update((nextState) => {
-        selectedImportedChat =
-          findExistingChatForImportedSession(
-            nextState.chats,
-            projectId,
-            latestImportedSession.chat,
-          ) ?? latestImportedSession.chat;
-        return {
-          ...mergeImportedSessionsForProject(
-            nextState,
-            projectId,
-            importedSessions,
-          ),
-          selectedProjectId: projectId,
-          selectedChatId: selectedImportedChat.id,
-        };
-      });
-
-      this.eventHub.emit("chat.created", selectedImportedChat, {
-        chatId: selectedImportedChat.id,
-      });
-      return selectedImportedChat;
     }
 
     let codexThreadId: string;
@@ -700,8 +668,23 @@ export class ServeServices {
   async getMessages(chatId: string): Promise<ChatMessageRecord[]> {
     await this.resetStaleTransientChatState();
     const state = await this.store.load();
-    this.requireChat(state, chatId);
-    return state.messages.filter((message) => message.chatId === chatId);
+    const chat = this.requireChat(state, chatId);
+    const localMessages = state.messages.filter(
+      (message) => message.chatId === chatId,
+    );
+    if (!chat.codexThreadId) {
+      return localMessages;
+    }
+
+    try {
+      const result = await this.codex.readThread(chat.codexThreadId, {
+        includeTurns: true,
+      });
+      const codexMessages = normalizeCodexThreadMessages(result, chat.id);
+      return mergeCodexAndLocalMessages(codexMessages, localMessages);
+    } catch {
+      return localMessages;
+    }
   }
 
   async sendMessage(
@@ -1653,168 +1636,11 @@ async function getProjectWorktreesDirectory(
   }
 }
 
-async function getKnownProjectWorktreePaths(
-  projectRootPath: string,
-): Promise<Set<string> | null> {
-  try {
-    const result = await listWorktrees(projectRootPath);
-    if (!result.ok) {
-      return null;
-    }
-    return new Set(result.value.worktrees.map((worktree) => worktree.path));
-  } catch {
-    return null;
-  }
-}
-
 function isPathInsideDirectory(path: string, directory: string): boolean {
   const relativePath = relative(directory, path);
   return Boolean(
     relativePath && !relativePath.startsWith("..") && !isAbsolute(relativePath),
   );
-}
-
-function shouldSyncProjectWorktreeChats({
-  importedSessions,
-  canPruneMissingWorktreeChats,
-  knownWorktreePaths,
-  projectId,
-  state,
-  worktrees,
-}: {
-  importedSessions: ImportedCodexSession[];
-  canPruneMissingWorktreeChats: boolean;
-  knownWorktreePaths: ReadonlySet<string> | null;
-  projectId: string;
-  state: ServeState;
-  worktrees: Array<{ path: string }>;
-}): boolean {
-  const existingChatsByPath = new Map(
-    state.chats
-      .filter((chat) => chat.projectId === projectId)
-      .map((chat) => [chat.worktreePath, chat]),
-  );
-  const importedWorktreePaths = new Set(
-    importedSessions.map((session) => session.chat.worktreePath),
-  );
-  return (
-    (canPruneMissingWorktreeChats &&
-      state.chats.some(
-        (chat) =>
-          chat.projectId === projectId &&
-          !knownWorktreePaths?.has(chat.worktreePath),
-      )) ||
-    worktrees.some(
-      (worktree) =>
-        !existingChatsByPath.has(worktree.path) &&
-        !importedWorktreePaths.has(worktree.path),
-    ) ||
-    importedSessions.some(
-      (session) =>
-        !state.chats.some((chat) =>
-          shouldPreferExistingChatOverImport(chat, session.chat),
-        ),
-    )
-  );
-}
-
-function shouldPreferExistingChatOverImport(
-  chat: ChatRecord,
-  importedChat: ChatRecord,
-): boolean {
-  if (chat.projectId !== importedChat.projectId) {
-    return false;
-  }
-  if (
-    chat.codexThreadId !== null &&
-    chat.codexThreadId === importedChat.codexThreadId
-  ) {
-    return true;
-  }
-  if (chat.codexThreadId !== null) {
-    return false;
-  }
-  return (
-    Boolean(
-      chat.activeTurnId ||
-      chat.status === "running" ||
-      chat.status === "waitingForApproval",
-    ) && chat.worktreePath === importedChat.worktreePath
-  );
-}
-
-function findExistingChatForImportedSession(
-  chats: ChatRecord[],
-  projectId: string,
-  importedChat: ChatRecord,
-): ChatRecord | null {
-  return (
-    chats.find(
-      (chat) =>
-        chat.projectId === projectId &&
-        (chat.id === importedChat.id ||
-          shouldPreferExistingChatOverImport(chat, importedChat)),
-    ) ?? null
-  );
-}
-
-function mergeImportedSessionsForProject(
-  state: ServeState,
-  projectId: string,
-  importedSessions: ImportedCodexSession[],
-): ServeState {
-  const importableSessions = importedSessions.filter(
-    (session) =>
-      !state.chats.some((chat) =>
-        shouldPreferExistingChatOverImport(chat, session.chat),
-      ),
-  );
-  const chatsToRemove = state.chats.filter(
-    (chat) =>
-      !shouldPreserveChatDuringImport(chat, projectId, importableSessions),
-  );
-  const chatIdsToRemove = new Set(chatsToRemove.map((chat) => chat.id));
-
-  return {
-    ...state,
-    chats: [
-      ...state.chats.filter((chat) => !chatIdsToRemove.has(chat.id)),
-      ...importableSessions.map((session) => session.chat),
-    ],
-    messages: [
-      ...state.messages.filter(
-        (message) => !chatIdsToRemove.has(message.chatId),
-      ),
-      ...importableSessions.flatMap((session) => session.messages),
-    ],
-  };
-}
-
-function shouldPreserveChatDuringWorktreeSync(
-  chat: ChatRecord,
-  projectId: string,
-  displayWorktreePaths: ReadonlySet<string>,
-  knownWorktreePaths: ReadonlySet<string> | null,
-  initialMissingWorktreeChatIds: ReadonlySet<string>,
-  pendingChatTurns: ReadonlySet<string>,
-  importedSessions: ImportedCodexSession[],
-): boolean {
-  if (chat.projectId !== projectId) {
-    return true;
-  }
-  if (displayWorktreePaths.has(chat.worktreePath)) {
-    return shouldPreserveChatDuringImport(chat, projectId, importedSessions);
-  }
-  if (knownWorktreePaths?.has(chat.worktreePath)) {
-    return true;
-  }
-  if (knownWorktreePaths) {
-    return (
-      !initialMissingWorktreeChatIds.has(chat.id) ||
-      isChatActive(chat, pendingChatTurns)
-    );
-  }
-  return true;
 }
 
 function isChatActive(
@@ -1829,51 +1655,306 @@ function isChatActive(
   );
 }
 
-function shouldPreserveChatDuringImport(
-  chat: ChatRecord,
-  projectId: string,
-  importedSessions: ImportedCodexSession[],
-): boolean {
-  if (chat.projectId !== projectId) {
-    return true;
-  }
-  if (
-    chat.activeTurnId ||
-    chat.status === "running" ||
-    chat.status === "waitingForApproval"
-  ) {
-    return true;
-  }
-  return !importedSessions.some((session) => {
-    const importedChat = session.chat;
-    return (
-      chat.id === importedChat.id ||
-      (chat.codexThreadId !== null &&
-        chat.codexThreadId === importedChat.codexThreadId) ||
-      (chat.codexThreadId === null &&
-        chat.worktreePath === importedChat.worktreePath)
-    );
-  });
+function normalizeCodexThreadList(value: unknown): CodexThreadRecord[] {
+  const source =
+    getRecordArray(value, "data") ?? getRecordArray(value, "threads");
+  return (source ?? [])
+    .map((thread) => normalizeCodexThread(thread))
+    .filter((thread): thread is CodexThreadRecord => Boolean(thread));
 }
 
-function findImportedReplacement(
-  selectedChatId: string | null,
-  removedChats: ChatRecord[],
-  importedSessions: ImportedCodexSession[],
-): ImportedCodexSession | null {
-  const removedChat = removedChats.find((chat) => chat.id === selectedChatId);
-  if (!removedChat) {
+function normalizeCodexThread(value: unknown): CodexThreadRecord | null {
+  if (!isRecord(value)) {
     return null;
   }
-  return (
-    importedSessions.find((session) => {
-      const importedChat = session.chat;
-      return (
-        removedChat.codexThreadId === importedChat.codexThreadId ||
-        removedChat.worktreePath === importedChat.worktreePath
-      );
-    }) ?? null
+  const id = getRecordString(value, "id") ?? getRecordString(value, "threadId");
+  if (!id) {
+    return null;
+  }
+  const fallbackTimestamp = createTimestamp();
+  const createdAt = normalizeCodexTimestamp(
+    value.createdAt ?? value.created_at,
+    fallbackTimestamp,
   );
+  const updatedAt = normalizeCodexTimestamp(
+    value.updatedAt ?? value.updated_at,
+    createdAt,
+  );
+  return {
+    id,
+    title:
+      getRecordString(value, "title") ??
+      getRecordString(value, "name") ??
+      getRecordString(value, "firstUserMessage") ??
+      null,
+    preview: getRecordString(value, "preview") ?? null,
+    worktreePath: getRecordString(value, "cwd") ?? null,
+    status: normalizeCodexThreadStatus(value.status),
+    createdAt,
+    updatedAt,
+  };
+}
+
+function normalizeCodexCursor(value: unknown, key: string): string | null {
+  return (
+    getRecordString(value, key) ?? getRecordString(value, "next_cursor") ?? null
+  );
+}
+
+function createChatFromCodexThread(
+  projectId: string,
+  thread: CodexThreadRecord,
+  worktreesByPath: ReadonlyMap<string, ProjectWorktreeSnapshot>,
+): ChatRecord | null {
+  if (!thread.worktreePath) {
+    return null;
+  }
+  const worktree = worktreesByPath.get(thread.worktreePath);
+  if (!worktree) {
+    return null;
+  }
+  const title =
+    normalizeTitle(thread.title) ??
+    normalizeTitle(thread.preview) ??
+    worktree.name;
+  return {
+    id: createImportedChatId(thread.id),
+    projectId,
+    worktreeName: worktree.name,
+    worktreePath: worktree.path,
+    branchName: worktree.branch,
+    codexThreadId: thread.id,
+    title,
+    status: thread.status,
+    activeTurnId: null,
+    createdAt: thread.createdAt,
+    updatedAt: thread.updatedAt,
+  };
+}
+
+function normalizeTitle(value: string | null): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+function createImportedChatId(threadId: string): string {
+  return `chat_codex_${threadId}`;
+}
+
+function normalizeCodexThreadStatus(value: unknown): ChatStatus {
+  if (typeof value === "string") {
+    if (value === "active" || value === "running") {
+      return "running";
+    }
+    if (value === "systemError" || value === "failed") {
+      return "failed";
+    }
+    return "idle";
+  }
+  if (!isRecord(value)) {
+    return "idle";
+  }
+  const type = getRecordString(value, "type");
+  if (type === "active") {
+    return "running";
+  }
+  if (type === "systemError" || type === "failed") {
+    return "failed";
+  }
+  return "idle";
+}
+
+function normalizeCodexTimestamp(value: unknown, fallback: string): string {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    const millis = value < 10_000_000_000 ? value * 1000 : value;
+    return new Date(millis).toISOString();
+  }
+  if (typeof value === "string") {
+    const parsed = Date.parse(value);
+    if (Number.isFinite(parsed)) {
+      return new Date(parsed).toISOString();
+    }
+  }
+  return fallback;
+}
+
+function sortChatsByUpdatedAt(chats: ChatRecord[]): ChatRecord[] {
+  return [...chats].sort((left, right) =>
+    right.updatedAt.localeCompare(left.updatedAt),
+  );
+}
+
+function normalizeCodexThreadMessages(
+  value: unknown,
+  chatId: string,
+): ChatMessageRecord[] {
+  const thread =
+    getRecordObject(value, "thread") ?? (isRecord(value) ? value : null);
+  const turns = thread ? getRecordArray(thread, "turns") : undefined;
+  if (!turns) {
+    return [];
+  }
+
+  const messages: ChatMessageRecord[] = [];
+  for (const [turnIndex, turn] of turns.entries()) {
+    const turnId =
+      getRecordString(turn, "id") ??
+      getRecordString(turn, "turnId") ??
+      String(turnIndex);
+    const turnTimestamp = normalizeCodexTimestamp(
+      turn.createdAt ?? turn.created_at ?? turn.updatedAt ?? turn.updated_at,
+      createTimestamp(),
+    );
+    const items = getCodexTurnItems(turn);
+    for (const [itemIndex, item] of items.entries()) {
+      const role = normalizeCodexMessageRole(item);
+      if (!role) {
+        continue;
+      }
+      const text = extractCodexText(item).trim();
+      if (!text) {
+        continue;
+      }
+      messages.push({
+        id: `${chatId}_codex_${turnId}_${itemIndex}`,
+        chatId,
+        role,
+        text,
+        itemId: getRecordString(item, "id") ?? undefined,
+        createdAt: normalizeCodexTimestamp(
+          item.createdAt ?? item.created_at ?? item.timestamp,
+          turnTimestamp,
+        ),
+      });
+    }
+  }
+  return messages.sort((left, right) =>
+    left.createdAt.localeCompare(right.createdAt),
+  );
+}
+
+function getCodexTurnItems(
+  turn: Record<string, unknown>,
+): Array<Record<string, unknown>> {
+  const inputItems = Array.isArray(turn.input)
+    ? turn.input.filter(isRecord).map((item) => ({ ...item, role: "user" }))
+    : [];
+  if (Array.isArray(turn.items)) {
+    return [...inputItems, ...turn.items.filter(isRecord)];
+  }
+  if (Array.isArray(turn.output)) {
+    return [...inputItems, ...turn.output.filter(isRecord)];
+  }
+  return inputItems;
+}
+
+function normalizeCodexMessageRole(
+  item: Record<string, unknown>,
+): "assistant" | "user" | null {
+  const role = getRecordString(item, "role");
+  if (role === "user" || role === "assistant") {
+    return role;
+  }
+  const type = getRecordString(item, "type");
+  if (
+    type === "userMessage" ||
+    type === "user_message" ||
+    type === "input_text"
+  ) {
+    return "user";
+  }
+  if (
+    type === "agentMessage" ||
+    type === "assistantMessage" ||
+    type === "agent_message" ||
+    type === "assistant_message" ||
+    type === "output_text"
+  ) {
+    return "assistant";
+  }
+  return null;
+}
+
+function extractCodexText(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map(extractCodexText).filter(Boolean).join("");
+  }
+  if (!isRecord(value)) {
+    return "";
+  }
+  const directText =
+    getRecordString(value, "text") ??
+    getRecordString(value, "message") ??
+    getRecordString(value, "input") ??
+    getRecordString(value, "output");
+  if (directText) {
+    return directText;
+  }
+  return extractCodexText(value.content);
+}
+
+function mergeCodexAndLocalMessages(
+  codexMessages: ChatMessageRecord[],
+  localMessages: ChatMessageRecord[],
+): ChatMessageRecord[] {
+  if (codexMessages.length === 0) {
+    return localMessages;
+  }
+  const unmatchedCodexMessages = [...codexMessages];
+  const merged = [
+    ...codexMessages,
+    ...localMessages.filter((message) => {
+      if (message.role === "event" || message.role === "error") {
+        return true;
+      }
+      const matchedCodexIndex = unmatchedCodexMessages.findIndex(
+        (codexMessage) => shouldDeduplicateLocalMessage(codexMessage, message),
+      );
+      if (matchedCodexIndex === -1) {
+        return true;
+      }
+      unmatchedCodexMessages.splice(matchedCodexIndex, 1);
+      return false;
+    }),
+  ];
+  return merged.sort((left, right) =>
+    left.createdAt.localeCompare(right.createdAt),
+  );
+}
+
+function shouldDeduplicateLocalMessage(
+  codexMessage: ChatMessageRecord,
+  localMessage: ChatMessageRecord,
+): boolean {
+  if (codexMessage.role !== localMessage.role) {
+    return false;
+  }
+  if (codexMessage.itemId && localMessage.itemId) {
+    return codexMessage.itemId === localMessage.itemId;
+  }
+  if (messageFingerprint(codexMessage) !== messageFingerprint(localMessage)) {
+    return false;
+  }
+  return isCodexMessageAtOrAfterLocalMessage(codexMessage, localMessage);
+}
+
+function isCodexMessageAtOrAfterLocalMessage(
+  codexMessage: ChatMessageRecord,
+  localMessage: ChatMessageRecord,
+): boolean {
+  const codexTime = Date.parse(codexMessage.createdAt);
+  const localTime = Date.parse(localMessage.createdAt);
+  if (Number.isFinite(codexTime) && Number.isFinite(localTime)) {
+    return codexTime >= localTime;
+  }
+  return codexMessage.createdAt >= localMessage.createdAt;
+}
+
+function messageFingerprint(message: ChatMessageRecord): string {
+  return `${message.role}:${message.text}`;
 }
 
 function normalizeTurnContextItems(
@@ -2058,6 +2139,17 @@ function getRecordArray(
     return undefined;
   }
   return candidate.filter(isRecord);
+}
+
+function getRecordObject(
+  value: unknown,
+  key: string,
+): Record<string, unknown> | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const candidate = value[key];
+  return isRecord(candidate) ? candidate : undefined;
 }
 
 function getRecordString(value: unknown, key: string): string | undefined {

--- a/packages/web/src/api/queries.ts
+++ b/packages/web/src/api/queries.ts
@@ -11,11 +11,6 @@ import type {
   ProjectWorktreeRecord,
 } from "@phantompane/server";
 
-export interface ProjectData {
-  chats: ChatRecord[];
-  worktrees: ProjectWorktreeRecord[];
-}
-
 export function authQueryOptions() {
   return queryOptions({
     queryKey: queryKeys.auth,
@@ -39,14 +34,25 @@ export function modelsQueryOptions() {
   });
 }
 
-export function projectDataQueryOptions(projectId: string, sync = false) {
+export function projectWorktreesQueryOptions(projectId: string) {
   return queryOptions({
-    queryKey: queryKeys.projectData(projectId, sync),
+    queryKey: queryKeys.projectWorktrees(projectId),
     queryFn: async () =>
-      readRpcJson<ProjectData>(
+      readRpcJson<{ worktrees: ProjectWorktreeRecord[] }>(
+        await api.projects[":projectId"].worktrees.$get({
+          param: { projectId: routeParam(projectId) },
+        }),
+      ),
+  });
+}
+
+export function projectChatsQueryOptions(projectId: string) {
+  return queryOptions({
+    queryKey: queryKeys.projectChats(projectId),
+    queryFn: async () =>
+      readRpcJson<{ chats: ChatRecord[] }>(
         await api.projects[":projectId"].chats.$get({
           param: { projectId: routeParam(projectId) },
-          query: sync ? { sync: "1" } : {},
         }),
       ),
   });

--- a/packages/web/src/api/query-keys.ts
+++ b/packages/web/src/api/query-keys.ts
@@ -2,8 +2,10 @@ export const queryKeys = {
   auth: ["auth"] as const,
   models: ["models"] as const,
   projects: ["projects"] as const,
-  projectData: (projectId: string, sync: boolean) =>
-    ["projects", projectId, "data", { sync }] as const,
+  projectChats: (projectId: string) =>
+    ["projects", projectId, "chats"] as const,
+  projectWorktrees: (projectId: string) =>
+    ["projects", projectId, "worktrees"] as const,
   chat: (chatId: string) => ["chats", chatId] as const,
   messages: (chatId: string) => ["chats", chatId, "messages"] as const,
   chatSkills: (chatId: string) => ["chats", chatId, "skills"] as const,

--- a/packages/web/src/routes/home-url-state.test.ts
+++ b/packages/web/src/routes/home-url-state.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
+  findValidatedSelectedProjectChat,
   findValidatedSelectedChat,
   getSelectableReasoningEfforts,
   isShareableFileSearchQuery,
+  mergeWorktreesWithChats,
+  retainRecordsForProjects,
 } from "./home-url-state";
 
 describe("isShareableFileSearchQuery", () => {
@@ -39,6 +42,54 @@ describe("findValidatedSelectedChat", () => {
   });
 });
 
+describe("findValidatedSelectedProjectChat", () => {
+  it("rejects stale chats whose project is no longer present", () => {
+    const chatsByProject = {
+      "project-removed": [{ id: "chat-stale", projectId: "project-removed" }],
+    };
+
+    expect(
+      findValidatedSelectedProjectChat(
+        chatsByProject,
+        [{ id: "project-current" }],
+        "chat-stale",
+        "project-removed",
+      ),
+    ).toBeNull();
+  });
+
+  it("accepts chats from the refreshed project list", () => {
+    const chat = { id: "chat-current", projectId: "project-current" };
+    const chatsByProject = {
+      "project-current": [chat],
+      "project-removed": [{ id: "chat-stale", projectId: "project-removed" }],
+    };
+
+    expect(
+      findValidatedSelectedProjectChat(
+        chatsByProject,
+        [{ id: "project-current" }],
+        "chat-current",
+        "project-current",
+      ),
+    ).toBe(chat);
+  });
+});
+
+describe("retainRecordsForProjects", () => {
+  it("drops records for projects that are absent from the refreshed list", () => {
+    expect(
+      retainRecordsForProjects(
+        {
+          "project-current": ["current"],
+          "project-removed": ["stale"],
+        },
+        new Set(["project-current"]),
+      ),
+    ).toEqual({ "project-current": ["current"] });
+  });
+});
+
 describe("getSelectableReasoningEfforts", () => {
   it("uses fallback efforts before model metadata is available", () => {
     expect(getSelectableReasoningEfforts(null)).toEqual([
@@ -53,5 +104,59 @@ describe("getSelectableReasoningEfforts", () => {
     expect(
       getSelectableReasoningEfforts({ supportedReasoningEfforts: [] }),
     ).toEqual([]);
+  });
+});
+
+describe("mergeWorktreesWithChats", () => {
+  it("attaches the latest chat for each worktree and clears stale chat fields", () => {
+    const worktrees = [
+      {
+        name: "feature",
+        path: "/repo/feature",
+        chatId: null,
+        chatStatus: null,
+        chatTitle: "feature",
+      },
+      {
+        name: "empty",
+        path: "/repo/empty",
+        chatId: "chat-stale",
+        chatStatus: "failed",
+        chatTitle: "stale",
+      },
+    ];
+    const chats = [
+      {
+        id: "chat-old",
+        worktreePath: "/repo/feature",
+        title: "old",
+        status: "idle",
+        updatedAt: "2026-04-25T00:00:00.000Z",
+      },
+      {
+        id: "chat-new",
+        worktreePath: "/repo/feature",
+        title: "new",
+        status: "running",
+        updatedAt: "2026-04-25T00:01:00.000Z",
+      },
+    ];
+
+    expect(mergeWorktreesWithChats(worktrees, chats)).toEqual([
+      {
+        name: "feature",
+        path: "/repo/feature",
+        chatId: "chat-new",
+        chatStatus: "running",
+        chatTitle: "new",
+      },
+      {
+        name: "empty",
+        path: "/repo/empty",
+        chatId: null,
+        chatStatus: null,
+        chatTitle: "empty",
+      },
+    ]);
   });
 });

--- a/packages/web/src/routes/home-url-state.ts
+++ b/packages/web/src/routes/home-url-state.ts
@@ -8,8 +8,28 @@ interface ChatSelectionRecord {
   projectId: string;
 }
 
+interface ProjectSelectionRecord {
+  id: string;
+}
+
 interface ModelReasoningEffortRecord {
   supportedReasoningEfforts: string[];
+}
+
+interface WorktreeChatMergeRecord<TStatus> {
+  id: string;
+  status: TStatus;
+  title: string;
+  updatedAt: string;
+  worktreePath: string;
+}
+
+interface WorktreeMergeRecord<TStatus> {
+  chatId: string | null;
+  chatStatus: TStatus | null;
+  chatTitle: string;
+  name: string;
+  path: string;
 }
 
 export function isShareableFileSearchQuery(value: string): boolean {
@@ -61,6 +81,67 @@ export function findValidatedSelectedChat<TChat extends ChatSelectionRecord>(
   }
 
   return null;
+}
+
+export function findValidatedSelectedProjectChat<
+  TChat extends ChatSelectionRecord,
+  TProject extends ProjectSelectionRecord,
+>(
+  chatsByProject: Record<string, TChat[]>,
+  projects: TProject[],
+  selectedChatId: string | null,
+  requestedProjectId: string | null,
+): TChat | null {
+  const projectIds = new Set(projects.map((project) => project.id));
+  return findValidatedSelectedChat(
+    Object.values(chatsByProject)
+      .flat()
+      .filter((chat) => projectIds.has(chat.projectId)),
+    selectedChatId,
+    requestedProjectId,
+  );
+}
+
+export function retainRecordsForProjects<TRecord>(
+  recordsByProject: Record<string, TRecord[]>,
+  projectIds: ReadonlySet<string>,
+): Record<string, TRecord[]> {
+  return Object.fromEntries(
+    Object.entries(recordsByProject).filter(([projectId]) =>
+      projectIds.has(projectId),
+    ),
+  );
+}
+
+export function mergeWorktreesWithChats<
+  TStatus,
+  TWorktree extends WorktreeMergeRecord<TStatus>,
+  TChat extends WorktreeChatMergeRecord<TStatus>,
+>(worktrees: TWorktree[], chats: TChat[]): TWorktree[] {
+  const latestChatsByPath = new Map<string, TChat>();
+  for (const chat of chats) {
+    const current = latestChatsByPath.get(chat.worktreePath);
+    if (!current || chat.updatedAt.localeCompare(current.updatedAt) > 0) {
+      latestChatsByPath.set(chat.worktreePath, chat);
+    }
+  }
+  return worktrees.map((worktree) => {
+    const chat = latestChatsByPath.get(worktree.path);
+    if (!chat) {
+      return {
+        ...worktree,
+        chatId: null,
+        chatStatus: null,
+        chatTitle: worktree.name,
+      };
+    }
+    return {
+      ...worktree,
+      chatId: chat.id,
+      chatStatus: chat.status,
+      chatTitle: chat.title,
+    };
+  });
 }
 
 export function getSelectableReasoningEfforts(

--- a/packages/web/src/routes/home.tsx
+++ b/packages/web/src/routes/home.tsx
@@ -47,7 +47,8 @@ import {
   fileSearchQueryOptions,
   messagesQueryOptions,
   modelsQueryOptions,
-  projectDataQueryOptions,
+  projectChatsQueryOptions,
+  projectWorktreesQueryOptions,
   projectsQueryOptions,
 } from "../api/queries";
 import { apiUrl } from "../api/client";
@@ -102,9 +103,12 @@ import { Textarea } from "../components/ui/textarea";
 import { shouldSubmitComposerOnEnter } from "../lib/composer-keyboard";
 import { cn } from "../lib/utils";
 import {
+  findValidatedSelectedProjectChat,
   findValidatedSelectedChat,
   getSelectableReasoningEfforts,
   isShareableFileSearchQuery,
+  mergeWorktreesWithChats,
+  retainRecordsForProjects,
 } from "./home-url-state";
 import type {
   ChatMessageRecord,
@@ -453,6 +457,9 @@ export function HomeRoute() {
   const [loadingProjectIds, setLoadingProjectIds] = useState<Set<string>>(
     () => new Set(),
   );
+  const [loadingChatProjectIds, setLoadingChatProjectIds] = useState<
+    Set<string>
+  >(() => new Set());
   const [isModelsLoading, setIsModelsLoading] = useState(true);
   const [isMessagesLoading, setIsMessagesLoading] = useState(false);
   const [isChatContextLoading, setIsChatContextLoading] = useState(false);
@@ -471,6 +478,8 @@ export function HomeRoute() {
   const selectedProjectIdRef = useRef<string | null>(null);
   const selectedChatIdRef = useRef<string | null>(null);
   const selectedChatVersionRef = useRef(0);
+  const chatsByProjectRef = useRef(chatsByProject);
+  const worktreesByProjectRef = useRef(worktreesByProject);
   const sendMessageRequestIdRef = useRef(0);
   const pendingSendChatIdsRef = useRef<Set<string>>(new Set());
   const [pendingApproval, setPendingApproval] =
@@ -623,6 +632,8 @@ export function HomeRoute() {
   const selectedProjectId = selectedChat?.projectId ?? requestedProjectId;
   selectedChatIdRef.current = selectedChatId;
   selectedProjectIdRef.current = selectedProjectId;
+  chatsByProjectRef.current = chatsByProject;
+  worktreesByProjectRef.current = worktreesByProject;
   fileSearchQueryRef.current = fileSearchQuery;
   const selectedProject = useMemo(
     () => projects.find((project) => project.id === selectedProjectId) ?? null,
@@ -820,8 +831,10 @@ export function HomeRoute() {
     if (!selectedProjectId) {
       return;
     }
+    void refreshWorktrees(selectedProjectId, {
+      updateSelection: isSelectedChatValidated,
+    });
     void refreshChats(selectedProjectId, {
-      sync: true,
       updateSelection: isSelectedChatValidated,
     });
   }, [isSelectedChatValidated, selectedProjectId]);
@@ -901,7 +914,7 @@ export function HomeRoute() {
       void refreshSelectedChat(selectedChatId);
       if (selectedProjectId) {
         void queryClient.invalidateQueries({
-          queryKey: queryKeys.projectData(selectedProjectId, false),
+          queryKey: queryKeys.projectChats(selectedProjectId),
         });
         void refreshChats(selectedProjectId);
       }
@@ -1109,33 +1122,35 @@ export function HomeRoute() {
     });
   }
 
+  function setChatProjectLoading(projectId: string, isLoading: boolean) {
+    setLoadingChatProjectIds((current) => {
+      const next = new Set(current);
+      if (isLoading) {
+        next.add(projectId);
+      } else {
+        next.delete(projectId);
+      }
+      return next;
+    });
+  }
+
   async function refreshProjects(): Promise<boolean> {
     const requestWorkspaceSelectionKey = workspaceSelectionKeyRef.current;
     setIsProjectsLoading(true);
     try {
       const data = await queryClient.fetchQuery(projectsQueryOptions());
       setProjects(data.projects);
-      const projectDataEntries = await Promise.all(
-        data.projects.map(
-          async (project) =>
-            [
-              project.id,
-              await loadProjectData(project.id, { sync: true }),
-            ] as const,
-        ),
+      const projectIds = new Set(data.projects.map((project) => project.id));
+      const nextChatsByProject = retainRecordsForProjects(
+        chatsByProjectRef.current,
+        projectIds,
       );
-      const nextChatsByProject = Object.fromEntries(
-        projectDataEntries.map(([projectId, projectData]) => [
-          projectId,
-          projectData.chats,
-        ]),
+      const nextWorktreesByProject = retainRecordsForProjects(
+        worktreesByProjectRef.current,
+        projectIds,
       );
-      const nextWorktreesByProject = Object.fromEntries(
-        projectDataEntries.map(([projectId, projectData]) => [
-          projectId,
-          projectData.worktrees,
-        ]),
-      );
+      chatsByProjectRef.current = nextChatsByProject;
+      worktreesByProjectRef.current = nextWorktreesByProject;
       setChatsByProject(nextChatsByProject);
       setWorktreesByProject(nextWorktreesByProject);
       if (workspaceSelectionKeyRef.current !== requestWorkspaceSelectionKey) {
@@ -1144,8 +1159,9 @@ export function HomeRoute() {
       const currentSelectedChatId = selectedChatIdRef.current;
       const currentSelectedProjectId = selectedProjectIdRef.current;
       const currentFileSearchQuery = fileSearchQueryRef.current;
-      const requestedChat = findValidatedSelectedChat(
-        Object.values(nextChatsByProject).flat(),
+      const requestedChat = findValidatedSelectedProjectChat(
+        nextChatsByProject,
+        data.projects,
         currentSelectedChatId,
         currentSelectedProjectId,
       );
@@ -1155,11 +1171,11 @@ export function HomeRoute() {
         data.projects.some((project) => project.id === currentSelectedProjectId)
           ? currentSelectedProjectId
           : (data.projects[0]?.id ?? null));
-      const fallbackWorktree = firstProjectWorktree(
-        fallbackProjectId,
-        nextWorktreesByProject,
-      );
-      const nextChatId = requestedChat?.id ?? fallbackWorktree?.chatId ?? null;
+      const pendingChatId =
+        currentSelectedProjectId === fallbackProjectId
+          ? currentSelectedChatId
+          : null;
+      const nextChatId = requestedChat?.id ?? pendingChatId;
       updateWorkspaceSearchParams(
         {
           projectId: fallbackProjectId,
@@ -1170,6 +1186,14 @@ export function HomeRoute() {
         },
         { replace: true },
       );
+      for (const project of data.projects) {
+        void refreshWorktrees(project.id, {
+          updateSelection: project.id === fallbackProjectId,
+        });
+        void refreshChats(project.id, {
+          updateSelection: project.id === fallbackProjectId,
+        });
+      }
       return true;
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
@@ -1213,37 +1237,27 @@ export function HomeRoute() {
     }
   }
 
-  async function loadProjectData(
+  async function refreshWorktrees(
     projectId: string,
-    options: { sync?: boolean } = {},
-  ): Promise<{
-    chats: ChatRecord[];
-    worktrees: ProjectWorktreeRecord[];
-  }> {
-    return await queryClient.fetchQuery(
-      projectDataQueryOptions(projectId, options.sync ?? false),
-    );
-  }
-
-  async function refreshChats(
-    projectId: string,
-    options: { sync?: boolean; updateSelection?: boolean } = {},
+    options: { updateSelection?: boolean } = {},
   ): Promise<boolean> {
     const requestWorkspaceSelectionKey = workspaceSelectionKeyRef.current;
     setProjectLoading(projectId, true);
     try {
-      const projectData = await loadProjectData(projectId, options);
-      setChatsByProject((current) => ({
-        ...current,
-        [projectId]: projectData.chats,
-      }));
-      if (options.sync) {
-        setWorktreesByProject((current) => ({
-          ...current,
-          [projectId]: projectData.worktrees,
-        }));
-      }
-      if ((options.updateSelection ?? options.sync === true) === false) {
+      const data = await queryClient.fetchQuery(
+        projectWorktreesQueryOptions(projectId),
+      );
+      const mergedWorktrees = mergeWorktreesWithChats(
+        data.worktrees,
+        chatsByProjectRef.current[projectId] ?? [],
+      );
+      const nextWorktreesByProject = {
+        ...worktreesByProjectRef.current,
+        [projectId]: mergedWorktrees,
+      };
+      worktreesByProjectRef.current = nextWorktreesByProject;
+      setWorktreesByProject(nextWorktreesByProject);
+      if (options.updateSelection === false) {
         return true;
       }
       if (selectedProjectIdRef.current !== projectId) {
@@ -1252,23 +1266,13 @@ export function HomeRoute() {
       if (workspaceSelectionKeyRef.current !== requestWorkspaceSelectionKey) {
         return true;
       }
-      const nextWorktreesByProject = options.sync
-        ? {
-            ...worktreesByProject,
-            [projectId]: projectData.worktrees,
-          }
-        : worktreesByProject;
       const fallbackWorktree = firstProjectWorktree(
         projectId,
         nextWorktreesByProject,
       );
       const currentSelectedChatId = selectedChatIdRef.current;
       const currentFileSearchQuery = fileSearchQueryRef.current;
-      const nextChatId = projectData.chats.some(
-        (chat) => chat.id === currentSelectedChatId,
-      )
-        ? currentSelectedChatId
-        : (fallbackWorktree?.chatId ?? null);
+      const nextChatId = fallbackWorktree?.chatId ?? currentSelectedChatId;
       updateWorkspaceSearchParams(
         {
           projectId,
@@ -1288,30 +1292,101 @@ export function HomeRoute() {
     }
   }
 
+  async function refreshChats(
+    projectId: string,
+    options: { updateSelection?: boolean } = {},
+  ): Promise<boolean> {
+    const requestWorkspaceSelectionKey = workspaceSelectionKeyRef.current;
+    setChatProjectLoading(projectId, true);
+    try {
+      const data = await queryClient.fetchQuery(
+        projectChatsQueryOptions(projectId),
+      );
+      const nextChatsByProject = {
+        ...chatsByProjectRef.current,
+        [projectId]: data.chats,
+      };
+      chatsByProjectRef.current = nextChatsByProject;
+      setChatsByProject(nextChatsByProject);
+      const currentProjectWorktrees =
+        worktreesByProjectRef.current[projectId] ?? [];
+      const mergedWorktrees = mergeWorktreesWithChats(
+        currentProjectWorktrees,
+        data.chats,
+      );
+      const nextWorktreesByProject = {
+        ...worktreesByProjectRef.current,
+        [projectId]: mergedWorktrees,
+      };
+      worktreesByProjectRef.current = nextWorktreesByProject;
+      setWorktreesByProject(nextWorktreesByProject);
+      if (options.updateSelection === false) {
+        return true;
+      }
+      if (selectedProjectIdRef.current !== projectId) {
+        return true;
+      }
+      if (workspaceSelectionKeyRef.current !== requestWorkspaceSelectionKey) {
+        return true;
+      }
+      const fallbackWorktree = firstProjectWorktree(
+        projectId,
+        nextWorktreesByProject,
+      );
+      const currentSelectedChatId = selectedChatIdRef.current;
+      const currentFileSearchQuery = fileSearchQueryRef.current;
+      const nextChatId = data.chats.some(
+        (chat) => chat.id === currentSelectedChatId,
+      )
+        ? currentSelectedChatId
+        : (fallbackWorktree?.chatId ?? data.chats[0]?.id ?? null);
+      updateWorkspaceSearchParams(
+        {
+          projectId,
+          chatId: nextChatId,
+          clearFileQuery:
+            Boolean(currentFileSearchQuery.trim()) &&
+            currentSelectedChatId !== nextChatId,
+        },
+        { replace: true },
+      );
+      return true;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      return false;
+    } finally {
+      setChatProjectLoading(projectId, false);
+    }
+  }
+
   async function refreshSelectedChat(chatId: string) {
     const data = await queryClient.fetchQuery(chatQueryOptions(chatId));
-    setChatsByProject((current) => {
-      const projectChats = current[data.chat.projectId] ?? [];
-      return {
-        ...current,
-        [data.chat.projectId]: projectChats.map((chat) =>
-          chat.id === chatId ? data.chat : chat,
-        ),
-      };
-    });
-    setWorktreesByProject((current) => ({
-      ...current,
-      [data.chat.projectId]: (current[data.chat.projectId] ?? []).map(
-        (worktree) =>
-          worktree.chatId === chatId
-            ? {
-                ...worktree,
-                chatStatus: data.chat.status,
-                chatTitle: data.chat.title,
-              }
-            : worktree,
+    const projectChats = chatsByProjectRef.current[data.chat.projectId] ?? [];
+    const nextChatsByProject = {
+      ...chatsByProjectRef.current,
+      [data.chat.projectId]: projectChats.map((chat) =>
+        chat.id === chatId ? data.chat : chat,
       ),
-    }));
+    };
+    chatsByProjectRef.current = nextChatsByProject;
+    setChatsByProject(nextChatsByProject);
+
+    const nextWorktreesByProject = {
+      ...worktreesByProjectRef.current,
+      [data.chat.projectId]: (
+        worktreesByProjectRef.current[data.chat.projectId] ?? []
+      ).map((worktree) =>
+        worktree.chatId === chatId
+          ? {
+              ...worktree,
+              chatStatus: data.chat.status,
+              chatTitle: data.chat.title,
+            }
+          : worktree,
+      ),
+    };
+    worktreesByProjectRef.current = nextWorktreesByProject;
+    setWorktreesByProject(nextWorktreesByProject);
   }
 
   async function refreshMessages(
@@ -1418,18 +1493,26 @@ export function HomeRoute() {
     try {
       const data = await createChatRequest.mutateAsync(projectId);
       void queryClient.invalidateQueries({
-        queryKey: queryKeys.projectData(projectId, true),
+        queryKey: queryKeys.projectWorktrees(projectId),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.projectChats(projectId),
       });
       setExpandedWorktreeKeys((current) =>
         new Set(current).add(
           getWorktreeExpansionKey(projectId, data.chat.worktreePath),
         ),
       );
-      const didRefresh = await refreshChats(projectId, {
-        sync: true,
+      const didRefreshWorktrees = await refreshWorktrees(projectId, {
         updateSelection: false,
       });
-      if (!didRefresh) {
+      if (!didRefreshWorktrees) {
+        return;
+      }
+      const didRefreshChats = await refreshChats(projectId, {
+        updateSelection: false,
+      });
+      if (!didRefreshChats) {
         return;
       }
       if (workspaceSelectionKeyRef.current !== requestWorkspaceSelectionKey) {
@@ -1496,11 +1579,16 @@ export function HomeRoute() {
         input: deleteWorktreeInput,
       });
       void queryClient.invalidateQueries({
-        queryKey: queryKeys.projectData(projectId, true),
+        queryKey: queryKeys.projectWorktrees(projectId),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.projectChats(projectId),
       });
       closeDeleteWorktreeDialog();
+      await refreshWorktrees(projectId, {
+        updateSelection: selectedProjectIdRef.current === projectId,
+      });
       await refreshChats(projectId, {
-        sync: true,
         updateSelection: selectedProjectIdRef.current === projectId,
       });
     } catch (err) {
@@ -1529,10 +1617,15 @@ export function HomeRoute() {
         },
       });
       void queryClient.invalidateQueries({
-        queryKey: queryKeys.projectData(projectId, true),
+        queryKey: queryKeys.projectWorktrees(projectId),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.projectChats(projectId),
+      });
+      await refreshWorktrees(projectId, {
+        updateSelection: selectedProjectIdRef.current === projectId,
       });
       await refreshChats(projectId, {
-        sync: true,
         updateSelection: selectedProjectIdRef.current === projectId,
       });
     } catch (err) {
@@ -1909,7 +2002,7 @@ export function HomeRoute() {
                                 const isWorktreeExpanded =
                                   expandedWorktreeKeys.has(worktreeKey);
                                 const isChatListLoading =
-                                  loadingProjectIds.has(project.id) &&
+                                  loadingChatProjectIds.has(project.id) &&
                                   worktreeChats.length === 0;
                                 const title = `${worktree.name} (${worktree.path})${
                                   worktree.isClean ? "" : " [dirty]"


### PR DESCRIPTION
## Summary
- Split serve project data loading so projects and worktrees can render independently from chat/history loading.
- Use Codex `thread/list` metadata with `useStateDbOnly` and explicit `sourceKinds` for chat lists, then call `thread/read` lazily only when messages are opened.
- Keep local runtime messages and worktree/chat UI merges correct while avoiding eager Codex history scans.

## Review fixes
- Include `appServer` Codex threads in list calls so Phantom-created chats are not omitted.
- Preserve repeated pending messages by deduping local messages only when a matching Codex message can represent the same local turn.
- Prune stale per-project chat/worktree state and validate selected chats against the refreshed project list.
- Update frontend worktree/chat state from latest refs to handle out-of-order fetch completion.

## Verification
- `pnpm --filter @phantompane/server test` (`74 passed`)
- `pnpm --filter @phantompane/web test` (`22 passed`)
- `pnpm --filter @phantompane/server typecheck`
- `pnpm --filter @phantompane/web typecheck`
- `pnpm ready`
- Local serve smoke check with API on `127.0.0.1:9760` and web dev server on `127.0.0.1:3001`:
  - `GET /api/health` returned 200.
  - `GET /api/projects`, `GET /api/projects/:id/worktrees`, and `GET /api/projects/:id/chats` returned 200.
  - Web proxy requests for worktrees and chats returned 200, with worktrees loading independently from chats.