### PR TITLE
[codex] support queue and steer chat sends

### DIFF
--- a/packages/server/src/rpc.ts
+++ b/packages/server/src/rpc.ts
@@ -37,9 +37,8 @@ const sendMessageSchema = z.object({
   skills: z.array(contextItemSchema).optional(),
 });
 
-const steerMessageSchema = z.object({
-  text: z.string().min(1, "Message text is required"),
-});
+const steerMessageSchema = sendMessageSchema;
+const queueMessageSchema = sendMessageSchema;
 
 const approvalSchema = z.object({
   decision: z.enum(["accept", "acceptForSession", "decline", "cancel"]),
@@ -306,6 +305,28 @@ export const rpcRoutes = new Hono()
       const chat = await getServeServices().steerMessage(
         c.req.param("chatId"),
         {
+          effort: optionalString(body.effort),
+          files: contextItems(body.files),
+          model: optionalString(body.model),
+          skills: contextItems(body.skills),
+          text: body.text,
+        },
+      );
+      return c.json({ chat }, 200);
+    } catch (error) {
+      return handleApiError(c, error);
+    }
+  })
+  .post("/chats/:chatId/queue", jsonBody(queueMessageSchema), async (c) => {
+    try {
+      const body = c.req.valid("json");
+      const chat = await getServeServices().queueMessage(
+        c.req.param("chatId"),
+        {
+          effort: optionalString(body.effort),
+          files: contextItems(body.files),
+          model: optionalString(body.model),
+          skills: contextItems(body.skills),
           text: body.text,
         },
       );

--- a/packages/server/src/services.test.ts
+++ b/packages/server/src/services.test.ts
@@ -132,6 +132,7 @@ function createTestState(overrides: Partial<ServeState> = {}): ServeState {
     projects: [],
     chats: [],
     messages: [],
+    queuedMessages: [],
     selectedProjectId: null,
     selectedChatId: null,
     ...overrides,
@@ -140,6 +141,7 @@ function createTestState(overrides: Partial<ServeState> = {}): ServeState {
 
 async function createHarness(state: ServeState): Promise<{
   codex: FakeCodexBridge;
+  codexHome: string;
   services: ServeServices;
   store: ServeStateStore;
 }> {
@@ -152,7 +154,7 @@ async function createHarness(state: ServeState): Promise<{
     codexHome,
     store,
   });
-  return { codex, services, store };
+  return { codex, codexHome, services, store };
 }
 
 function markChatActiveInCurrentProcess(
@@ -1168,6 +1170,69 @@ describe("ServeServices", () => {
     );
   });
 
+  it("preserves queued chats when syncing Codex thread metadata", async () => {
+    const worktreePath = "/repo/.git/phantom/worktrees/worktree";
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [
+        createChat({
+          codexThreadId: null,
+          worktreeName: "worktree",
+          worktreePath,
+          branchName: "worktree",
+        }),
+      ],
+      messages: [
+        {
+          id: "msg_queued",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "queued while pending",
+          eventType: "chat.message.queued",
+          createdAt: timestamp,
+        },
+      ],
+      queuedMessages: [
+        {
+          id: "queue_1",
+          chatId: "chat_1",
+          messageId: "msg_queued",
+          text: "queued while pending",
+          createdAt: timestamp,
+        },
+      ],
+      selectedChatId: "chat_1",
+    };
+    const { codex, services, store } = await createHarness(state);
+    coreMocks.listWorktrees.mockResolvedValueOnce({
+      ok: true,
+      value: {
+        worktrees: [
+          {
+            name: "main",
+            path: "/repo",
+            pathToDisplay: ".",
+            branch: "main",
+            isClean: true,
+          },
+        ],
+      },
+    });
+    codex.listThreads.mockResolvedValueOnce({ threads: [] });
+
+    const chats = await services.listChats("proj_1");
+
+    strictEqual(chats[0]?.id, "chat_1");
+    const savedState = await store.load();
+    strictEqual(savedState.chats.length, 1);
+    strictEqual(savedState.chats[0]?.id, "chat_1");
+    strictEqual(savedState.chats[0]?.codexThreadId, null);
+    strictEqual(savedState.queuedMessages[0]?.text, "queued while pending");
+    strictEqual(savedState.messages[0]?.text, "queued while pending");
+    strictEqual(savedState.selectedChatId, "chat_1");
+  });
+
   it("adds distinct Codex threads when a failed local chat exists for the same worktree", async () => {
     const failedThreadId = "019dc000-0000-7000-8000-000000000001";
     const importedThreadId = "019dc000-0000-7000-8000-000000000002";
@@ -1668,6 +1733,75 @@ describe("ServeServices", () => {
     ]);
   });
 
+  it("keeps a worktree busy until all overlapping syncs finish", async () => {
+    const worktreePath = "/repo/.git/phantom/worktrees/worktree";
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [
+        createChat({
+          worktreeName: "worktree",
+          worktreePath,
+        }),
+      ],
+    };
+    const { codex, services } = await createHarness(state);
+    coreMocks.createContext.mockResolvedValue({
+      gitRoot: "/repo",
+      worktreesDirectory: "/repo/.git/phantom/worktrees",
+      preferences: {},
+      config: {},
+    });
+    coreMocks.listWorktrees.mockResolvedValue({
+      ok: true,
+      value: {
+        worktrees: [
+          {
+            name: "worktree",
+            path: worktreePath,
+            pathToDisplay: ".git/phantom/worktrees/worktree",
+            branch: "worktree",
+            isClean: true,
+          },
+        ],
+      },
+    });
+    gitMocks.getUpstreamBranch.mockResolvedValue("origin/worktree");
+    gitMocks.getRemotes.mockResolvedValue(["origin"]);
+    const resolvePulls: Array<() => void> = [];
+    gitMocks.pull.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvePulls.push(() => resolve({ ok: true, value: undefined }));
+        }),
+    );
+
+    const firstSync = services.syncProjectWorktreeBranch("proj_1", {
+      name: "worktree",
+    });
+    await vi.waitFor(() => {
+      strictEqual(gitMocks.pull.mock.calls.length, 1);
+    });
+    const secondSync = services.syncProjectWorktreeBranch("proj_1", {
+      name: "worktree",
+    });
+    await vi.waitFor(() => {
+      strictEqual(gitMocks.pull.mock.calls.length, 2);
+    });
+
+    resolvePulls[0]!();
+    await firstSync;
+
+    await rejects(
+      services.sendMessage("chat_1", { text: "during second sync" }),
+      /busy/,
+    );
+    strictEqual(codex.startTurn.mock.calls.length, 0);
+
+    resolvePulls[1]!();
+    await secondSync;
+  });
+
   it.each([
     {
       description: "running",
@@ -1686,6 +1820,11 @@ describe("ServeServices", () => {
       chat: {},
       markPending: true,
     },
+    {
+      description: "queued message",
+      chat: {},
+      hasQueuedMessage: true,
+    },
   ])("does not sync a worktree with a $description chat", async (scenario) => {
     const worktreePath = "/repo/.git/phantom/worktrees/worktree";
     const state = {
@@ -1698,13 +1837,24 @@ describe("ServeServices", () => {
           worktreePath,
         }),
       ],
+      queuedMessages: scenario.hasQueuedMessage
+        ? [
+            {
+              id: "queue_1",
+              chatId: "chat_1",
+              messageId: "msg_queued",
+              text: "queued before sync",
+              createdAt: timestamp,
+            },
+          ]
+        : [],
     };
     const { services } = await createHarness(state);
     if (scenario.markPending) {
       (
         services as unknown as { pendingChatTurns: Set<string> }
       ).pendingChatTurns.add("chat_1");
-    } else {
+    } else if (!scenario.hasQueuedMessage) {
       markChatActiveInCurrentProcess(services, "chat_1");
     }
     coreMocks.createContext.mockResolvedValueOnce({
@@ -1734,6 +1884,78 @@ describe("ServeServices", () => {
     );
 
     strictEqual(gitMocks.pull.mock.calls.length, 0);
+  });
+
+  it("does not sync when a queued message appears after sync starts", async () => {
+    const worktreePath = "/repo/.git/phantom/worktrees/worktree";
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [
+        createChat({
+          worktreeName: "worktree",
+          worktreePath,
+        }),
+      ],
+    };
+    const { services, store } = await createHarness(state);
+    coreMocks.createContext.mockResolvedValueOnce({
+      gitRoot: "/repo",
+      worktreesDirectory: "/repo/.git/phantom/worktrees",
+      preferences: {},
+      config: {},
+    });
+    coreMocks.listWorktrees.mockImplementationOnce(async () => {
+      await store.update((currentState) => ({
+        ...currentState,
+        messages: [
+          ...currentState.messages,
+          {
+            id: "msg_queued",
+            chatId: "chat_1",
+            role: "user" as const,
+            text: "queued during sync",
+            eventType: "chat.message.queued",
+            createdAt: timestamp,
+          },
+        ],
+        queuedMessages: [
+          ...currentState.queuedMessages,
+          {
+            id: "queue_1",
+            chatId: "chat_1",
+            messageId: "msg_queued",
+            text: "queued during sync",
+            createdAt: timestamp,
+          },
+        ],
+      }));
+      return {
+        ok: true,
+        value: {
+          worktrees: [
+            {
+              name: "worktree",
+              path: worktreePath,
+              pathToDisplay: ".git/phantom/worktrees/worktree",
+              branch: "worktree",
+              isClean: true,
+            },
+          ],
+        },
+      };
+    });
+
+    await rejects(
+      services.syncProjectWorktreeBranch("proj_1", { name: "worktree" }),
+      /has an active chat/,
+    );
+
+    strictEqual(gitMocks.pull.mock.calls.length, 0);
+    strictEqual(
+      (await store.load()).queuedMessages[0]?.text,
+      "queued during sync",
+    );
   });
 
   it("deletes a project worktree and removes its local chat history", async () => {
@@ -2138,6 +2360,135 @@ describe("ServeServices", () => {
     );
 
     strictEqual(coreMocks.deleteWorktree.mock.calls.length, 0);
+  });
+
+  it("does not delete a worktree with queued messages", async () => {
+    const worktreePath = "/repo/.git/phantom/worktrees/worktree";
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [
+        createChat({
+          branchName: "old-name",
+          worktreeName: "old-name",
+          worktreePath,
+        }),
+      ],
+      queuedMessages: [
+        {
+          id: "queue_1",
+          chatId: "chat_1",
+          messageId: "msg_queued",
+          text: "queued before delete",
+          createdAt: timestamp,
+        },
+      ],
+    };
+    const { services, store } = await createHarness(state);
+    coreMocks.createContext.mockResolvedValueOnce({
+      gitRoot: "/repo",
+      worktreesDirectory: "/repo/.git/phantom/worktrees",
+      preferences: {},
+      config: {},
+    });
+    coreMocks.listWorktrees.mockResolvedValueOnce({
+      ok: true,
+      value: {
+        worktrees: [
+          {
+            name: "worktree",
+            path: worktreePath,
+            pathToDisplay: ".git/phantom/worktrees/worktree",
+            branch: "worktree",
+            isClean: true,
+          },
+        ],
+      },
+    });
+
+    await rejects(
+      services.deleteProjectWorktree("proj_1", { name: "worktree" }),
+      /has an active chat/,
+    );
+
+    strictEqual(coreMocks.deleteWorktree.mock.calls.length, 0);
+    strictEqual(
+      (await store.load()).queuedMessages[0]?.text,
+      "queued before delete",
+    );
+  });
+
+  it("does not delete when a queued message appears after delete starts", async () => {
+    const worktreePath = "/repo/.git/phantom/worktrees/worktree";
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [
+        createChat({
+          branchName: "old-name",
+          worktreeName: "old-name",
+          worktreePath,
+        }),
+      ],
+    };
+    const { services, store } = await createHarness(state);
+    coreMocks.createContext.mockResolvedValueOnce({
+      gitRoot: "/repo",
+      worktreesDirectory: "/repo/.git/phantom/worktrees",
+      preferences: {},
+      config: {},
+    });
+    coreMocks.listWorktrees.mockImplementationOnce(async () => {
+      await store.update((currentState) => ({
+        ...currentState,
+        messages: [
+          ...currentState.messages,
+          {
+            id: "msg_queued",
+            chatId: "chat_1",
+            role: "user" as const,
+            text: "queued during delete",
+            eventType: "chat.message.queued",
+            createdAt: timestamp,
+          },
+        ],
+        queuedMessages: [
+          ...currentState.queuedMessages,
+          {
+            id: "queue_1",
+            chatId: "chat_1",
+            messageId: "msg_queued",
+            text: "queued during delete",
+            createdAt: timestamp,
+          },
+        ],
+      }));
+      return {
+        ok: true,
+        value: {
+          worktrees: [
+            {
+              name: "worktree",
+              path: worktreePath,
+              pathToDisplay: ".git/phantom/worktrees/worktree",
+              branch: "worktree",
+              isClean: true,
+            },
+          ],
+        },
+      };
+    });
+
+    await rejects(
+      services.deleteProjectWorktree("proj_1", { name: "worktree" }),
+      /has an active chat/,
+    );
+
+    strictEqual(coreMocks.deleteWorktree.mock.calls.length, 0);
+    strictEqual(
+      (await store.load()).queuedMessages[0]?.text,
+      "queued during delete",
+    );
   });
 
   it("does not delete a worktree while a chat is starting a turn", async () => {
@@ -3014,6 +3365,645 @@ describe("ServeServices", () => {
     const savedState = await store.load();
     strictEqual(savedState.messages.length, 0);
     strictEqual(savedState.chats[0]?.status, "idle");
+    strictEqual(codex.startTurn.mock.calls.length, 0);
+    strictEqual(codex.steerTurn.mock.calls.length, 0);
+  });
+
+  it("queues a message while a chat is running and starts it after the active turn completes", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "running", activeTurnId: "turn_1" })],
+    };
+    const { codex, services, store } = await createHarness(state);
+    markChatActiveInCurrentProcess(services, "chat_1");
+    codex.resumeThread.mockResolvedValueOnce({});
+    codex.startTurn.mockResolvedValueOnce({ turn: { id: "turn_2" } });
+
+    await services.queueMessage("chat_1", { text: "follow up next" });
+
+    let savedState = await store.load();
+    strictEqual(savedState.messages[0]?.text, "follow up next");
+    strictEqual(savedState.queuedMessages[0]?.text, "follow up next");
+    strictEqual(savedState.chats[0]?.status, "running");
+    strictEqual(savedState.chats[0]?.activeTurnId, "turn_1");
+    strictEqual(codex.startTurn.mock.calls.length, 0);
+    strictEqual(codex.steerTurn.mock.calls.length, 0);
+
+    codex.emitNotification({
+      method: "turn/completed",
+      params: {
+        threadId: "thread_1",
+        turn: { id: "turn_1", status: "completed" },
+      },
+    });
+
+    await vi.waitFor(() => {
+      strictEqual(codex.startTurn.mock.calls.length, 1);
+    });
+    deepStrictEqual(codex.startTurn.mock.calls[0], [
+      "thread_1",
+      "follow up next",
+      "/repo/.git/phantom/worktrees/worktree",
+    ]);
+    savedState = await store.load();
+    strictEqual(savedState.queuedMessages.length, 0);
+    strictEqual(savedState.chats[0]?.status, "running");
+    strictEqual(savedState.chats[0]?.activeTurnId, "turn_2");
+    deepStrictEqual(
+      savedState.messages
+        .filter((message) => message.role === "user")
+        .map((message) => message.text),
+      ["follow up next"],
+    );
+  });
+
+  it("starts immediately when an active turn completes before the queue update is serialized", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "running", activeTurnId: "turn_1" })],
+    };
+    const store = new ImportRaceStore(
+      await createTemporaryDirectory(),
+      (currentState) => ({
+        ...currentState,
+        chats: currentState.chats.map((chat) =>
+          chat.id === "chat_1"
+            ? { ...chat, status: "idle", activeTurnId: null }
+            : chat,
+        ),
+      }),
+    );
+    await store.save(state);
+    const codex = new FakeCodexBridge();
+    const services = new ServeServices({
+      codex: codex as unknown as CodexBridge,
+      codexHome: await createTemporaryDirectory(),
+      store,
+    });
+    markChatActiveInCurrentProcess(services, "chat_1");
+    codex.resumeThread.mockResolvedValueOnce({});
+    codex.startTurn.mockResolvedValueOnce({ turn: { id: "turn_2" } });
+
+    await services.queueMessage("chat_1", { text: "race follow up" });
+
+    const savedState = await store.load();
+    strictEqual(savedState.queuedMessages.length, 0);
+    strictEqual(savedState.chats[0]?.status, "running");
+    strictEqual(savedState.chats[0]?.activeTurnId, "turn_2");
+    deepStrictEqual(
+      savedState.messages
+        .filter((message) => message.role === "user")
+        .map((message) => message.text),
+      ["race follow up"],
+    );
+    deepStrictEqual(codex.startTurn.mock.calls[0], [
+      "thread_1",
+      "race follow up",
+      "/repo/.git/phantom/worktrees/worktree",
+    ]);
+  });
+
+  it("queues messages while a new turn is pending but not yet persisted as running", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "idle", activeTurnId: null })],
+    };
+    const { codex, services, store } = await createHarness(state);
+    (
+      services as unknown as { pendingChatTurns: Set<string> }
+    ).pendingChatTurns.add("chat_1");
+
+    await services.queueMessage("chat_1", { text: "during pending start" });
+
+    const savedState = await store.load();
+    strictEqual(savedState.messages[0]?.text, "during pending start");
+    strictEqual(savedState.queuedMessages[0]?.text, "during pending start");
+    strictEqual(savedState.chats[0]?.status, "idle");
+    strictEqual(codex.startTurn.mock.calls.length, 0);
+    strictEqual(codex.steerTurn.mock.calls.length, 0);
+  });
+
+  it("queues messages while a new turn is normalizing context before starting", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "idle", activeTurnId: null })],
+    };
+    const { codex, services, store } = await createHarness(state);
+    let resolveSkills!: (value: unknown) => void;
+    codex.listSkills.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveSkills = resolve;
+        }),
+    );
+    codex.resumeThread.mockResolvedValueOnce({});
+    codex.startTurn.mockResolvedValueOnce({ turn: { id: "turn_1" } });
+
+    const firstSend = services.sendMessage("chat_1", {
+      skills: [{ name: "review", path: "/skills/review/SKILL.md" }],
+      text: "start with skill",
+    });
+    await vi.waitFor(() => {
+      strictEqual(codex.listSkills.mock.calls.length, 1);
+    });
+
+    await services.queueMessage("chat_1", {
+      text: "queued during context normalization",
+    });
+
+    let savedState = await store.load();
+    strictEqual(
+      savedState.queuedMessages[0]?.text,
+      "queued during context normalization",
+    );
+    strictEqual(codex.startTurn.mock.calls.length, 0);
+
+    resolveSkills({
+      skills: [
+        {
+          enabled: true,
+          name: "review",
+          path: "/skills/review/SKILL.md",
+        },
+      ],
+    });
+    await firstSend;
+
+    savedState = await store.load();
+    strictEqual(savedState.queuedMessages.length, 1);
+    strictEqual(savedState.chats[0]?.status, "running");
+    strictEqual(savedState.chats[0]?.activeTurnId, "turn_1");
+    strictEqual(codex.startTurn.mock.calls.length, 1);
+  });
+
+  it("drains queued messages when a pending new turn fails during context normalization", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "idle", activeTurnId: null })],
+    };
+    const { codex, services, store } = await createHarness(state);
+    let rejectSkills!: (error: Error) => void;
+    codex.listSkills.mockImplementationOnce(
+      () =>
+        new Promise((_, reject) => {
+          rejectSkills = reject;
+        }),
+    );
+    codex.resumeThread.mockResolvedValueOnce({});
+    codex.startTurn.mockResolvedValueOnce({ turn: { id: "turn_1" } });
+
+    const firstSend = services.sendMessage("chat_1", {
+      skills: [{ name: "review", path: "/skills/review/SKILL.md" }],
+      text: "start with invalid skill context",
+    });
+    await vi.waitFor(() => {
+      strictEqual(codex.listSkills.mock.calls.length, 1);
+    });
+
+    await services.queueMessage("chat_1", {
+      text: "queued after failed normalization",
+    });
+    rejectSkills(new Error("skills unavailable"));
+    await rejects(firstSend, /skills unavailable/);
+
+    await vi.waitFor(() => {
+      strictEqual(codex.startTurn.mock.calls.length, 1);
+    });
+    const savedState = await store.load();
+    strictEqual(savedState.queuedMessages.length, 0);
+    strictEqual(savedState.chats[0]?.status, "running");
+    strictEqual(savedState.chats[0]?.activeTurnId, "turn_1");
+    deepStrictEqual(
+      savedState.messages
+        .filter((message) => message.role === "user")
+        .map((message) => message.text),
+      ["queued after failed normalization"],
+    );
+  });
+
+  it("keeps queued messages when a pending new turn fails after starting", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "idle", activeTurnId: null })],
+    };
+    const { codex, services, store } = await createHarness(state);
+    let rejectStart!: (error: Error) => void;
+    codex.resumeThread.mockResolvedValueOnce({});
+    codex.startTurn.mockImplementationOnce(
+      () =>
+        new Promise((_, reject) => {
+          rejectStart = reject;
+        }),
+    );
+
+    const firstSend = services.sendMessage("chat_1", {
+      text: "start but fail",
+    });
+    await vi.waitFor(() => {
+      strictEqual(codex.startTurn.mock.calls.length, 1);
+    });
+
+    await services.queueMessage("chat_1", {
+      text: "queued after rejected start",
+    });
+    rejectStart(new Error("Codex rejected the turn"));
+    await rejects(firstSend, /Codex rejected the turn/);
+
+    const savedState = await store.load();
+    strictEqual(savedState.queuedMessages.length, 1);
+    strictEqual(
+      savedState.queuedMessages[0]?.text,
+      "queued after rejected start",
+    );
+    deepStrictEqual(
+      savedState.messages
+        .filter((message) => message.role === "user")
+        .map((message) => message.text),
+      ["queued after rejected start"],
+    );
+    strictEqual(savedState.messages[0]?.eventType, "chat.message.queued");
+    strictEqual(savedState.chats[0]?.status, "failed");
+    strictEqual(savedState.chats[0]?.activeTurnId, null);
+  });
+
+  it("continues draining when a queued turn completes before buffered events flush", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "running", activeTurnId: "turn_1" })],
+    };
+    const { codex, services, store } = await createHarness(state);
+    markChatActiveInCurrentProcess(services, "chat_1");
+    codex.resumeThread.mockResolvedValueOnce({});
+    codex.startTurn
+      .mockImplementationOnce(async () => {
+        codex.emitNotification({
+          method: "turn/completed",
+          params: {
+            threadId: "thread_1",
+            turn: { id: "turn_2", status: "completed" },
+          },
+        });
+        return { turn: { id: "turn_2" } };
+      })
+      .mockResolvedValueOnce({ turn: { id: "turn_3" } });
+
+    await services.queueMessage("chat_1", { text: "first queued" });
+    await services.queueMessage("chat_1", { text: "second queued" });
+
+    codex.emitNotification({
+      method: "turn/completed",
+      params: {
+        threadId: "thread_1",
+        turn: { id: "turn_1", status: "completed" },
+      },
+    });
+
+    await vi.waitFor(() => {
+      strictEqual(codex.startTurn.mock.calls.length, 2);
+    });
+    strictEqual((await store.load()).queuedMessages.length, 0);
+    strictEqual(codex.startTurn.mock.calls[0]?.[1], "first queued");
+    strictEqual(codex.startTurn.mock.calls[1]?.[1], "second queued");
+  });
+
+  it("serializes overlapping queued drains without reporting contention", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "idle", activeTurnId: null })],
+      messages: [
+        {
+          id: "msg_queued",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "queued once",
+          eventType: "chat.message.queued",
+          createdAt: timestamp,
+        },
+      ],
+      queuedMessages: [
+        {
+          id: "queue_1",
+          chatId: "chat_1",
+          messageId: "msg_queued",
+          text: "queued once",
+          createdAt: timestamp,
+        },
+      ],
+    };
+    const { codex, services, store } = await createHarness(state);
+    const emitSpy = vi.spyOn(services.eventHub, "emit");
+    codex.resumeThread.mockResolvedValueOnce({});
+    let resolveStart!: (value: { turn: { id: string } }) => void;
+    codex.startTurn.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveStart = resolve;
+        }),
+    );
+    const drainQueuedMessagesAndReport = (
+      services as unknown as {
+        drainQueuedMessagesAndReport(chatId: string): Promise<void>;
+      }
+    ).drainQueuedMessagesAndReport.bind(services);
+
+    const firstDrain = drainQueuedMessagesAndReport("chat_1");
+    await vi.waitFor(() => {
+      strictEqual(codex.startTurn.mock.calls.length, 1);
+    });
+    const secondDrain = drainQueuedMessagesAndReport("chat_1");
+
+    await secondDrain;
+    resolveStart({ turn: { id: "turn_2" } });
+    await firstDrain;
+
+    const savedState = await store.load();
+    strictEqual(codex.startTurn.mock.calls.length, 1);
+    strictEqual(savedState.queuedMessages.length, 0);
+    strictEqual(
+      savedState.messages.some((message) => message.role === "error"),
+      false,
+    );
+    strictEqual(
+      emitSpy.mock.calls.some((call) => call[0] === "agent.error"),
+      false,
+    );
+  });
+
+  it("removes queued records when queued turn promotion fails", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "running", activeTurnId: "turn_1" })],
+      messages: [
+        {
+          id: "msg_queued",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "queued failure",
+          eventType: "chat.message.queued",
+          createdAt: timestamp,
+        },
+      ],
+      queuedMessages: [
+        {
+          id: "queue_1",
+          chatId: "chat_1",
+          messageId: "msg_queued",
+          text: "queued failure",
+          createdAt: timestamp,
+        },
+      ],
+    };
+    const { codex, services, store } = await createHarness(state);
+    markChatActiveInCurrentProcess(services, "chat_1");
+    const emitSpy = vi.spyOn(services.eventHub, "emit");
+    codex.resumeThread.mockResolvedValueOnce({});
+    codex.startTurn.mockRejectedValueOnce(new Error("queued start failed"));
+
+    codex.emitNotification({
+      method: "turn/completed",
+      params: {
+        threadId: "thread_1",
+        turn: { id: "turn_1", status: "completed" },
+      },
+    });
+
+    await vi.waitFor(() => {
+      strictEqual(
+        emitSpy.mock.calls.some((call) => call[0] === "agent.error"),
+        true,
+      );
+    });
+    const savedState = await store.load();
+    strictEqual(savedState.queuedMessages.length, 0);
+    strictEqual(savedState.messages[0]?.text, "queued failure");
+    strictEqual(savedState.messages.at(-1)?.role, "error");
+    strictEqual(savedState.messages.at(-1)?.text, "queued start failed");
+    strictEqual(savedState.chats[0]?.status, "failed");
+    strictEqual(savedState.chats[0]?.activeTurnId, null);
+  });
+
+  it("removes queued records when queued turn context normalization fails", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "running", activeTurnId: "turn_1" })],
+      messages: [
+        {
+          id: "msg_queued",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "queued invalid context",
+          eventType: "chat.message.queued",
+          createdAt: timestamp,
+        },
+      ],
+      queuedMessages: [
+        {
+          id: "queue_1",
+          chatId: "chat_1",
+          messageId: "msg_queued",
+          text: "queued invalid context",
+          skills: [{ name: "review", path: "/skills/review/SKILL.md" }],
+          createdAt: timestamp,
+        },
+      ],
+    };
+    const { codex, services, store } = await createHarness(state);
+    markChatActiveInCurrentProcess(services, "chat_1");
+    const emitSpy = vi.spyOn(services.eventHub, "emit");
+    codex.listSkills.mockResolvedValueOnce({ skills: [] });
+
+    codex.emitNotification({
+      method: "turn/completed",
+      params: {
+        threadId: "thread_1",
+        turn: { id: "turn_1", status: "completed" },
+      },
+    });
+
+    await vi.waitFor(async () => {
+      const savedState = await store.load();
+      strictEqual(savedState.queuedMessages.length, 0);
+      strictEqual(
+        emitSpy.mock.calls.some((call) => call[0] === "agent.error"),
+        true,
+      );
+    });
+    const savedState = await store.load();
+    strictEqual(codex.startTurn.mock.calls.length, 0);
+    strictEqual(savedState.messages[0]?.text, "queued invalid context");
+    strictEqual(savedState.messages[0]?.eventType, undefined);
+    strictEqual(savedState.messages.at(-1)?.role, "error");
+    strictEqual(
+      savedState.messages.at(-1)?.text,
+      "Skill context path is not available: /skills/review/SKILL.md",
+    );
+    strictEqual(savedState.chats[0]?.status, "idle");
+    strictEqual(savedState.chats[0]?.activeTurnId, null);
+  });
+
+  it("removes stale queued records and reports when the queued message is missing", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "running", activeTurnId: "turn_1" })],
+      queuedMessages: [
+        {
+          id: "queue_1",
+          chatId: "chat_1",
+          messageId: "msg_missing",
+          text: "missing queued message",
+          createdAt: timestamp,
+        },
+      ],
+    };
+    const { codex, services, store } = await createHarness(state);
+    markChatActiveInCurrentProcess(services, "chat_1");
+    const emitSpy = vi.spyOn(services.eventHub, "emit");
+
+    codex.emitNotification({
+      method: "turn/completed",
+      params: {
+        threadId: "thread_1",
+        turn: { id: "turn_1", status: "completed" },
+      },
+    });
+
+    await vi.waitFor(() => {
+      strictEqual(
+        emitSpy.mock.calls.some((call) => call[0] === "agent.error"),
+        true,
+      );
+    });
+    const savedState = await store.load();
+    strictEqual(savedState.queuedMessages.length, 0);
+    strictEqual(savedState.messages.at(-1)?.role, "error");
+    strictEqual(
+      savedState.messages.at(-1)?.text,
+      "Queued message was not found",
+    );
+    strictEqual(codex.startTurn.mock.calls.length, 0);
+  });
+
+  it("starts existing queued messages before new sends on inactive chats", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "failed", activeTurnId: null })],
+      messages: [
+        {
+          id: "msg_queued",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "queued first",
+          eventType: "chat.message.queued",
+          createdAt: timestamp,
+        },
+      ],
+      queuedMessages: [
+        {
+          id: "queue_1",
+          chatId: "chat_1",
+          messageId: "msg_queued",
+          text: "queued first",
+          createdAt: timestamp,
+        },
+      ],
+    };
+    const { codex, services, store } = await createHarness(state);
+    codex.resumeThread.mockResolvedValueOnce({});
+    codex.startTurn.mockResolvedValueOnce({ turn: { id: "turn_2" } });
+
+    await services.sendMessage("chat_1", { text: "new after queue" });
+
+    const savedState = await store.load();
+    strictEqual(codex.startTurn.mock.calls[0]?.[1], "queued first");
+    strictEqual(savedState.chats[0]?.status, "running");
+    strictEqual(savedState.chats[0]?.activeTurnId, "turn_2");
+    deepStrictEqual(
+      savedState.messages
+        .filter((message) => message.role === "user")
+        .map((message) => [message.text, message.eventType]),
+      [
+        ["queued first", undefined],
+        ["new after queue", "chat.message.queued"],
+      ],
+    );
+    strictEqual(savedState.queuedMessages.length, 1);
+    strictEqual(savedState.queuedMessages[0]?.text, "new after queue");
+  });
+
+  it("drains queued messages one turn at a time", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "running", activeTurnId: "turn_1" })],
+    };
+    const { codex, services, store } = await createHarness(state);
+    markChatActiveInCurrentProcess(services, "chat_1");
+    codex.resumeThread.mockResolvedValueOnce({});
+    codex.startTurn
+      .mockResolvedValueOnce({ turn: { id: "turn_2" } })
+      .mockResolvedValueOnce({ turn: { id: "turn_3" } });
+
+    await services.queueMessage("chat_1", { text: "first queued" });
+    await services.queueMessage("chat_1", { text: "second queued" });
+
+    codex.emitNotification({
+      method: "turn/completed",
+      params: {
+        threadId: "thread_1",
+        turn: { id: "turn_1", status: "completed" },
+      },
+    });
+
+    await vi.waitFor(() => {
+      strictEqual(codex.startTurn.mock.calls.length, 1);
+    });
+    strictEqual((await store.load()).queuedMessages.length, 1);
+    strictEqual(codex.startTurn.mock.calls[0]?.[1], "first queued");
+
+    codex.emitNotification({
+      method: "turn/completed",
+      params: {
+        threadId: "thread_1",
+        turn: { id: "turn_2", status: "completed" },
+      },
+    });
+
+    await vi.waitFor(() => {
+      strictEqual(codex.startTurn.mock.calls.length, 2);
+    });
+    strictEqual((await store.load()).queuedMessages.length, 0);
+    strictEqual(codex.startTurn.mock.calls[1]?.[1], "second queued");
+  });
+
+  it("queues messages while the chat is waiting for approval", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [
+        createChat({ status: "waitingForApproval", activeTurnId: "turn_1" }),
+      ],
+    };
+    const { codex, services, store } = await createHarness(state);
+    markChatActiveInCurrentProcess(services, "chat_1");
+
+    await services.queueMessage("chat_1", { text: "after approval" });
+
+    const savedState = await store.load();
+    strictEqual(savedState.messages[0]?.text, "after approval");
+    strictEqual(savedState.queuedMessages[0]?.text, "after approval");
+    strictEqual(savedState.chats[0]?.status, "waitingForApproval");
     strictEqual(codex.startTurn.mock.calls.length, 0);
     strictEqual(codex.steerTurn.mock.calls.length, 0);
   });

--- a/packages/server/src/services.ts
+++ b/packages/server/src/services.ts
@@ -46,6 +46,7 @@ import type {
   CodexTurnContextItem,
   ProjectWorktreeRecord,
   ProjectRecord,
+  QueuedMessageRecord,
   ServeState,
 } from "./types.ts";
 
@@ -103,6 +104,13 @@ interface PendingTurnEventBuffer {
   chatId: string;
   discard: boolean;
   events: PendingTurnEvent[];
+  flushing: boolean;
+}
+
+interface SubmitMessageOptions {
+  existingUserMessageId?: string;
+  queuedMessageId?: string;
+  requireActiveTurn: boolean;
 }
 
 type PendingTurnEvent =
@@ -139,7 +147,11 @@ export class ServeServices {
     PendingTurnEventBuffer
   >();
   private readonly pendingChatTurns = new Set<string>();
+  private readonly drainingQueuedMessageChatIds = new Set<string>();
+  private readonly pendingQueuedMessageDrainChatIds = new Set<string>();
   private readonly activeTurnChatIds = new Set<string>();
+  private readonly activeWorktreeOperationLocks = new Map<string, number>();
+  private readonly reportedAgentErrors = new WeakSet<object>();
 
   constructor(options: ServeServicesOptions = {}) {
     this.eventHub = options.eventHub ?? new EventHub();
@@ -233,6 +245,9 @@ export class ServeServices {
         messages: state.messages.filter(
           (message) => !removedChatIds.has(message.chatId),
         ),
+        queuedMessages: state.queuedMessages.filter(
+          (message) => !removedChatIds.has(message.chatId),
+        ),
         selectedProjectId:
           state.selectedProjectId === projectId
             ? null
@@ -284,6 +299,7 @@ export class ServeServices {
       const existingProjectChats = nextState.chats.filter(
         (chat) => chat.projectId === projectId,
       );
+      const queuedMessageChatIds = getQueuedMessageChatIds(nextState);
       const existingChatsByThreadId = new Map(
         existingProjectChats
           .filter((chat) => chat.codexThreadId)
@@ -319,6 +335,7 @@ export class ServeServices {
           (worktreesByPath.has(chat.worktreePath) ||
             !canPruneMissingChats ||
             isChatActive(chat, this.pendingChatTurns) ||
+            queuedMessageChatIds.has(chat.id) ||
             !initialProjectChatIds.has(chat.id)),
       );
       const retainedProjectChats = sortChatsByUpdatedAt([
@@ -346,6 +363,9 @@ export class ServeServices {
           ...retainedProjectChats,
         ],
         messages: nextState.messages.filter(
+          (message) => !removedProjectChatIds.has(message.chatId),
+        ),
+        queuedMessages: nextState.queuedMessages.filter(
           (message) => !removedProjectChatIds.has(message.chatId),
         ),
         selectedChatId,
@@ -483,26 +503,36 @@ export class ServeServices {
     if (!targetWorktree) {
       throw new Error(`Worktree '${worktreeName}' not found`);
     }
-    const activeChat = findActiveWorktreeChat(
-      state.chats,
+    this.assertNoBlockingWorktreeChat(
+      state,
       projectId,
       targetWorktree.path,
-      this.pendingChatTurns,
+      worktreeName,
+      "syncing the branch",
     );
-    if (activeChat) {
-      throw new Error(
-        `Worktree '${worktreeName}' has an active chat. Stop the chat before syncing the branch.`,
-      );
-    }
 
-    const pullTarget = await getWorktreePullTarget(targetWorktree.path);
-    const result = await pull({
-      cwd: targetWorktree.path,
-      remote: pullTarget.remote,
-      branch: pullTarget.branch,
-    });
-    if (!result.ok) {
-      throw result.error;
+    const releaseWorktreeOperation = this.acquireWorktreeOperationLock(
+      targetWorktree.path,
+    );
+    try {
+      this.assertNoBlockingWorktreeChat(
+        await this.store.load(),
+        projectId,
+        targetWorktree.path,
+        worktreeName,
+        "syncing the branch",
+      );
+      const pullTarget = await getWorktreePullTarget(targetWorktree.path);
+      const result = await pull({
+        cwd: targetWorktree.path,
+        remote: pullTarget.remote,
+        branch: pullTarget.branch,
+      });
+      if (!result.ok) {
+        throw result.error;
+      }
+    } finally {
+      releaseWorktreeOperation();
     }
 
     return {
@@ -608,55 +638,76 @@ export class ServeServices {
         `Worktree '${worktreeName}' is not managed by Phantom and cannot be deleted from Serve.`,
       );
     }
-    const worktreeChats = state.chats.filter(
-      (chat) =>
-        chat.projectId === projectId &&
-        chat.worktreePath === targetWorktree.path,
-    );
-    const activeChat = findActiveWorktreeChat(
-      worktreeChats,
+    this.assertNoBlockingWorktreeChat(
+      state,
       projectId,
       targetWorktree.path,
-      this.pendingChatTurns,
-    );
-    if (activeChat) {
-      throw new Error(
-        `Worktree '${worktreeName}' has an active chat. Stop the chat before deleting the worktree.`,
-      );
-    }
-
-    const result = await deleteWorktreeCore(
-      context.gitRoot,
-      context.worktreesDirectory,
       worktreeName,
-      {
-        force: input.force,
-        keepBranch: input.keepBranch ?? context.preferences.keepBranch ?? false,
-        path: targetWorktree.path,
-      },
-      context.config?.preDelete?.commands,
+      "deleting the worktree",
     );
-    if (!result.ok) {
-      throw result.error;
-    }
 
-    const removedChatIds = new Set(worktreeChats.map((chat) => chat.id));
-    await this.store.update((nextState) => ({
-      ...nextState,
-      chats: nextState.chats.filter((chat) => !removedChatIds.has(chat.id)),
-      messages: nextState.messages.filter(
-        (message) => !removedChatIds.has(message.chatId),
-      ),
-      selectedChatId: removedChatIds.has(nextState.selectedChatId ?? "")
-        ? null
-        : nextState.selectedChatId,
-    }));
+    let deleteMessage = "";
+    const releaseWorktreeOperation = this.acquireWorktreeOperationLock(
+      targetWorktree.path,
+    );
+    try {
+      this.assertNoBlockingWorktreeChat(
+        await this.store.load(),
+        projectId,
+        targetWorktree.path,
+        worktreeName,
+        "deleting the worktree",
+      );
+      const result = await deleteWorktreeCore(
+        context.gitRoot,
+        context.worktreesDirectory,
+        worktreeName,
+        {
+          force: input.force,
+          keepBranch:
+            input.keepBranch ?? context.preferences.keepBranch ?? false,
+          path: targetWorktree.path,
+        },
+        context.config?.preDelete?.commands,
+      );
+      if (!result.ok) {
+        throw result.error;
+      }
+      deleteMessage = result.value.message;
+
+      await this.store.update((nextState) => {
+        const removedChatIds = new Set(
+          nextState.chats
+            .filter(
+              (chat) =>
+                chat.projectId === projectId &&
+                chat.worktreePath === targetWorktree.path,
+            )
+            .map((chat) => chat.id),
+        );
+        return {
+          ...nextState,
+          chats: nextState.chats.filter((chat) => !removedChatIds.has(chat.id)),
+          messages: nextState.messages.filter(
+            (message) => !removedChatIds.has(message.chatId),
+          ),
+          queuedMessages: nextState.queuedMessages.filter(
+            (message) => !removedChatIds.has(message.chatId),
+          ),
+          selectedChatId: removedChatIds.has(nextState.selectedChatId ?? "")
+            ? null
+            : nextState.selectedChatId,
+        };
+      });
+    } finally {
+      releaseWorktreeOperation();
+    }
 
     this.eventHub.emit("worktree.removed", {
       projectId,
       worktreeName,
     });
-    return { message: result.value.message };
+    return { message: deleteMessage };
   }
 
   async getChat(chatId: string): Promise<ChatRecord> {
@@ -691,6 +742,16 @@ export class ServeServices {
     chatId: string,
     input: SendMessageInput,
   ): Promise<ChatRecord> {
+    await this.resetStaleTransientChatState();
+    const state = await this.store.load();
+    const chat = this.requireChat(state, chatId);
+    if (
+      !isChatInActiveTurn(chat) &&
+      !this.pendingChatTurns.has(chatId) &&
+      state.queuedMessages.some((message) => message.chatId === chatId)
+    ) {
+      return this.queueMessage(chatId, input);
+    }
     return this.submitMessage(chatId, input, { requireActiveTurn: false });
   }
 
@@ -701,10 +762,65 @@ export class ServeServices {
     return this.submitMessage(chatId, input, { requireActiveTurn: true });
   }
 
+  async queueMessage(
+    chatId: string,
+    input: SendMessageInput,
+  ): Promise<ChatRecord> {
+    await this.resetStaleTransientChatState();
+    const text = input.text.trim();
+    if (!text) {
+      throw new Error("Message text cannot be empty");
+    }
+
+    let shouldSubmitImmediately = false;
+    let shouldDrainQueuedMessages = false;
+    let queuedUserMessage: ChatMessageRecord | null = null;
+    await this.store.update((nextState) => {
+      const chat = this.requireChat(nextState, chatId);
+      this.assertChatWorktreeIsAvailable(chat);
+      const hasQueuedMessages = nextState.queuedMessages.some(
+        (message) => message.chatId === chatId,
+      );
+      const isQueueBlocked =
+        isChatInActiveTurn(chat) || this.pendingChatTurns.has(chatId);
+      if (!isQueueBlocked && !hasQueuedMessages) {
+        shouldSubmitImmediately = true;
+        return nextState;
+      }
+      shouldDrainQueuedMessages = !isQueueBlocked;
+
+      const userMessage = createMessage(
+        chat.id,
+        "user",
+        text,
+        "chat.message.queued",
+      );
+      const queuedMessage = createQueuedMessage(chat.id, userMessage.id, input);
+      queuedUserMessage = userMessage;
+      return {
+        ...nextState,
+        messages: [...nextState.messages, userMessage],
+        queuedMessages: [...nextState.queuedMessages, queuedMessage],
+      };
+    });
+
+    if (shouldSubmitImmediately) {
+      return this.submitMessage(chatId, input, { requireActiveTurn: false });
+    }
+
+    if (queuedUserMessage) {
+      this.eventHub.emit("chat.message.created", queuedUserMessage, { chatId });
+    }
+    if (shouldDrainQueuedMessages) {
+      await this.drainQueuedMessagesAndReport(chatId);
+    }
+    return await this.getChat(chatId);
+  }
+
   private async submitMessage(
     chatId: string,
     input: SendMessageInput,
-    options: { requireActiveTurn: boolean },
+    options: SubmitMessageOptions,
   ): Promise<ChatRecord> {
     await this.resetStaleTransientChatState();
     const text = input.text.trim();
@@ -717,6 +833,18 @@ export class ServeServices {
     if (chat.status === "waitingForApproval") {
       throw new Error("Chat is waiting for approval");
     }
+    this.assertChatWorktreeIsAvailable(chat);
+    const existingUserMessage = options.existingUserMessageId
+      ? state.messages.find(
+          (message) =>
+            message.id === options.existingUserMessageId &&
+            message.chatId === chatId &&
+            message.role === "user",
+        )
+      : undefined;
+    if (options.existingUserMessageId && !existingUserMessage) {
+      throw new Error("Queued message was not found");
+    }
     const previousMessageIds = new Set(
       state.messages
         .filter((message) => message.chatId === chatId)
@@ -727,7 +855,13 @@ export class ServeServices {
     if (options.requireActiveTurn && !isSteeringActiveTurn) {
       throw new Error("Chat does not have an active Codex turn");
     }
-    const turnOptions = await this.createCodexTurnOptions(input, chat);
+    let pendingChatTurnCleared = false;
+    const clearPendingChatTurn = () => {
+      if (!isSteeringActiveTurn && !pendingChatTurnCleared) {
+        this.pendingChatTurns.delete(chatId);
+        pendingChatTurnCleared = true;
+      }
+    };
     if (!isSteeringActiveTurn) {
       if (this.pendingChatTurns.has(chatId)) {
         throw new Error("Chat already has an active Codex turn");
@@ -735,7 +869,35 @@ export class ServeServices {
       this.pendingChatTurns.add(chatId);
     }
 
-    const userMessage = createMessage(chat.id, "user", text);
+    const turnOptions = await this.createCodexTurnOptions(input, chat).catch(
+      async (error) => {
+        clearPendingChatTurn();
+        if (options.queuedMessageId) {
+          await this.store.update((nextState) => ({
+            ...nextState,
+            messages: existingUserMessage
+              ? nextState.messages.map((message) =>
+                  message.id === existingUserMessage.id
+                    ? { ...message, eventType: undefined }
+                    : message,
+                )
+              : nextState.messages,
+            queuedMessages: nextState.queuedMessages.filter(
+              (message) => message.id !== options.queuedMessageId,
+            ),
+          }));
+        }
+        await this.drainQueuedMessagesAndReport(chatId);
+        throw error;
+      },
+    );
+
+    const userMessage = existingUserMessage
+      ? {
+          ...existingUserMessage,
+          eventType: undefined,
+        }
+      : createMessage(chat.id, "user", text);
     let nextStatus: ChatStatus | null = null;
     let nextActiveTurnId: string | null | undefined;
     let pendingTurnThreadId: string | null = null;
@@ -744,7 +906,11 @@ export class ServeServices {
     try {
       await this.store.update((nextState) => ({
         ...nextState,
-        messages: [...nextState.messages, userMessage],
+        messages: existingUserMessage
+          ? nextState.messages.map((message) =>
+              message.id === userMessage.id ? userMessage : message,
+            )
+          : [...nextState.messages, userMessage],
       }));
       userMessageStored = true;
 
@@ -768,13 +934,16 @@ export class ServeServices {
             if (existingPendingTurn.discard) {
               throw new Error("Chat is waiting for failed Codex turn cleanup");
             }
-            throw new Error("Chat already has an active Codex turn");
+            if (!existingPendingTurn.flushing) {
+              throw new Error("Chat already has an active Codex turn");
+            }
           }
           pendingTurnThreadId = threadId;
           this.pendingTurnEvents.set(threadId, {
             chatId,
             discard: false,
             events: [],
+            flushing: false,
           });
           const turnResult = turnOptions
             ? await this.codex.startTurn(
@@ -795,35 +964,43 @@ export class ServeServices {
         if (pendingTurnThreadId) {
           this.discardPendingTurnEvents(pendingTurnThreadId);
         }
-        await this.store.update((nextState) => ({
-          ...nextState,
-          messages: userMessageStored
-            ? nextState.messages.filter(
-                (message) =>
-                  message.id !== userMessage.id &&
-                  (isSteeringActiveTurn ||
-                    message.chatId !== chatId ||
-                    previousMessageIds.has(message.id)),
-              )
-            : nextState.messages,
-          chats: isSteeringActiveTurn
-            ? nextState.chats
-            : nextState.chats.map((candidate) =>
-                candidate.id === chatId
-                  ? {
-                      ...candidate,
-                      status: "failed",
-                      activeTurnId: chat.activeTurnId ?? null,
-                      updatedAt: createTimestamp(),
-                    }
-                  : candidate,
-              ),
-        }));
-        this.eventHub.emit(
-          "agent.error",
-          { message: toErrorMessage(error) },
-          { chatId },
-        );
+        await this.store.update((nextState) => {
+          const queuedMessageIds = new Set(
+            nextState.queuedMessages.map((message) => message.messageId),
+          );
+          return {
+            ...nextState,
+            messages:
+              userMessageStored && !existingUserMessage
+                ? nextState.messages.filter(
+                    (message) =>
+                      message.id !== userMessage.id &&
+                      (isSteeringActiveTurn ||
+                        message.chatId !== chatId ||
+                        previousMessageIds.has(message.id) ||
+                        queuedMessageIds.has(message.id)),
+                  )
+                : nextState.messages,
+            queuedMessages: options.queuedMessageId
+              ? nextState.queuedMessages.filter(
+                  (message) => message.id !== options.queuedMessageId,
+                )
+              : nextState.queuedMessages,
+            chats: isSteeringActiveTurn
+              ? nextState.chats
+              : nextState.chats.map((candidate) =>
+                  candidate.id === chatId
+                    ? {
+                        ...candidate,
+                        status: "failed",
+                        activeTurnId: chat.activeTurnId ?? null,
+                        updatedAt: createTimestamp(),
+                      }
+                    : candidate,
+                ),
+          };
+        });
+        this.emitAgentError(chatId, error);
         throw error instanceof Error ? error : new Error(String(error));
       }
 
@@ -839,17 +1016,23 @@ export class ServeServices {
               }
             : candidate,
         ),
+        queuedMessages: options.queuedMessageId
+          ? nextState.queuedMessages.filter(
+              (message) => message.id !== options.queuedMessageId,
+            )
+          : nextState.queuedMessages,
       }));
-      this.eventHub.emit("chat.message.created", userMessage, { chatId });
+      if (!existingUserMessage) {
+        this.eventHub.emit("chat.message.created", userMessage, { chatId });
+      }
+      clearPendingChatTurn();
       if (pendingTurnThreadId) {
         await this.flushPendingTurnEvents(pendingTurnThreadId);
       }
 
       return await this.getChat(chatId);
     } finally {
-      if (!isSteeringActiveTurn) {
-        this.pendingChatTurns.delete(chatId);
-      }
+      clearPendingChatTurn();
     }
   }
 
@@ -1100,6 +1283,9 @@ export class ServeServices {
       }
       await this.addMessageFromCodexEvent(chat.id, method, message.params);
       this.eventHub.emit(eventType, message, { chatId: chat.id });
+      if (method === "turn/completed") {
+        await this.drainQueuedMessagesAndReport(chat.id);
+      }
     } else {
       if (method === "serverRequest/resolved") {
         return;
@@ -1201,12 +1387,167 @@ export class ServeServices {
     );
   }
 
+  private async drainQueuedMessages(chatId: string): Promise<void> {
+    const state = await this.store.load();
+    const chat = this.requireChat(state, chatId);
+    if (isChatInActiveTurn(chat) || this.pendingChatTurns.has(chatId)) {
+      return;
+    }
+
+    const queuedMessage = state.queuedMessages.find(
+      (message) => message.chatId === chatId,
+    );
+    if (!queuedMessage) {
+      return;
+    }
+    const queuedUserMessage = state.messages.find(
+      (message) =>
+        message.id === queuedMessage.messageId &&
+        message.chatId === chatId &&
+        message.role === "user",
+    );
+    if (!queuedUserMessage) {
+      await this.store.update((nextState) => ({
+        ...nextState,
+        queuedMessages: nextState.queuedMessages.filter(
+          (message) => message.id !== queuedMessage.id,
+        ),
+      }));
+      await this.drainQueuedMessages(chatId);
+      throw new Error("Queued message was not found");
+    }
+
+    await this.submitMessage(chatId, queuedMessageToSendInput(queuedMessage), {
+      existingUserMessageId: queuedMessage.messageId,
+      queuedMessageId: queuedMessage.id,
+      requireActiveTurn: false,
+    });
+  }
+
+  private async drainQueuedMessagesAndReport(chatId: string): Promise<void> {
+    if (this.drainingQueuedMessageChatIds.has(chatId)) {
+      this.pendingQueuedMessageDrainChatIds.add(chatId);
+      return;
+    }
+
+    this.drainingQueuedMessageChatIds.add(chatId);
+    try {
+      do {
+        this.pendingQueuedMessageDrainChatIds.delete(chatId);
+        try {
+          await this.drainQueuedMessages(chatId);
+        } catch (error) {
+          const wasReported = this.isAgentErrorReported(error);
+          await this.addAgentErrorMessage(chatId, error);
+          if (!wasReported) {
+            this.emitAgentError(chatId, error);
+          }
+        }
+      } while (this.pendingQueuedMessageDrainChatIds.has(chatId));
+    } finally {
+      this.pendingQueuedMessageDrainChatIds.delete(chatId);
+      this.drainingQueuedMessageChatIds.delete(chatId);
+    }
+  }
+
+  private async addAgentErrorMessage(
+    chatId: string,
+    error: unknown,
+  ): Promise<void> {
+    const message = toErrorMessage(error);
+    await this.store.update((state) => {
+      if (!state.chats.some((chat) => chat.id === chatId)) {
+        return state;
+      }
+      return {
+        ...state,
+        messages: [...state.messages, createMessage(chatId, "error", message)],
+      };
+    });
+  }
+
+  private emitAgentError(chatId: string, error: unknown): void {
+    this.markAgentErrorReported(error);
+    this.eventHub.emit(
+      "agent.error",
+      { message: toErrorMessage(error) },
+      { chatId },
+    );
+  }
+
+  private markAgentErrorReported(error: unknown): void {
+    if ((typeof error === "object" || typeof error === "function") && error) {
+      this.reportedAgentErrors.add(error);
+    }
+  }
+
+  private isAgentErrorReported(error: unknown): boolean {
+    if (!error || (typeof error !== "object" && typeof error !== "function")) {
+      return false;
+    }
+    return this.reportedAgentErrors.has(error);
+  }
+
+  private assertChatWorktreeIsAvailable(chat: ChatRecord): void {
+    if (this.isWorktreeOperationActive(chat.worktreePath)) {
+      throw new Error(
+        `Worktree '${chat.worktreeName}' is busy. Wait for the current worktree operation to finish before sending messages.`,
+      );
+    }
+  }
+
+  private acquireWorktreeOperationLock(worktreePath: string): () => void {
+    const activeCount =
+      this.activeWorktreeOperationLocks.get(worktreePath) ?? 0;
+    this.activeWorktreeOperationLocks.set(worktreePath, activeCount + 1);
+    let released = false;
+    return () => {
+      if (released) {
+        return;
+      }
+      released = true;
+      const nextCount =
+        (this.activeWorktreeOperationLocks.get(worktreePath) ?? 1) - 1;
+      if (nextCount > 0) {
+        this.activeWorktreeOperationLocks.set(worktreePath, nextCount);
+      } else {
+        this.activeWorktreeOperationLocks.delete(worktreePath);
+      }
+    };
+  }
+
+  private isWorktreeOperationActive(worktreePath: string): boolean {
+    return (this.activeWorktreeOperationLocks.get(worktreePath) ?? 0) > 0;
+  }
+
+  private assertNoBlockingWorktreeChat(
+    state: ServeState,
+    projectId: string,
+    worktreePath: string,
+    worktreeName: string,
+    action: string,
+  ): void {
+    const activeChat = findActiveWorktreeChat(
+      state.chats,
+      projectId,
+      worktreePath,
+      this.pendingChatTurns,
+      getQueuedMessageChatIds(state),
+    );
+    if (activeChat) {
+      throw new Error(
+        `Worktree '${worktreeName}' has an active chat. Stop the chat before ${action}.`,
+      );
+    }
+  }
+
   private async flushPendingTurnEvents(threadId: string): Promise<void> {
     const pendingTurnEvents = this.pendingTurnEvents.get(threadId);
     if (!pendingTurnEvents || pendingTurnEvents.discard) {
       this.pendingTurnEvents.delete(threadId);
       return;
     }
+    pendingTurnEvents.flushing = true;
     while (!pendingTurnEvents.discard && pendingTurnEvents.events.length > 0) {
       const pendingEvent = pendingTurnEvents.events.shift();
       if (!pendingEvent) {
@@ -1218,6 +1559,7 @@ export class ServeServices {
         await this.processCodexServerRequest(pendingEvent.message);
       }
     }
+    pendingTurnEvents.flushing = false;
     if (this.pendingTurnEvents.get(threadId) === pendingTurnEvents) {
       this.pendingTurnEvents.delete(threadId);
     }
@@ -1507,6 +1849,55 @@ function createMessage(
   };
 }
 
+function createQueuedMessage(
+  chatId: string,
+  messageId: string,
+  input: SendMessageInput,
+): QueuedMessageRecord {
+  return {
+    id: createRecordId("queue"),
+    chatId,
+    messageId,
+    text: input.text.trim(),
+    effort: input.effort,
+    files: cloneContextItems(input.files),
+    model: input.model,
+    skills: cloneContextItems(input.skills),
+    createdAt: createTimestamp(),
+  };
+}
+
+function queuedMessageToSendInput(
+  message: QueuedMessageRecord,
+): SendMessageInput {
+  return {
+    effort: message.effort,
+    files: cloneContextItems(message.files),
+    model: message.model,
+    skills: cloneContextItems(message.skills),
+    text: message.text,
+  };
+}
+
+function cloneContextItems(
+  items: CodexTurnContextItem[] | undefined,
+): CodexTurnContextItem[] | undefined {
+  if (!items || items.length === 0) {
+    return undefined;
+  }
+  return items.map((item) => ({
+    name: item.name,
+    path: item.path,
+  }));
+}
+
+function isChatInActiveTurn(chat: ChatRecord): boolean {
+  return Boolean(
+    chat.activeTurnId &&
+    (chat.status === "running" || chat.status === "waitingForApproval"),
+  );
+}
+
 function latestChatForWorktree(chats: ChatRecord[]): ChatRecord | null {
   const sortedChats = [...chats].sort((left, right) =>
     right.updatedAt.localeCompare(left.updatedAt),
@@ -1521,12 +1912,14 @@ function findActiveWorktreeChat(
   projectId: string,
   worktreePath: string,
   pendingChatTurns: ReadonlySet<string>,
+  queuedMessageChatIds: ReadonlySet<string>,
 ): ChatRecord | undefined {
   return chats.find(
     (chat) =>
       chat.projectId === projectId &&
       chat.worktreePath === worktreePath &&
       (pendingChatTurns.has(chat.id) ||
+        queuedMessageChatIds.has(chat.id) ||
         chat.status === "running" ||
         chat.status === "waitingForApproval" ||
         Boolean(chat.activeTurnId)),
@@ -1653,6 +2046,10 @@ function isChatActive(
     chat.status === "running" ||
     chat.status === "waitingForApproval",
   );
+}
+
+function getQueuedMessageChatIds(state: ServeState): ReadonlySet<string> {
+  return new Set(state.queuedMessages.map((message) => message.chatId));
 }
 
 function normalizeCodexThreadList(value: unknown): CodexThreadRecord[] {

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -5,6 +5,7 @@ export type {
   ChatRecord,
   ChatStatus,
   ProjectRecord,
+  QueuedMessageRecord,
   ServeState,
 } from "@phantompane/state";
 

--- a/packages/state/src/store.test.ts
+++ b/packages/state/src/store.test.ts
@@ -28,6 +28,7 @@ function createTestState(overrides: Partial<ServeState> = {}): ServeState {
     projects: [],
     chats: [],
     messages: [],
+    queuedMessages: [],
     selectedProjectId: null,
     selectedChatId: null,
     ...overrides,

--- a/packages/state/src/store.ts
+++ b/packages/state/src/store.ts
@@ -16,6 +16,7 @@ function createEmptyState(): ServeState {
     projects: [],
     chats: [],
     messages: [],
+    queuedMessages: [],
     selectedProjectId: null,
     selectedChatId: null,
   };
@@ -117,6 +118,7 @@ export class ServeStateStore {
         projects: [...state.projects],
         chats: [...state.chats],
         messages: [...state.messages],
+        queuedMessages: [...state.queuedMessages],
       });
       await this.save(nextState);
       return nextState;

--- a/packages/state/src/types.ts
+++ b/packages/state/src/types.ts
@@ -27,6 +27,23 @@ const chatMessageRecordBaseSchema = z.object({
   createdAt: z.string(),
 });
 
+const turnContextItemBaseSchema = z.object({
+  name: z.string(),
+  path: z.string(),
+});
+
+const queuedMessageRecordBaseSchema = z.object({
+  id: z.string(),
+  chatId: z.string(),
+  messageId: z.string(),
+  text: z.string(),
+  effort: z.string().optional(),
+  files: z.array(turnContextItemBaseSchema).optional(),
+  model: z.string().optional(),
+  skills: z.array(turnContextItemBaseSchema).optional(),
+  createdAt: z.string(),
+});
+
 const chatRecordBaseSchema = z.object({
   id: z.string(),
   projectId: z.string(),
@@ -51,6 +68,7 @@ const serveStateBaseSchema = z.object({
   projects: z.array(projectRecordBaseSchema),
   chats: z.array(chatRecordBaseSchema),
   messages: z.array(chatMessageRecordBaseSchema),
+  queuedMessages: z.array(queuedMessageRecordBaseSchema).default([]),
   selectedProjectId: nullableStringFromUnknownSchema,
   selectedChatId: nullableStringFromUnknownSchema,
 });
@@ -58,6 +76,7 @@ const serveStateBaseSchema = z.object({
 export type ChatStatus = z.infer<typeof chatStatusSchema>;
 export type ProjectRecord = z.infer<typeof projectRecordBaseSchema>;
 export type ChatMessageRecord = z.infer<typeof chatMessageRecordBaseSchema>;
+export type QueuedMessageRecord = z.infer<typeof queuedMessageRecordBaseSchema>;
 export type ChatRecord = z.infer<typeof chatRecordBaseSchema>;
 export type ServeState = z.infer<typeof serveStateBaseSchema>;
 
@@ -65,6 +84,8 @@ export const projectRecordSchema: z.ZodType<ProjectRecord> =
   projectRecordBaseSchema.passthrough();
 export const chatMessageRecordSchema: z.ZodType<ChatMessageRecord> =
   chatMessageRecordBaseSchema.passthrough();
+export const queuedMessageRecordSchema: z.ZodType<QueuedMessageRecord> =
+  queuedMessageRecordBaseSchema.passthrough();
 export const chatRecordSchema: z.ZodType<ChatRecord> =
   chatRecordBaseSchema.passthrough();
 export const serveStateSchema: z.ZodType<ServeState> = z
@@ -73,6 +94,7 @@ export const serveStateSchema: z.ZodType<ServeState> = z
     projects: z.array(projectRecordSchema),
     chats: z.array(chatRecordSchema),
     messages: z.array(chatMessageRecordSchema),
+    queuedMessages: z.array(queuedMessageRecordSchema).default([]),
     selectedProjectId: nullableStringFromUnknownSchema,
     selectedChatId: nullableStringFromUnknownSchema,
   })

--- a/packages/web/src/api/mutations.test.ts
+++ b/packages/web/src/api/mutations.test.ts
@@ -1,6 +1,10 @@
 import { strictEqual } from "node:assert";
 import { afterEach, describe, it, vi } from "vitest";
-import { answerApprovalMutation } from "./mutations";
+import {
+  answerApprovalMutation,
+  queueMessageMutation,
+  steerMessageMutation,
+} from "./mutations";
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -37,5 +41,57 @@ describe("answerApprovalMutation", () => {
       requestUrl,
       "/api/chats/chat%2Fwith%23hash/approvals/request%2Fwith%23hash",
     );
+  });
+});
+
+describe("message control mutations", () => {
+  it("encodes steer route params before calling Hono RPC", async () => {
+    let requestUrl: string | undefined;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        requestUrl =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+        return new Response('{"chat":{"id":"chat_1"}}', {
+          headers: {
+            "Content-Type": "application/json",
+          },
+          status: 200,
+        });
+      }),
+    );
+
+    await steerMessageMutation("chat/with#hash", { text: "adjust" });
+
+    strictEqual(requestUrl, "/api/chats/chat%2Fwith%23hash/steer");
+  });
+
+  it("encodes queue route params before calling Hono RPC", async () => {
+    let requestUrl: string | undefined;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        requestUrl =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+        return new Response('{"chat":{"id":"chat_1"}}', {
+          headers: {
+            "Content-Type": "application/json",
+          },
+          status: 200,
+        });
+      }),
+    );
+
+    await queueMessageMutation("chat/with#hash", { text: "later" });
+
+    strictEqual(requestUrl, "/api/chats/chat%2Fwith%23hash/queue");
   });
 });

--- a/packages/web/src/api/mutations.ts
+++ b/packages/web/src/api/mutations.ts
@@ -73,6 +73,30 @@ export async function sendMessageMutation(
   );
 }
 
+export async function steerMessageMutation(
+  chatId: string,
+  input: SendMessageInput,
+) {
+  return readRpcJson<{ chat: ChatRecord }>(
+    await api.chats[":chatId"].steer.$post({
+      param: { chatId: routeParam(chatId) },
+      json: input,
+    }),
+  );
+}
+
+export async function queueMessageMutation(
+  chatId: string,
+  input: SendMessageInput,
+) {
+  return readRpcJson<{ chat: ChatRecord }>(
+    await api.chats[":chatId"].queue.$post({
+      param: { chatId: routeParam(chatId) },
+      json: input,
+    }),
+  );
+}
+
 export async function interruptChatMutation(chatId: string) {
   return readRpcJson<unknown>(
     await api.chats[":chatId"].interrupt.$post({

--- a/packages/web/src/lib/composer-keyboard.test.ts
+++ b/packages/web/src/lib/composer-keyboard.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { shouldSubmitComposerOnEnter } from "./composer-keyboard";
+import {
+  getComposerEnterAction,
+  getComposerSubmitModeForEnter,
+  shouldSubmitComposerOnEnter,
+} from "./composer-keyboard";
 
 function createEnvironment(
   options: {
@@ -38,6 +42,12 @@ function createEnvironment(
 describe("shouldSubmitComposerOnEnter", () => {
   it("submits bare Enter from a hardware keyboard", () => {
     expect(
+      getComposerEnterAction(
+        { code: "Enter", key: "Enter" },
+        createEnvironment(),
+      ),
+    ).toBe("submit");
+    expect(
       shouldSubmitComposerOnEnter(
         { code: "Enter", key: "Enter" },
         createEnvironment(),
@@ -51,7 +61,37 @@ describe("shouldSubmitComposerOnEnter", () => {
     ).toBe(true);
   });
 
+  it("returns a modified submit action for Command or Ctrl Enter", () => {
+    expect(
+      getComposerEnterAction(
+        { code: "Enter", key: "Enter", metaKey: true },
+        createEnvironment(),
+      ),
+    ).toBe("modifiedSubmit");
+    expect(
+      getComposerEnterAction(
+        { code: "Enter", ctrlKey: true, key: "Enter" },
+        createEnvironment(),
+      ),
+    ).toBe("modifiedSubmit");
+    expect(
+      shouldSubmitComposerOnEnter(
+        { code: "Enter", key: "Enter", metaKey: true },
+        createEnvironment(),
+      ),
+    ).toBe(false);
+    expect(
+      shouldSubmitComposerOnEnter(
+        { code: "Enter", ctrlKey: true, key: "Enter" },
+        createEnvironment(),
+      ),
+    ).toBe(false);
+  });
+
   it("does not submit Enter without a hardware key code", () => {
+    expect(getComposerEnterAction({ key: "Enter" }, createEnvironment())).toBe(
+      null,
+    );
     expect(
       shouldSubmitComposerOnEnter({ key: "Enter" }, createEnvironment()),
     ).toBe(false);
@@ -81,12 +121,6 @@ describe("shouldSubmitComposerOnEnter", () => {
     expect(
       shouldSubmitComposerOnEnter(
         { code: "Enter", ctrlKey: true, key: "Enter" },
-        environment,
-      ),
-    ).toBe(false);
-    expect(
-      shouldSubmitComposerOnEnter(
-        { code: "Enter", key: "Enter", metaKey: true },
         environment,
       ),
     ).toBe(false);
@@ -136,5 +170,57 @@ describe("shouldSubmitComposerOnEnter", () => {
         }),
       ),
     ).toBe(false);
+  });
+});
+
+describe("getComposerSubmitModeForEnter", () => {
+  it("sends bare Enter when the chat has no active turn", () => {
+    expect(getComposerSubmitModeForEnter("submit", null)).toBe("send");
+    expect(
+      getComposerSubmitModeForEnter("submit", {
+        activeTurnId: null,
+        status: "idle",
+      }),
+    ).toBe("send");
+  });
+
+  it("queues modified Enter regardless of local active turn state", () => {
+    expect(getComposerSubmitModeForEnter("modifiedSubmit", null)).toBe("queue");
+    expect(
+      getComposerSubmitModeForEnter("modifiedSubmit", {
+        activeTurnId: null,
+        status: "idle",
+      }),
+    ).toBe("queue");
+  });
+
+  it("steers bare Enter only while the active chat is running", () => {
+    expect(
+      getComposerSubmitModeForEnter("submit", {
+        activeTurnId: "turn_1",
+        status: "running",
+      }),
+    ).toBe("steer");
+    expect(
+      getComposerSubmitModeForEnter("submit", {
+        activeTurnId: "turn_1",
+        status: "waitingForApproval",
+      }),
+    ).toBe(null);
+  });
+
+  it("queues Command Enter while the chat has an active turn", () => {
+    expect(
+      getComposerSubmitModeForEnter("modifiedSubmit", {
+        activeTurnId: "turn_1",
+        status: "running",
+      }),
+    ).toBe("queue");
+    expect(
+      getComposerSubmitModeForEnter("modifiedSubmit", {
+        activeTurnId: "turn_1",
+        status: "waitingForApproval",
+      }),
+    ).toBe("queue");
   });
 });

--- a/packages/web/src/lib/composer-keyboard.ts
+++ b/packages/web/src/lib/composer-keyboard.ts
@@ -25,26 +25,58 @@ type ComposerEnterKeyEnvironment = {
   };
 };
 
+export type ComposerEnterAction = "modifiedSubmit" | "submit";
+export type ComposerSubmitMode = "queue" | "send" | "steer";
+
+type ComposerChatState = {
+  activeTurnId?: string | null;
+  status?: string | null;
+};
+
 export function shouldSubmitComposerOnEnter(
   event: ComposerEnterKeyEvent,
   environment: ComposerEnterKeyEnvironment = globalThis,
 ): boolean {
+  return getComposerEnterAction(event, environment) === "submit";
+}
+
+export function getComposerEnterAction(
+  event: ComposerEnterKeyEvent,
+  environment: ComposerEnterKeyEnvironment = globalThis,
+): ComposerEnterAction | null {
   const isImeComposing = event.isComposing || event.keyCode === 229;
   if (
     event.key !== "Enter" ||
     event.shiftKey ||
-    event.metaKey ||
-    event.ctrlKey ||
     event.altKey ||
     isImeComposing
   ) {
-    return false;
+    return null;
   }
 
-  return (
-    isHardwareEnterKey(event) &&
-    !isLikelyMobileTextEntryEnvironment(environment)
-  );
+  if (
+    !isHardwareEnterKey(event) ||
+    isLikelyMobileTextEntryEnvironment(environment)
+  ) {
+    return null;
+  }
+
+  return event.metaKey || event.ctrlKey ? "modifiedSubmit" : "submit";
+}
+
+export function getComposerSubmitModeForEnter(
+  action: ComposerEnterAction,
+  chat: ComposerChatState | null | undefined,
+): ComposerSubmitMode | null {
+  if (action === "modifiedSubmit") {
+    return "queue";
+  }
+
+  if (!chat?.activeTurnId) {
+    return "send";
+  }
+
+  return chat.status === "running" ? "steer" : null;
 }
 
 function isHardwareEnterKey(event: ComposerEnterKeyEvent): boolean {

--- a/packages/web/src/routes/home.tsx
+++ b/packages/web/src/routes/home.tsx
@@ -37,7 +37,9 @@ import {
   createChatMutation,
   deleteWorktreeMutation,
   interruptChatMutation,
+  queueMessageMutation,
   sendMessageMutation,
+  steerMessageMutation,
   syncWorktreeMutation,
 } from "../api/mutations";
 import {
@@ -100,7 +102,11 @@ import {
   SidebarTrigger,
 } from "../components/ui/sidebar";
 import { Textarea } from "../components/ui/textarea";
-import { shouldSubmitComposerOnEnter } from "../lib/composer-keyboard";
+import {
+  getComposerEnterAction,
+  getComposerSubmitModeForEnter,
+  type ComposerSubmitMode,
+} from "../lib/composer-keyboard";
 import { cn } from "../lib/utils";
 import {
   findValidatedSelectedProjectChat,
@@ -522,6 +528,24 @@ export function HomeRoute() {
       chatId: string;
       input: Parameters<typeof sendMessageMutation>[1];
     }) => sendMessageMutation(chatId, input),
+  });
+  const steerMessageRequest = useMutation({
+    mutationFn: ({
+      chatId,
+      input,
+    }: {
+      chatId: string;
+      input: Parameters<typeof steerMessageMutation>[1];
+    }) => steerMessageMutation(chatId, input),
+  });
+  const queueMessageRequest = useMutation({
+    mutationFn: ({
+      chatId,
+      input,
+    }: {
+      chatId: string;
+      input: Parameters<typeof queueMessageMutation>[1];
+    }) => queueMessageMutation(chatId, input),
   });
   const interruptChatRequest = useMutation({
     mutationFn: interruptChatMutation,
@@ -1637,11 +1661,16 @@ export function HomeRoute() {
 
   async function sendMessage(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
+    await submitComposer("send");
+  }
+
+  async function submitComposer(mode: ComposerSubmitMode) {
     if (
       !selectedChatId ||
       !canSendMessage ||
       isSendingMessage ||
-      pendingSendChatIdsRef.current.has(selectedChatId)
+      pendingSendChatIdsRef.current.has(selectedChatId) ||
+      (mode === "steer" && !selectedChat?.activeTurnId)
     ) {
       return;
     }
@@ -1681,7 +1710,13 @@ export function HomeRoute() {
     pendingSendChatIdsRef.current.add(requestChatId);
     setIsSendingMessage(true);
     try {
-      await sendMessageRequest.mutateAsync({
+      const mutation =
+        mode === "steer"
+          ? steerMessageRequest
+          : mode === "queue"
+            ? queueMessageRequest
+            : sendMessageRequest;
+      await mutation.mutateAsync({
         chatId: requestChatId,
         input: {
           effort: turnEffort,
@@ -1719,30 +1754,32 @@ export function HomeRoute() {
   }
 
   function handleComposerKeyDown(event: KeyboardEvent<HTMLTextAreaElement>) {
-    if (
-      !shouldSubmitComposerOnEnter({
-        altKey: event.altKey,
-        code: event.code,
-        ctrlKey: event.ctrlKey,
-        isComposing: event.nativeEvent.isComposing,
-        key: event.key,
-        keyCode: event.keyCode,
-        metaKey: event.metaKey,
-        shiftKey: event.shiftKey,
-      })
-    ) {
+    const action = getComposerEnterAction({
+      altKey: event.altKey,
+      code: event.code,
+      ctrlKey: event.ctrlKey,
+      isComposing: event.nativeEvent.isComposing,
+      key: event.key,
+      keyCode: event.keyCode,
+      metaKey: event.metaKey,
+      shiftKey: event.shiftKey,
+    });
+    if (!action) {
       return;
     }
-    if (
-      !selectedChatId ||
-      !canSendMessage ||
-      isChatRunning ||
-      isSendingMessage
-    ) {
+    if (!selectedChatId || !canSendMessage || isSendingMessage) {
+      return;
+    }
+    const submitMode = getComposerSubmitModeForEnter(action, selectedChat);
+    if (!submitMode) {
       return;
     }
     event.preventDefault();
-    event.currentTarget.form?.requestSubmit();
+    if (submitMode === "send") {
+      event.currentTarget.form?.requestSubmit();
+      return;
+    }
+    void submitComposer(submitMode);
   }
 
   async function interruptChat() {


### PR DESCRIPTION
## Summary

Adds explicit queue and steer chat submission support for Phantom Serve's web composer while Codex is already running.

## What changed

- Added persisted queued chat messages to serve state, with backward-compatible defaults for existing state files.
- Added `/chats/:chatId/queue` and expanded `/chats/:chatId/steer` to accept the same context payload as normal sends.
- Drains queued messages one at a time after each active Codex turn completes.
- Updated the web composer so Enter steers an active turn and Command+Enter queues a follow-up.
- Added coverage for server queue draining, waiting-for-approval queue behavior, web mutations, and composer keyboard handling.

## Why

Users need to keep typing while Codex is running. Urgent corrections should steer the active turn, while follow-up work should wait until the current turn is finished.

## Impact

The normal idle send path is unchanged. While a chat is active, queued messages are shown as user messages immediately and are submitted as future turns in FIFO order.

## Validation

- `pnpm --filter @phantompane/server test`
- `pnpm --filter @phantompane/web test`
- `pnpm ready`
- `git diff --check`