### PR TITLE
[codex] add web dark mode support

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -125,6 +125,125 @@ Primitive colors should not be used directly in components. Map them through sem
 }
 ```
 
+### Dark Mode
+
+Product surfaces must support both light and dark themes through the same
+purpose-based tokens. Components should not branch on theme or use primitive
+colors directly for foregrounds, backgrounds, status dots, skeletons, or
+scrollbars.
+
+Theme activation should follow this order:
+
+- Default to the light token set in `:root`.
+- Respect the system preference with `@media (prefers-color-scheme: dark)`.
+- Allow explicit overrides through `data-theme="light"` and
+  `data-theme="dark"` on the document root for future settings surfaces.
+
+Dark mode should remain quiet and low-saturation. It should not become a high
+contrast black UI; use charcoal surfaces, soft dividers, and muted semantic
+tones that remain readable during long sessions.
+
+Recommended dark token values:
+
+```css
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --surface-window: #15171b;
+    --surface-sidebar: #1a1c21;
+    --surface-panel: #181a1f;
+    --surface-card: #20232a;
+    --surface-code: #1d2026;
+    --surface-input: #20232a;
+    --surface-floating: rgba(32, 35, 42, 0.86);
+    --surface-overlay: rgba(4, 6, 10, 0.62);
+
+    --text-primary: #e6e8ee;
+    --text-secondary: #b3b7c1;
+    --text-tertiary: #858b98;
+    --text-muted: #686f7c;
+    --text-disabled: #565c67;
+
+    --border-subtle: #292d35;
+    --border-default: #353a45;
+    --border-strong: #444a56;
+    --border-focus: #697493;
+    --border-divider: rgba(230, 232, 238, 0.08);
+
+    --semantic-success-bg: #1c2a22;
+    --semantic-success-fg: #85c59b;
+    --semantic-success-border: #3f7b54;
+
+    --semantic-danger-bg: #2e2026;
+    --semantic-danger-fg: #d58ba2;
+    --semantic-danger-border: #8f5164;
+
+    --semantic-warning-bg: #2d271a;
+    --semantic-warning-fg: #d5bd70;
+    --semantic-warning-border: #8e7536;
+
+    --semantic-info-bg: #202537;
+    --semantic-info-fg: #9aa9df;
+    --semantic-info-border: #586a9c;
+
+    --diff-added-bg: #233129;
+    --diff-added-bg-soft: #1c2a22;
+    --diff-added-fg: #85c59b;
+    --diff-added-border: #3f7b54;
+
+    --diff-removed-bg: #34252b;
+    --diff-removed-bg-soft: #2e2026;
+    --diff-removed-fg: #d58ba2;
+    --diff-removed-border: #8f5164;
+
+    --diff-hunk-bg: #28263a;
+    --diff-hunk-fg: #b7abe7;
+    --diff-hunk-border: #645b92;
+
+    --shadow-xs: 0 1px 2px rgba(4, 6, 10, 0.24);
+    --shadow-sm: 0 2px 8px rgba(4, 6, 10, 0.28);
+    --shadow-md: 0 10px 28px rgba(4, 6, 10, 0.36);
+    --shadow-lg: 0 18px 54px rgba(4, 6, 10, 0.48);
+
+    --state-hover-bg: rgba(230, 232, 238, 0.06);
+    --state-pressed-bg: rgba(230, 232, 238, 0.1);
+    --state-selected-bg: rgba(230, 232, 238, 0.08);
+    --state-focus-ring: 0 0 0 3px rgba(132, 149, 210, 0.26);
+
+    --icon-color-default: #9aa0ac;
+    --icon-color-muted: #717987;
+    --icon-color-active: #eef0f4;
+
+    --button-primary-bg: #d9dde6;
+    --button-primary-fg: #171a20;
+    --button-primary-hover-bg: #c8ceda;
+    --button-secondary-bg: #242832;
+    --button-secondary-fg: var(--text-primary);
+    --button-secondary-hover-bg: #2b303a;
+    --button-destructive-bg: #8f5164;
+    --button-destructive-fg: #fdfdfd;
+    --button-destructive-hover-bg: #a96678;
+
+    --brand-mark-bg: #d9dde6;
+    --brand-mark-fg: #171a20;
+    --chat-user-bg: #d9dde6;
+    --chat-user-fg: #171a20;
+    --chat-user-skeleton-bg: rgba(217, 221, 230, 0.14);
+    --skeleton-bg: #2b3039;
+    --scrollbar-thumb: #3f4653;
+    --scrollbar-thumb-hover: #525b6a;
+    --status-archived-dot: #747b89;
+    --status-idle-dot: #9aa0ac;
+
+    color-scheme: dark;
+  }
+}
+```
+
+When a component needs a theme-sensitive value that is not a reusable surface,
+text, border, semantic, diff, or state token, create a component-specific token
+such as `--button-primary-hover-bg`, `--chat-user-bg`,
+`--skeleton-bg`, or `--scrollbar-thumb`.
+
 ### Surface Tokens
 
 ```css

--- a/packages/web/src/components/loading.tsx
+++ b/packages/web/src/components/loading.tsx
@@ -16,7 +16,7 @@ export function Skeleton({ className }: { className?: string }) {
     <span
       aria-hidden="true"
       className={cn(
-        "block animate-pulse rounded-[var(--radius-sm)] bg-[var(--color-gray-200)]",
+        "block animate-pulse rounded-[var(--radius-sm)] bg-[var(--skeleton-bg)]",
         className,
       )}
     />
@@ -153,7 +153,7 @@ function MessageSkeleton({
       className={cn(
         "rounded-[var(--radius-lg)] border px-4 py-3 shadow-[var(--shadow-xs)]",
         align === "right"
-          ? "ml-auto w-[min(78%,34rem)] border-transparent bg-[var(--color-gray-900)]/10"
+          ? "ml-auto w-[min(78%,34rem)] border-transparent bg-[var(--chat-user-skeleton-bg)]"
           : "mr-auto w-[min(82%,42rem)] border-border bg-card",
       )}
     >

--- a/packages/web/src/components/ui/button.tsx
+++ b/packages/web/src/components/ui/button.tsx
@@ -3,14 +3,14 @@ import { cn } from "../../lib/utils";
 
 const variants = {
   default:
-    "bg-primary text-primary-foreground shadow-[var(--shadow-xs)] hover:bg-[var(--color-gray-800)]",
+    "bg-primary text-primary-foreground shadow-[var(--shadow-xs)] hover:bg-[var(--button-primary-hover-bg)]",
   destructive:
-    "bg-destructive text-destructive-foreground shadow-[var(--shadow-xs)] hover:bg-[var(--color-rose-500)] focus-visible:ring-[var(--semantic-danger-border)]/40",
+    "bg-destructive text-destructive-foreground shadow-[var(--shadow-xs)] hover:bg-[var(--button-destructive-hover-bg)] focus-visible:ring-[var(--semantic-danger-border)]/40",
   ghost: "hover:bg-accent hover:text-accent-foreground",
   outline:
     "border border-input bg-[var(--surface-card)] shadow-[var(--shadow-xs)] hover:bg-accent hover:text-accent-foreground",
   secondary:
-    "bg-secondary text-secondary-foreground shadow-[var(--shadow-xs)] hover:bg-[var(--color-gray-150)]",
+    "bg-secondary text-secondary-foreground shadow-[var(--shadow-xs)] hover:bg-[var(--button-secondary-hover-bg)]",
 } as const;
 
 const sizes = {

--- a/packages/web/src/routes/home.tsx
+++ b/packages/web/src/routes/home.tsx
@@ -155,7 +155,7 @@ const statusMeta: Record<
 > = {
   archived: {
     badge: "secondary",
-    dot: "bg-[var(--color-gray-400)]",
+    dot: "bg-[var(--status-archived-dot)]",
     label: "Archived",
   },
   failed: {
@@ -165,7 +165,7 @@ const statusMeta: Record<
   },
   idle: {
     badge: "secondary",
-    dot: "bg-[var(--color-gray-500)]",
+    dot: "bg-[var(--status-idle-dot)]",
     label: "Idle",
   },
   running: {
@@ -1774,7 +1774,7 @@ export function HomeRoute() {
     <SidebarProvider className="app-shell">
       <Sidebar collapsible="offcanvas" variant="inset">
         <SidebarHeader>
-          <div className="flex size-8 shrink-0 items-center justify-center rounded-[var(--radius-sm)] bg-[var(--color-gray-900)] text-primary-foreground">
+          <div className="flex size-8 shrink-0 items-center justify-center rounded-[var(--radius-sm)] bg-[var(--brand-mark-bg)] text-[var(--brand-mark-fg)]">
             <FolderGit2 className="size-4" />
           </div>
           <div className="min-w-0 flex-1 group-data-[state=collapsed]/sidebar:hidden">
@@ -2142,7 +2142,7 @@ export function HomeRoute() {
                 Branch handling
               </Label>
               <select
-                className="h-9 rounded-[var(--radius-sm)] border border-input bg-background px-3 text-[length:var(--font-size-sm)] shadow-xs outline-none transition-[border-color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50"
+                className="h-9 rounded-[var(--radius-sm)] border border-input bg-[var(--surface-input)] px-3 text-[length:var(--font-size-sm)] shadow-[var(--shadow-xs)] outline-none transition-[border-color,box-shadow] focus-visible:border-ring focus-visible:shadow-[var(--state-focus-ring)] disabled:cursor-not-allowed disabled:opacity-[var(--opacity-disabled)]"
                 id="delete-worktree-branch-mode"
                 onChange={(event) =>
                   setDeleteWorktreeBranchMode(
@@ -2708,7 +2708,7 @@ function MessageCard({ message }: { message: VisibleMessageRecord }) {
     <article
       className={cn(
         isUser &&
-          "ml-auto max-w-[78%] rounded-[var(--radius-lg)] border border-transparent bg-[var(--color-gray-900)] px-4 py-3 text-primary-foreground shadow-[var(--shadow-xs)]",
+          "ml-auto max-w-[78%] rounded-[var(--radius-lg)] border border-transparent bg-[var(--chat-user-bg)] px-4 py-3 text-[var(--chat-user-fg)] shadow-[var(--shadow-xs)]",
         message.role === "assistant" &&
           "mr-auto max-w-[82%] px-2 py-1 text-[var(--text-primary)]",
         isError &&

--- a/packages/web/src/styles.css
+++ b/packages/web/src/styles.css
@@ -169,22 +169,42 @@
   --icon-color-muted: #a9adb6;
   --icon-color-active: #343844;
 
+  --button-primary-bg: var(--color-gray-900);
+  --button-primary-fg: var(--color-white);
+  --button-primary-hover-bg: var(--color-gray-800);
+  --button-secondary-bg: var(--color-gray-100);
+  --button-secondary-fg: var(--text-primary);
+  --button-secondary-hover-bg: var(--color-gray-150);
+  --button-destructive-bg: var(--semantic-danger-fg);
+  --button-destructive-fg: var(--color-white);
+  --button-destructive-hover-bg: var(--color-rose-500);
+  --brand-mark-bg: var(--color-gray-900);
+  --brand-mark-fg: var(--color-white);
+  --chat-user-bg: var(--color-gray-900);
+  --chat-user-fg: var(--color-white);
+  --chat-user-skeleton-bg: rgba(31, 35, 48, 0.1);
+  --skeleton-bg: var(--color-gray-200);
+  --scrollbar-thumb: var(--color-gray-300);
+  --scrollbar-thumb-hover: var(--color-gray-400);
+  --status-archived-dot: var(--color-gray-400);
+  --status-idle-dot: var(--color-gray-500);
+
   --background: var(--surface-window);
   --foreground: var(--text-primary);
   --card: var(--surface-card);
   --card-foreground: var(--text-primary);
   --popover: var(--surface-floating);
   --popover-foreground: var(--text-primary);
-  --primary: var(--color-gray-900);
-  --primary-foreground: var(--color-white);
-  --secondary: var(--color-gray-100);
-  --secondary-foreground: var(--text-primary);
+  --primary: var(--button-primary-bg);
+  --primary-foreground: var(--button-primary-fg);
+  --secondary: var(--button-secondary-bg);
+  --secondary-foreground: var(--button-secondary-fg);
   --muted: var(--surface-panel);
   --muted-foreground: var(--text-secondary);
   --accent: var(--state-hover-bg);
   --accent-foreground: var(--text-primary);
-  --destructive: var(--semantic-danger-fg);
-  --destructive-foreground: var(--color-white);
+  --destructive: var(--button-destructive-bg);
+  --destructive-foreground: var(--button-destructive-fg);
   --border: var(--border-default);
   --input: var(--border-default);
   --ring: var(--border-focus);
@@ -198,6 +218,197 @@
   font-family: var(--font-sans);
   background: var(--surface-window);
   color: var(--text-primary);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --surface-window: #15171b;
+    --surface-sidebar: #1a1c21;
+    --surface-panel: #181a1f;
+    --surface-card: #20232a;
+    --surface-code: #1d2026;
+    --surface-input: #20232a;
+    --surface-floating: rgba(32, 35, 42, 0.86);
+    --surface-overlay: rgba(4, 6, 10, 0.62);
+
+    --text-primary: #e6e8ee;
+    --text-secondary: #b3b7c1;
+    --text-tertiary: #858b98;
+    --text-muted: #686f7c;
+    --text-disabled: #565c67;
+
+    --text-link: #9aa9df;
+    --text-success: #85c59b;
+    --text-danger: #d58ba2;
+    --text-warning: #d5bd70;
+
+    --border-subtle: #292d35;
+    --border-default: #353a45;
+    --border-strong: #444a56;
+    --border-focus: #697493;
+    --border-divider: rgba(230, 232, 238, 0.08);
+
+    --semantic-success-bg: #1c2a22;
+    --semantic-success-fg: #85c59b;
+    --semantic-success-border: #3f7b54;
+
+    --semantic-danger-bg: #2e2026;
+    --semantic-danger-fg: #d58ba2;
+    --semantic-danger-border: #8f5164;
+
+    --semantic-warning-bg: #2d271a;
+    --semantic-warning-fg: #d5bd70;
+    --semantic-warning-border: #8e7536;
+
+    --semantic-info-bg: #202537;
+    --semantic-info-fg: #9aa9df;
+    --semantic-info-border: #586a9c;
+
+    --diff-added-bg: #233129;
+    --diff-added-bg-soft: #1c2a22;
+    --diff-added-fg: #85c59b;
+    --diff-added-border: #3f7b54;
+
+    --diff-removed-bg: #34252b;
+    --diff-removed-bg-soft: #2e2026;
+    --diff-removed-fg: #d58ba2;
+    --diff-removed-border: #8f5164;
+
+    --diff-hunk-bg: #28263a;
+    --diff-hunk-fg: #b7abe7;
+    --diff-hunk-border: #645b92;
+
+    --shadow-xs: 0 1px 2px rgba(4, 6, 10, 0.24);
+    --shadow-sm: 0 2px 8px rgba(4, 6, 10, 0.28);
+    --shadow-md: 0 10px 28px rgba(4, 6, 10, 0.36);
+    --shadow-lg: 0 18px 54px rgba(4, 6, 10, 0.48);
+
+    --state-hover-bg: rgba(230, 232, 238, 0.06);
+    --state-pressed-bg: rgba(230, 232, 238, 0.1);
+    --state-selected-bg: rgba(230, 232, 238, 0.08);
+    --state-focus-ring: 0 0 0 3px rgba(132, 149, 210, 0.26);
+
+    --icon-color-default: #9aa0ac;
+    --icon-color-muted: #717987;
+    --icon-color-active: #eef0f4;
+
+    --button-primary-bg: #d9dde6;
+    --button-primary-fg: #171a20;
+    --button-primary-hover-bg: #c8ceda;
+    --button-secondary-bg: #242832;
+    --button-secondary-fg: var(--text-primary);
+    --button-secondary-hover-bg: #2b303a;
+    --button-destructive-bg: #8f5164;
+    --button-destructive-fg: #fdfdfd;
+    --button-destructive-hover-bg: #a96678;
+    --brand-mark-bg: #d9dde6;
+    --brand-mark-fg: #171a20;
+    --chat-user-bg: #d9dde6;
+    --chat-user-fg: #171a20;
+    --chat-user-skeleton-bg: rgba(217, 221, 230, 0.14);
+    --skeleton-bg: #2b3039;
+    --scrollbar-thumb: #3f4653;
+    --scrollbar-thumb-hover: #525b6a;
+    --status-archived-dot: #747b89;
+    --status-idle-dot: #9aa0ac;
+
+    color-scheme: dark;
+  }
+}
+
+:root[data-theme="dark"],
+[data-theme="dark"] {
+  --surface-window: #15171b;
+  --surface-sidebar: #1a1c21;
+  --surface-panel: #181a1f;
+  --surface-card: #20232a;
+  --surface-code: #1d2026;
+  --surface-input: #20232a;
+  --surface-floating: rgba(32, 35, 42, 0.86);
+  --surface-overlay: rgba(4, 6, 10, 0.62);
+
+  --text-primary: #e6e8ee;
+  --text-secondary: #b3b7c1;
+  --text-tertiary: #858b98;
+  --text-muted: #686f7c;
+  --text-disabled: #565c67;
+
+  --text-link: #9aa9df;
+  --text-success: #85c59b;
+  --text-danger: #d58ba2;
+  --text-warning: #d5bd70;
+
+  --border-subtle: #292d35;
+  --border-default: #353a45;
+  --border-strong: #444a56;
+  --border-focus: #697493;
+  --border-divider: rgba(230, 232, 238, 0.08);
+
+  --semantic-success-bg: #1c2a22;
+  --semantic-success-fg: #85c59b;
+  --semantic-success-border: #3f7b54;
+
+  --semantic-danger-bg: #2e2026;
+  --semantic-danger-fg: #d58ba2;
+  --semantic-danger-border: #8f5164;
+
+  --semantic-warning-bg: #2d271a;
+  --semantic-warning-fg: #d5bd70;
+  --semantic-warning-border: #8e7536;
+
+  --semantic-info-bg: #202537;
+  --semantic-info-fg: #9aa9df;
+  --semantic-info-border: #586a9c;
+
+  --diff-added-bg: #233129;
+  --diff-added-bg-soft: #1c2a22;
+  --diff-added-fg: #85c59b;
+  --diff-added-border: #3f7b54;
+
+  --diff-removed-bg: #34252b;
+  --diff-removed-bg-soft: #2e2026;
+  --diff-removed-fg: #d58ba2;
+  --diff-removed-border: #8f5164;
+
+  --diff-hunk-bg: #28263a;
+  --diff-hunk-fg: #b7abe7;
+  --diff-hunk-border: #645b92;
+
+  --shadow-xs: 0 1px 2px rgba(4, 6, 10, 0.24);
+  --shadow-sm: 0 2px 8px rgba(4, 6, 10, 0.28);
+  --shadow-md: 0 10px 28px rgba(4, 6, 10, 0.36);
+  --shadow-lg: 0 18px 54px rgba(4, 6, 10, 0.48);
+
+  --state-hover-bg: rgba(230, 232, 238, 0.06);
+  --state-pressed-bg: rgba(230, 232, 238, 0.1);
+  --state-selected-bg: rgba(230, 232, 238, 0.08);
+  --state-focus-ring: 0 0 0 3px rgba(132, 149, 210, 0.26);
+
+  --icon-color-default: #9aa0ac;
+  --icon-color-muted: #717987;
+  --icon-color-active: #eef0f4;
+
+  --button-primary-bg: #d9dde6;
+  --button-primary-fg: #171a20;
+  --button-primary-hover-bg: #c8ceda;
+  --button-secondary-bg: #242832;
+  --button-secondary-fg: var(--text-primary);
+  --button-secondary-hover-bg: #2b303a;
+  --button-destructive-bg: #8f5164;
+  --button-destructive-fg: #fdfdfd;
+  --button-destructive-hover-bg: #a96678;
+  --brand-mark-bg: #d9dde6;
+  --brand-mark-fg: #171a20;
+  --chat-user-bg: #d9dde6;
+  --chat-user-fg: #171a20;
+  --chat-user-skeleton-bg: rgba(217, 221, 230, 0.14);
+  --skeleton-bg: #2b3039;
+  --scrollbar-thumb: #3f4653;
+  --scrollbar-thumb-hover: #525b6a;
+  --status-archived-dot: #747b89;
+  --status-idle-dot: #9aa0ac;
+
+  color-scheme: dark;
 }
 
 @theme inline {
@@ -301,14 +512,14 @@ textarea {
 }
 
 ::-webkit-scrollbar-thumb {
-  background: var(--color-gray-300);
+  background: var(--scrollbar-thumb);
   border: 3px solid transparent;
   border-radius: var(--radius-pill);
   background-clip: padding-box;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: var(--color-gray-400);
+  background: var(--scrollbar-thumb-hover);
   border: 3px solid transparent;
   background-clip: padding-box;
 }


### PR DESCRIPTION
## Summary

- Document dark mode guidance and token expectations in `DESIGN.md`.
- Add system-preference and explicit `data-theme` dark token support for `packages/web`.
- Replace light-mode primitive color usage in web UI components with purpose-based tokens.

## Impact

The web UI now follows the Phantom design system in both light and dark system themes while keeping component styles tied to semantic and component-specific tokens.

## Validation

- `pnpm ready`
- Headless Chromium screenshots for light and dark rendering
- `git diff --check`