### PR TITLE
[codex] Start chats in existing worktrees

### DIFF
--- a/packages/server/src/rpc.test.ts
+++ b/packages/server/src/rpc.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, it, vi } from "vitest";
 
 const services = vi.hoisted(() => ({
   addProject: vi.fn(),
+  createChat: vi.fn(),
   listProjects: vi.fn(),
 }));
 
@@ -60,6 +61,42 @@ describe("rpcRoutes", () => {
     deepStrictEqual(await response.json(), {
       error: {
         message: "Invalid input: expected string, received undefined",
+      },
+    });
+  });
+
+  it("rejects partial existing-worktree chat creation bodies", async () => {
+    const response = await rpcRoutes.request("/projects/proj_1/chats", {
+      method: "POST",
+      body: JSON.stringify({ worktreeName: "feature" }),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+    strictEqual(response.status, 400);
+    strictEqual(services.createChat.mock.calls.length, 0);
+    deepStrictEqual(await response.json(), {
+      error: {
+        message: "Worktree path is required",
+      },
+    });
+  });
+
+  it("rejects blank existing-worktree chat paths", async () => {
+    const response = await rpcRoutes.request("/projects/proj_1/chats", {
+      method: "POST",
+      body: JSON.stringify({ worktreeName: "feature", worktreePath: " " }),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+    strictEqual(response.status, 400);
+    strictEqual(services.createChat.mock.calls.length, 0);
+    deepStrictEqual(await response.json(), {
+      error: {
+        message: "Worktree path is required",
       },
     });
   });

--- a/packages/server/src/rpc.ts
+++ b/packages/server/src/rpc.ts
@@ -14,10 +14,29 @@ const createProjectSchema = z.object({
   path: z.string().min(1, "Project path is required"),
 });
 
-const createChatSchema = z.object({
-  name: z.string().optional(),
-  base: z.string().optional(),
-});
+const createChatSchema = z
+  .object({
+    name: z.string().optional(),
+    base: z.string().optional(),
+    worktreeName: z.string().optional(),
+    worktreePath: z.string().optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (value.worktreePath !== undefined && !value.worktreePath.trim()) {
+      ctx.addIssue({
+        code: "custom",
+        message: "Worktree path is required",
+        path: ["worktreePath"],
+      });
+    }
+    if (value.worktreeName !== undefined && value.worktreePath === undefined) {
+      ctx.addIssue({
+        code: "custom",
+        message: "Worktree path is required",
+        path: ["worktreePath"],
+      });
+    }
+  });
 
 const worktreeSchema = z.object({
   name: z.string().min(1, "Worktree name is required"),
@@ -188,6 +207,8 @@ export const rpcRoutes = new Hono()
         {
           name: body.name,
           base: body.base,
+          worktreeName: body.worktreeName,
+          worktreePath: body.worktreePath,
         },
       );
       return c.json({ chat }, 201);

--- a/packages/server/src/services.test.ts
+++ b/packages/server/src/services.test.ts
@@ -1332,6 +1332,85 @@ describe("ServeServices", () => {
     deepStrictEqual(savedState.messages, []);
   });
 
+  it("starts a new Codex thread in an existing worktree", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+    };
+    const store = new ServeStateStore(await createTemporaryDirectory());
+    await store.save(state);
+    const codex = new FakeCodexBridge();
+    const services = new ServeServices({
+      codex: codex as unknown as CodexBridge,
+      store,
+    });
+    coreMocks.listWorktrees.mockResolvedValueOnce({
+      ok: true,
+      value: {
+        worktrees: [
+          {
+            name: "main",
+            path: "/repo",
+            pathToDisplay: ".",
+            branch: "main",
+            isClean: true,
+          },
+          {
+            name: "feature",
+            path: "/repo/.git/phantom/worktrees/feature",
+            pathToDisplay: ".git/phantom/worktrees/feature",
+            branch: "feature",
+            isClean: true,
+          },
+        ],
+      },
+    });
+    codex.startThread.mockResolvedValueOnce({ thread: { id: "thread_new" } });
+
+    const chat = await services.createChat("proj_1", {
+      worktreeName: "feature",
+      worktreePath: "/repo/.git/phantom/worktrees/feature",
+    });
+
+    strictEqual(coreMocks.runCreateWorktree.mock.calls.length, 0);
+    deepStrictEqual(coreMocks.listWorktrees.mock.calls[0], [
+      "/repo",
+      { includePrunable: false },
+    ]);
+    deepStrictEqual(codex.startThread.mock.calls[0], [
+      "/repo/.git/phantom/worktrees/feature",
+    ]);
+    strictEqual(chat.worktreeName, "feature");
+    strictEqual(chat.worktreePath, "/repo/.git/phantom/worktrees/feature");
+    strictEqual(chat.branchName, "feature");
+    strictEqual(chat.codexThreadId, "thread_new");
+    const savedState = await store.load();
+    strictEqual(savedState.selectedChatId, chat.id);
+    deepStrictEqual(
+      savedState.chats.map((candidate) => candidate.id),
+      [chat.id],
+    );
+  });
+
+  it("rejects partial existing-worktree chat creation input", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+    };
+    const { codex, services } = await createHarness(state);
+
+    await rejects(
+      services.createChat("proj_1", {
+        worktreeName: "feature",
+      }),
+      /Worktree path is required/,
+    );
+
+    strictEqual(coreMocks.runCreateWorktree.mock.calls.length, 0);
+    strictEqual(coreMocks.listWorktrees.mock.calls.length, 0);
+    strictEqual(codex.startThread.mock.calls.length, 0);
+  });
+
   it("stores a newly created chat without importing existing history", async () => {
     const worktreePath = "/repo/.git/phantom/worktrees/feature";
     const state = {

--- a/packages/server/src/services.ts
+++ b/packages/server/src/services.ts
@@ -53,6 +53,8 @@ import type {
 export interface CreateChatInput {
   name?: string;
   base?: string;
+  worktreeName?: string;
+  worktreePath?: string;
 }
 
 export interface DeleteProjectWorktreeInput {
@@ -546,6 +548,59 @@ export class ServeServices {
   ): Promise<ChatRecord> {
     const state = await this.store.load();
     const project = this.requireProject(state, projectId);
+
+    const targetWorktreePath = input.worktreePath?.trim();
+    const targetWorktreeName = input.worktreeName?.trim();
+    const hasExistingWorktreeInput =
+      input.worktreePath !== undefined || input.worktreeName !== undefined;
+    if (hasExistingWorktreeInput) {
+      if (!targetWorktreePath) {
+        throw new Error("Worktree path is required");
+      }
+      const worktreesResult = await listWorktrees(project.rootPath, {
+        includePrunable: false,
+      });
+      if (!worktreesResult.ok) {
+        throw worktreesResult.error;
+      }
+      const targetWorktree = worktreesResult.value.worktrees.find(
+        (worktree) =>
+          worktree.path === targetWorktreePath &&
+          (!targetWorktreeName || worktree.name === targetWorktreeName),
+      );
+      if (!targetWorktree) {
+        throw new Error(`Worktree '${targetWorktreePath}' not found`);
+      }
+
+      const threadResult = await this.codex.startThread(targetWorktree.path);
+      const codexThreadId = extractThreadId(threadResult);
+      this.loadedThreadIds.add(codexThreadId);
+      const timestamp = createTimestamp();
+      const chat: ChatRecord = {
+        id: createRecordId("chat"),
+        projectId,
+        worktreeName: targetWorktree.name,
+        worktreePath: targetWorktree.path,
+        branchName: targetWorktree.branch,
+        codexThreadId,
+        title: targetWorktree.name,
+        status: "idle",
+        activeTurnId: null,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      };
+
+      await this.store.update((nextState) => ({
+        ...nextState,
+        chats: [...nextState.chats, chat],
+        selectedProjectId: projectId,
+        selectedChatId: chat.id,
+      }));
+
+      this.eventHub.emit("chat.created", chat, { chatId: chat.id });
+      return chat;
+    }
+
     const createResult = await runCreateWorktree({
       gitRoot: project.rootPath,
       name: input.name,

--- a/packages/web/src/api/mutations.test.ts
+++ b/packages/web/src/api/mutations.test.ts
@@ -2,6 +2,7 @@ import { strictEqual } from "node:assert";
 import { afterEach, describe, it, vi } from "vitest";
 import {
   answerApprovalMutation,
+  createChatMutation,
   queueMessageMutation,
   steerMessageMutation,
 } from "./mutations";
@@ -40,6 +41,37 @@ describe("answerApprovalMutation", () => {
     strictEqual(
       requestUrl,
       "/api/chats/chat%2Fwith%23hash/approvals/request%2Fwith%23hash",
+    );
+  });
+});
+
+describe("createChatMutation", () => {
+  it("sends target worktree data when starting a chat in an existing worktree", async () => {
+    let requestBody: string | undefined;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        requestBody = init?.body?.toString();
+        return new Response('{"chat":{"id":"chat_1"}}', {
+          headers: {
+            "Content-Type": "application/json",
+          },
+          status: 201,
+        });
+      }),
+    );
+
+    await createChatMutation("proj_1", {
+      worktreeName: "feature",
+      worktreePath: "/repo/.git/phantom/worktrees/feature",
+    });
+
+    strictEqual(
+      requestBody,
+      JSON.stringify({
+        worktreeName: "feature",
+        worktreePath: "/repo/.git/phantom/worktrees/feature",
+      }),
     );
   });
 });

--- a/packages/web/src/api/mutations.ts
+++ b/packages/web/src/api/mutations.ts
@@ -20,6 +20,11 @@ export interface SendMessageInput {
   text: string;
 }
 
+export interface CreateChatInput {
+  worktreeName?: string;
+  worktreePath?: string;
+}
+
 export async function addProjectMutation(path: string) {
   return readRpcJson<{ project: ProjectRecord }>(
     await api.projects.$post({
@@ -28,11 +33,14 @@ export async function addProjectMutation(path: string) {
   );
 }
 
-export async function createChatMutation(projectId: string) {
+export async function createChatMutation(
+  projectId: string,
+  input: CreateChatInput = {},
+) {
   return readRpcJson<{ chat: ChatRecord }>(
     await api.projects[":projectId"].chats.$post({
       param: { projectId: routeParam(projectId) },
-      json: {},
+      json: input,
     }),
   );
 }

--- a/packages/web/src/routes/home.tsx
+++ b/packages/web/src/routes/home.tsx
@@ -473,6 +473,9 @@ export function HomeRoute() {
   const [creatingProjectId, setCreatingProjectId] = useState<string | null>(
     null,
   );
+  const [creatingWorktreeKey, setCreatingWorktreeKey] = useState<string | null>(
+    null,
+  );
   const [isSendingMessage, setIsSendingMessage] = useState(false);
   const [pendingComposerMode, setPendingComposerMode] =
     useState<ComposerSubmitMode | null>(null);
@@ -500,7 +503,13 @@ export function HomeRoute() {
     mutationFn: addProjectMutation,
   });
   const createChatRequest = useMutation({
-    mutationFn: createChatMutation,
+    mutationFn: ({
+      input,
+      projectId,
+    }: {
+      input?: Parameters<typeof createChatMutation>[1];
+      projectId: string;
+    }) => createChatMutation(projectId, input),
   });
   const deleteWorktreeRequest = useMutation({
     mutationFn: ({
@@ -1539,18 +1548,36 @@ export function HomeRoute() {
     }
   }
 
-  async function createChat(projectId: string) {
+  async function createChat(
+    projectId: string,
+    worktree?: ProjectWorktreeRecord,
+  ) {
     if (isBusy || createChatInFlightRef.current) {
       return;
     }
 
     setError(null);
     const requestWorkspaceSelectionKey = workspaceSelectionKeyRef.current;
+    const worktreeKey = worktree
+      ? getWorktreeExpansionKey(projectId, worktree.path)
+      : null;
     createChatInFlightRef.current = true;
-    setCreatingProjectId(projectId);
+    if (worktreeKey) {
+      setCreatingWorktreeKey(worktreeKey);
+    } else {
+      setCreatingProjectId(projectId);
+    }
     setIsBusy(true);
     try {
-      const data = await createChatRequest.mutateAsync(projectId);
+      const data = await createChatRequest.mutateAsync({
+        projectId,
+        input: worktree
+          ? {
+              worktreeName: worktree.name,
+              worktreePath: worktree.path,
+            }
+          : {},
+      });
       void queryClient.invalidateQueries({
         queryKey: queryKeys.projectWorktrees(projectId),
       });
@@ -1587,6 +1614,7 @@ export function HomeRoute() {
     } finally {
       createChatInFlightRef.current = false;
       setCreatingProjectId(null);
+      setCreatingWorktreeKey(null);
       setIsBusy(false);
     }
   }
@@ -2077,6 +2105,8 @@ export function HomeRoute() {
                                   project.id,
                                   worktree.path,
                                 );
+                                const isCreatingWorktreeChat =
+                                  creatingWorktreeKey === worktreeKey;
                                 const isWorktreeExpanded =
                                   expandedWorktreeKeys.has(worktreeKey);
                                 const isChatListLoading =
@@ -2161,6 +2191,29 @@ export function HomeRoute() {
                                           />
                                         )}
                                       </SidebarMenuSubButton>
+                                      <Button
+                                        aria-label={`Start new chat in ${worktree.name}`}
+                                        className={cn(
+                                          "size-7 text-[var(--icon-color-default)] opacity-100 sm:opacity-0 sm:group-focus-within/worktree:opacity-100 sm:group-hover/worktree:opacity-100",
+                                          (isSelectedWorktree ||
+                                            isCreatingWorktreeChat) &&
+                                            "sm:opacity-100",
+                                        )}
+                                        disabled={isBusy}
+                                        onClick={() =>
+                                          void createChat(project.id, worktree)
+                                        }
+                                        size="icon"
+                                        title="New chat"
+                                        type="button"
+                                        variant="ghost"
+                                      >
+                                        {isCreatingWorktreeChat ? (
+                                          <LoadingSpinner className="size-4" />
+                                        ) : (
+                                          <MessageSquarePlus className="size-4" />
+                                        )}
+                                      </Button>
                                       {canShowActions && (
                                         <DropdownMenu>
                                           <DropdownMenuTrigger asChild>


### PR DESCRIPTION
## Summary

Adds support for starting a new Codex chat inside an existing worktree from Phantom Serve.

## Changes

- Extends the create chat RPC payload with target worktree fields.
- Starts a new Codex thread against an existing worktree when `worktreePath` is provided.
- Adds a compact new-chat action to each worktree row in the sidebar.
- Selects and expands the newly created chat after creation.
- Covers the server path and web mutation payload with tests.

## Validation

- `pnpm --filter @phantompane/server test -- services.test.ts`
- `pnpm --filter @phantompane/web test -- mutations.test.ts`
- `pnpm ready`