### PR TITLE
[codex] Show queued and steered message states

### DIFF
--- a/packages/server/src/services.test.ts
+++ b/packages/server/src/services.test.ts
@@ -1094,6 +1094,609 @@ describe("ServeServices", () => {
     );
   });
 
+  it("preserves steered message metadata when Codex history uses the turn timestamp", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat()],
+      messages: [
+        {
+          id: "msg_steered",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "adjust course",
+          eventType: "chat.message.steered",
+          itemId: "turn_1",
+          createdAt: "2026-04-25T00:01:00.000Z",
+        },
+      ],
+    };
+    const { codex, services } = await createHarness(state);
+    codex.readThread.mockResolvedValueOnce({
+      thread: {
+        turns: [
+          {
+            id: "turn_1",
+            createdAt: "2026-04-25T00:00:00.000Z",
+            input: [{ text: "start" }],
+            items: [{ type: "userMessage", text: "adjust course" }],
+          },
+        ],
+      },
+    });
+
+    const messages = await services.getMessages("chat_1");
+
+    deepStrictEqual(
+      messages.map((message) => [
+        message.id,
+        message.role,
+        message.text,
+        message.eventType,
+        message.createdAt,
+      ]),
+      [
+        [
+          "chat_1_codex_turn_1_0",
+          "user",
+          "start",
+          undefined,
+          "2026-04-25T00:00:00.000Z",
+        ],
+        [
+          "chat_1_codex_turn_1_1",
+          "user",
+          "adjust course",
+          "chat.message.steered",
+          "2026-04-25T00:01:00.000Z",
+        ],
+      ],
+    );
+  });
+
+  it("keeps queued messages local while matching Codex history exists", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat()],
+      messages: [
+        {
+          id: "msg_queued",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "repeat",
+          eventType: "chat.message.queued",
+          createdAt: "2026-04-25T00:01:00.000Z",
+        },
+      ],
+      queuedMessages: [
+        {
+          id: "queue_1",
+          chatId: "chat_1",
+          messageId: "msg_queued",
+          text: "repeat",
+          createdAt: "2026-04-25T00:01:00.000Z",
+        },
+      ],
+    };
+    const { codex, services } = await createHarness(state);
+    codex.readThread.mockResolvedValueOnce({
+      thread: {
+        turns: [
+          {
+            id: "turn_1",
+            createdAt: "2026-04-25T00:02:00.000Z",
+            items: [{ type: "userMessage", text: "repeat" }],
+          },
+        ],
+      },
+    });
+
+    const messages = await services.getMessages("chat_1");
+
+    deepStrictEqual(
+      messages.map((message) => [
+        message.id,
+        message.role,
+        message.text,
+        message.eventType,
+      ]),
+      [
+        ["msg_queued", "user", "repeat", "chat.message.queued"],
+        ["chat_1_codex_turn_1_0", "user", "repeat", undefined],
+      ],
+    );
+  });
+
+  it("attaches steered metadata to the later matching Codex item", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat()],
+      messages: [
+        {
+          id: "msg_steered_repeat",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "repeat",
+          eventType: "chat.message.steered",
+          itemId: "turn_1",
+          createdAt: "2026-04-25T00:01:00.000Z",
+        },
+      ],
+    };
+    const { codex, services } = await createHarness(state);
+    codex.readThread.mockResolvedValueOnce({
+      thread: {
+        turns: [
+          {
+            id: "turn_1",
+            createdAt: "2026-04-25T00:00:00.000Z",
+            input: [{ text: "repeat" }],
+            items: [{ type: "userMessage", text: "repeat" }],
+          },
+        ],
+      },
+    });
+
+    const messages = await services.getMessages("chat_1");
+
+    deepStrictEqual(
+      messages.map((message) => [
+        message.id,
+        message.role,
+        message.text,
+        message.eventType,
+        message.createdAt,
+      ]),
+      [
+        [
+          "chat_1_codex_turn_1_0",
+          "user",
+          "repeat",
+          undefined,
+          "2026-04-25T00:00:00.000Z",
+        ],
+        [
+          "chat_1_codex_turn_1_1",
+          "user",
+          "repeat",
+          "chat.message.steered",
+          "2026-04-25T00:01:00.000Z",
+        ],
+      ],
+    );
+  });
+
+  it("preserves repeated same-text steered message order", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat()],
+      messages: [
+        {
+          id: "msg_steered_repeat_1",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "repeat",
+          eventType: "chat.message.steered",
+          itemId: "turn_1",
+          createdAt: "2026-04-25T00:01:00.000Z",
+        },
+        {
+          id: "msg_steered_repeat_2",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "repeat",
+          eventType: "chat.message.steered",
+          itemId: "turn_1",
+          createdAt: "2026-04-25T00:02:00.000Z",
+        },
+      ],
+    };
+    const { codex, services } = await createHarness(state);
+    codex.readThread.mockResolvedValueOnce({
+      thread: {
+        turns: [
+          {
+            id: "turn_1",
+            createdAt: "2026-04-25T00:00:00.000Z",
+            input: [{ text: "repeat" }],
+            items: [
+              { type: "userMessage", text: "repeat" },
+              { type: "userMessage", text: "repeat" },
+            ],
+          },
+        ],
+      },
+    });
+
+    const messages = await services.getMessages("chat_1");
+
+    deepStrictEqual(
+      messages.map((message) => [
+        message.id,
+        message.role,
+        message.text,
+        message.eventType,
+        message.createdAt,
+      ]),
+      [
+        [
+          "chat_1_codex_turn_1_0",
+          "user",
+          "repeat",
+          undefined,
+          "2026-04-25T00:00:00.000Z",
+        ],
+        [
+          "chat_1_codex_turn_1_1",
+          "user",
+          "repeat",
+          "chat.message.steered",
+          "2026-04-25T00:01:00.000Z",
+        ],
+        [
+          "chat_1_codex_turn_1_2",
+          "user",
+          "repeat",
+          "chat.message.steered",
+          "2026-04-25T00:02:00.000Z",
+        ],
+      ],
+    );
+  });
+
+  it("does not attach steered metadata to repeated initial Codex input", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat()],
+      messages: [
+        {
+          id: "msg_steered_after_inputs",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "repeat",
+          eventType: "chat.message.steered",
+          itemId: "turn_1",
+          createdAt: "2026-04-25T00:01:00.000Z",
+        },
+      ],
+    };
+    const { codex, services } = await createHarness(state);
+    codex.readThread.mockResolvedValueOnce({
+      thread: {
+        turns: [
+          {
+            id: "turn_1",
+            createdAt: "2026-04-25T00:00:00.000Z",
+            input: [{ text: "repeat" }, { text: "repeat" }],
+            items: [{ type: "userMessage", text: "repeat" }],
+          },
+        ],
+      },
+    });
+
+    const messages = await services.getMessages("chat_1");
+
+    deepStrictEqual(
+      messages.map((message) => [
+        message.id,
+        message.role,
+        message.text,
+        message.eventType,
+        message.createdAt,
+        "codexItemSource" in message,
+        "codexOrder" in message,
+        "mergeSortBucket" in message,
+        "mergeSortIndex" in message,
+      ]),
+      [
+        [
+          "chat_1_codex_turn_1_0",
+          "user",
+          "repeat",
+          undefined,
+          "2026-04-25T00:00:00.000Z",
+          false,
+          false,
+          false,
+          false,
+        ],
+        [
+          "chat_1_codex_turn_1_1",
+          "user",
+          "repeat",
+          undefined,
+          "2026-04-25T00:00:00.000Z",
+          false,
+          false,
+          false,
+          false,
+        ],
+        [
+          "chat_1_codex_turn_1_2",
+          "user",
+          "repeat",
+          "chat.message.steered",
+          "2026-04-25T00:01:00.000Z",
+          false,
+          false,
+          false,
+          false,
+        ],
+      ],
+    );
+  });
+
+  it("matches steered Codex item metadata when a turn has no input records", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat()],
+      messages: [
+        {
+          id: "msg_steered_without_input",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "repeat",
+          eventType: "chat.message.steered",
+          itemId: "turn_1",
+          createdAt: "2026-04-25T00:01:00.000Z",
+        },
+      ],
+    };
+    const { codex, services } = await createHarness(state);
+    codex.readThread.mockResolvedValueOnce({
+      thread: {
+        turns: [
+          {
+            id: "turn_1",
+            createdAt: "2026-04-25T00:00:00.000Z",
+            items: [{ type: "userMessage", text: "repeat" }],
+          },
+          {
+            id: "turn_2",
+            createdAt: "2026-04-25T00:03:00.000Z",
+            items: [{ type: "userMessage", text: "repeat" }],
+          },
+        ],
+      },
+    });
+
+    const messages = await services.getMessages("chat_1");
+
+    deepStrictEqual(
+      messages.map((message) => [
+        message.id,
+        message.role,
+        message.text,
+        message.eventType,
+        message.createdAt,
+      ]),
+      [
+        [
+          "chat_1_codex_turn_1_0",
+          "user",
+          "repeat",
+          "chat.message.steered",
+          "2026-04-25T00:01:00.000Z",
+        ],
+        [
+          "chat_1_codex_turn_2_0",
+          "user",
+          "repeat",
+          undefined,
+          "2026-04-25T00:03:00.000Z",
+        ],
+      ],
+    );
+  });
+
+  it("does not attach steered metadata to the first same-text item when a turn has no input records", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat()],
+      messages: [
+        {
+          id: "msg_steered_without_input_repeat",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "repeat",
+          eventType: "chat.message.steered",
+          itemId: "turn_1",
+          createdAt: "2026-04-25T00:01:00.000Z",
+        },
+      ],
+    };
+    const { codex, services } = await createHarness(state);
+    codex.readThread.mockResolvedValueOnce({
+      thread: {
+        turns: [
+          {
+            id: "turn_1",
+            createdAt: "2026-04-25T00:00:00.000Z",
+            items: [
+              { type: "userMessage", text: "repeat" },
+              { type: "userMessage", text: "repeat" },
+            ],
+          },
+        ],
+      },
+    });
+
+    const messages = await services.getMessages("chat_1");
+
+    deepStrictEqual(
+      messages.map((message) => [
+        message.id,
+        message.role,
+        message.text,
+        message.eventType,
+        message.createdAt,
+      ]),
+      [
+        [
+          "chat_1_codex_turn_1_0",
+          "user",
+          "repeat",
+          undefined,
+          "2026-04-25T00:00:00.000Z",
+        ],
+        [
+          "chat_1_codex_turn_1_1",
+          "user",
+          "repeat",
+          "chat.message.steered",
+          "2026-04-25T00:01:00.000Z",
+        ],
+      ],
+    );
+  });
+
+  it("preserves repeated same-text steered order when a turn has no input records", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat()],
+      messages: [
+        {
+          id: "msg_steered_without_input_1",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "repeat",
+          eventType: "chat.message.steered",
+          itemId: "turn_1",
+          createdAt: "2026-04-25T00:01:00.000Z",
+        },
+        {
+          id: "msg_steered_without_input_2",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "repeat",
+          eventType: "chat.message.steered",
+          itemId: "turn_1",
+          createdAt: "2026-04-25T00:02:00.000Z",
+        },
+      ],
+    };
+    const { codex, services } = await createHarness(state);
+    codex.readThread.mockResolvedValueOnce({
+      thread: {
+        turns: [
+          {
+            id: "turn_1",
+            createdAt: "2026-04-25T00:00:00.000Z",
+            items: [
+              { type: "userMessage", text: "repeat" },
+              { type: "userMessage", text: "repeat" },
+            ],
+          },
+        ],
+      },
+    });
+
+    const messages = await services.getMessages("chat_1");
+
+    deepStrictEqual(
+      messages.map((message) => [
+        message.id,
+        message.role,
+        message.text,
+        message.eventType,
+        message.createdAt,
+      ]),
+      [
+        [
+          "chat_1_codex_turn_1_0",
+          "user",
+          "repeat",
+          "chat.message.steered",
+          "2026-04-25T00:01:00.000Z",
+        ],
+        [
+          "chat_1_codex_turn_1_1",
+          "user",
+          "repeat",
+          "chat.message.steered",
+          "2026-04-25T00:02:00.000Z",
+        ],
+      ],
+    );
+  });
+
+  it("keeps Codex item order when steered metadata uses the local timestamp", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat()],
+      messages: [
+        {
+          id: "msg_steered_before_assistant",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "adjust course",
+          eventType: "chat.message.steered",
+          itemId: "turn_1",
+          createdAt: "2026-04-25T00:01:00.000Z",
+        },
+      ],
+    };
+    const { codex, services } = await createHarness(state);
+    codex.readThread.mockResolvedValueOnce({
+      thread: {
+        turns: [
+          {
+            id: "turn_1",
+            createdAt: "2026-04-25T00:00:00.000Z",
+            input: [{ text: "start" }],
+            items: [
+              { type: "userMessage", text: "adjust course" },
+              { type: "assistantMessage", text: "done" },
+            ],
+          },
+        ],
+      },
+    });
+
+    const messages = await services.getMessages("chat_1");
+
+    deepStrictEqual(
+      messages.map((message) => [
+        message.id,
+        message.role,
+        message.text,
+        message.eventType,
+        message.createdAt,
+      ]),
+      [
+        [
+          "chat_1_codex_turn_1_0",
+          "user",
+          "start",
+          undefined,
+          "2026-04-25T00:00:00.000Z",
+        ],
+        [
+          "chat_1_codex_turn_1_1",
+          "user",
+          "adjust course",
+          "chat.message.steered",
+          "2026-04-25T00:01:00.000Z",
+        ],
+        [
+          "chat_1_codex_turn_1_2",
+          "assistant",
+          "done",
+          undefined,
+          "2026-04-25T00:00:00.000Z",
+        ],
+      ],
+    );
+  });
+
   it("preserves local chats that already match Codex threads", async () => {
     const threadId = "019dc000-0000-7000-8000-000000000001";
     const worktreePath = "/repo/.git/phantom/worktrees/feature/list";
@@ -3319,6 +3922,32 @@ describe("ServeServices", () => {
     strictEqual(savedState.chats[0]?.status, "waitingForApproval");
     strictEqual(codex.startTurn.mock.calls.length, 0);
     strictEqual(codex.steerTurn.mock.calls.length, 0);
+  });
+
+  it("marks messages that steer an active turn", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "running", activeTurnId: "turn_1" })],
+    };
+    const { codex, services, store } = await createHarness(state);
+    markChatActiveInCurrentProcess(services, "chat_1");
+    codex.resumeThread.mockResolvedValueOnce({});
+
+    await services.steerMessage("chat_1", { text: "adjust course" });
+
+    const savedState = await store.load();
+    strictEqual(savedState.messages[0]?.text, "adjust course");
+    strictEqual(savedState.messages[0]?.eventType, "chat.message.steered");
+    strictEqual(savedState.messages[0]?.itemId, "turn_1");
+    strictEqual(savedState.chats[0]?.status, "running");
+    strictEqual(savedState.chats[0]?.activeTurnId, "turn_1");
+    deepStrictEqual(codex.steerTurn.mock.calls[0], [
+      "thread_1",
+      "turn_1",
+      "adjust course",
+    ]);
+    strictEqual(codex.startTurn.mock.calls.length, 0);
   });
 
   it("keeps a running chat active when steering fails", async () => {

--- a/packages/server/src/services.ts
+++ b/packages/server/src/services.ts
@@ -116,6 +116,14 @@ interface SubmitMessageOptions {
 type PendingTurnEvent =
   | { kind: "notification"; message: CodexMessage }
   | { kind: "serverRequest"; message: CodexMessage };
+
+type CodexTurnItemSource = "input" | "item";
+type InternalChatMessageRecord = ChatMessageRecord & {
+  codexOrder?: number;
+  codexItemSource?: CodexTurnItemSource;
+  mergeSortBucket?: number;
+  mergeSortIndex?: number;
+};
 type ServerRequestId = number | string;
 
 interface ProjectWorktreeSnapshot {
@@ -897,7 +905,13 @@ export class ServeServices {
           ...existingUserMessage,
           eventType: undefined,
         }
-      : createMessage(chat.id, "user", text);
+      : createMessage(
+          chat.id,
+          "user",
+          text,
+          isSteeringActiveTurn ? "chat.message.steered" : undefined,
+          isSteeringActiveTurn ? (chat.activeTurnId ?? undefined) : undefined,
+        );
     let nextStatus: ChatStatus | null = null;
     let nextActiveTurnId: string | null | undefined;
     let pendingTurnThreadId: string | null = null;
@@ -2184,7 +2198,7 @@ function sortChatsByUpdatedAt(chats: ChatRecord[]): ChatRecord[] {
 function normalizeCodexThreadMessages(
   value: unknown,
   chatId: string,
-): ChatMessageRecord[] {
+): InternalChatMessageRecord[] {
   const thread =
     getRecordObject(value, "thread") ?? (isRecord(value) ? value : null);
   const turns = thread ? getRecordArray(thread, "turns") : undefined;
@@ -2192,7 +2206,8 @@ function normalizeCodexThreadMessages(
     return [];
   }
 
-  const messages: ChatMessageRecord[] = [];
+  const messages: InternalChatMessageRecord[] = [];
+  let codexOrder = 0;
   for (const [turnIndex, turn] of turns.entries()) {
     const turnId =
       getRecordString(turn, "id") ??
@@ -2217,6 +2232,8 @@ function normalizeCodexThreadMessages(
         chatId,
         role,
         text,
+        codexOrder: codexOrder++,
+        codexItemSource: item.codexItemSource,
         itemId: getRecordString(item, "id") ?? undefined,
         createdAt: normalizeCodexTimestamp(
           item.createdAt ?? item.created_at ?? item.timestamp,
@@ -2232,15 +2249,23 @@ function normalizeCodexThreadMessages(
 
 function getCodexTurnItems(
   turn: Record<string, unknown>,
-): Array<Record<string, unknown>> {
+): Array<Record<string, unknown> & { codexItemSource: CodexTurnItemSource }> {
   const inputItems = Array.isArray(turn.input)
-    ? turn.input.filter(isRecord).map((item) => ({ ...item, role: "user" }))
+    ? turn.input.filter(isRecord).map((item) => ({
+        ...item,
+        codexItemSource: "input" as const,
+        role: "user",
+      }))
     : [];
+  const turnItems = (items: unknown[]) =>
+    items
+      .filter(isRecord)
+      .map((item) => ({ ...item, codexItemSource: "item" as const }));
   if (Array.isArray(turn.items)) {
-    return [...inputItems, ...turn.items.filter(isRecord)];
+    return [...inputItems, ...turnItems(turn.items)];
   }
   if (Array.isArray(turn.output)) {
-    return [...inputItems, ...turn.output.filter(isRecord)];
+    return [...inputItems, ...turnItems(turn.output)];
   }
   return inputItems;
 }
@@ -2294,48 +2319,236 @@ function extractCodexText(value: unknown): string {
 }
 
 function mergeCodexAndLocalMessages(
-  codexMessages: ChatMessageRecord[],
+  codexMessages: InternalChatMessageRecord[],
   localMessages: ChatMessageRecord[],
 ): ChatMessageRecord[] {
   if (codexMessages.length === 0) {
     return localMessages;
   }
-  const unmatchedCodexMessages = [...codexMessages];
-  const merged = [
-    ...codexMessages,
-    ...localMessages.filter((message) => {
-      if (message.role === "event" || message.role === "error") {
-        return true;
-      }
-      const matchedCodexIndex = unmatchedCodexMessages.findIndex(
-        (codexMessage) => shouldDeduplicateLocalMessage(codexMessage, message),
+  const mergedCodexMessages = [...codexMessages];
+  const unmatchedCodexMessageIndexes = codexMessages.map((_, index) => index);
+  const steeredLocalMessageCounts = countSteeredLocalMessages(localMessages);
+  const retainedLocalMessages = localMessages.filter((message) => {
+    if (message.role === "event" || message.role === "error") {
+      return true;
+    }
+    if (message.eventType === "chat.message.queued") {
+      return true;
+    }
+    const matchedCodexIndex = findDeduplicatedCodexMessageIndex(
+      unmatchedCodexMessageIndexes,
+      mergedCodexMessages,
+      message,
+      steeredLocalMessageCounts,
+    );
+    if (matchedCodexIndex === undefined) {
+      return true;
+    }
+    const matchedCodexMessage = mergedCodexMessages[matchedCodexIndex];
+    if (message.eventType && matchedCodexMessage) {
+      mergedCodexMessages[matchedCodexIndex] = {
+        ...matchedCodexMessage,
+        createdAt:
+          message.eventType === "chat.message.steered"
+            ? message.createdAt
+            : matchedCodexMessage.createdAt,
+        eventType: message.eventType,
+      };
+    }
+    unmatchedCodexMessageIndexes.splice(
+      unmatchedCodexMessageIndexes.indexOf(matchedCodexIndex),
+      1,
+    );
+    return false;
+  });
+  return assignMergedMessageSortKeys(mergedCodexMessages, retainedLocalMessages)
+    .sort(compareMergedMessages)
+    .map(stripInternalCodexMessageMetadata);
+}
+
+function assignMergedMessageSortKeys(
+  codexMessages: InternalChatMessageRecord[],
+  localMessages: ChatMessageRecord[],
+): InternalChatMessageRecord[] {
+  const orderedCodexMessages = [...codexMessages].sort(
+    (left, right) => (left.codexOrder ?? 0) - (right.codexOrder ?? 0),
+  );
+  return [
+    ...orderedCodexMessages.map((message, index) => ({
+      ...message,
+      mergeSortBucket: (message.codexOrder ?? index) * 2,
+      mergeSortIndex: 0,
+    })),
+    ...localMessages.map((message, index) => {
+      const insertionIndex = orderedCodexMessages.findIndex(
+        (codexMessage) => codexMessage.createdAt > message.createdAt,
       );
-      if (matchedCodexIndex === -1) {
-        return true;
-      }
-      unmatchedCodexMessages.splice(matchedCodexIndex, 1);
-      return false;
+      return {
+        ...message,
+        mergeSortBucket:
+          insertionIndex === -1
+            ? orderedCodexMessages.length * 2 + 1
+            : insertionIndex * 2 - 1,
+        mergeSortIndex: index,
+      };
     }),
   ];
-  return merged.sort((left, right) =>
-    left.createdAt.localeCompare(right.createdAt),
-  );
+}
+
+function compareMergedMessages(
+  left: InternalChatMessageRecord,
+  right: InternalChatMessageRecord,
+): number {
+  if (left.mergeSortBucket !== right.mergeSortBucket) {
+    return (left.mergeSortBucket ?? 0) - (right.mergeSortBucket ?? 0);
+  }
+  const timeComparison = left.createdAt.localeCompare(right.createdAt);
+  if (timeComparison !== 0) {
+    return timeComparison;
+  }
+  return (left.mergeSortIndex ?? 0) - (right.mergeSortIndex ?? 0);
+}
+
+function findDeduplicatedCodexMessageIndex(
+  unmatchedCodexMessageIndexes: number[],
+  codexMessages: InternalChatMessageRecord[],
+  localMessage: ChatMessageRecord,
+  steeredLocalMessageCounts: ReadonlyMap<string, number>,
+): number | undefined {
+  const matchedIndexes = unmatchedCodexMessageIndexes.filter((index) => {
+    const codexMessage = codexMessages[index];
+    return codexMessage
+      ? shouldDeduplicateLocalMessage(codexMessage, localMessage)
+      : false;
+  });
+  if (localMessage.eventType === "chat.message.steered") {
+    const orderedMatchedIndexes = [...matchedIndexes].sort(
+      (left, right) =>
+        (codexMessages[left]?.codexOrder ?? left) -
+        (codexMessages[right]?.codexOrder ?? right),
+    );
+    const localGroupKey = getSteeredMessageGroupKey(localMessage);
+    if (localMessage.itemId && localGroupKey) {
+      const localSteeredCount =
+        steeredLocalMessageCounts.get(localGroupKey) ?? 0;
+      const sameTurnCandidateIndexes = codexMessages
+        .map((message, index) => ({ index, message }))
+        .filter(
+          ({ message }) =>
+            message.codexItemSource === "item" &&
+            messageFingerprint(message) === messageFingerprint(localMessage) &&
+            getCodexTurnItemIndex(message, localMessage.itemId ?? "") !== null,
+        )
+        .sort(
+          (left, right) =>
+            (left.message.codexOrder ?? left.index) -
+            (right.message.codexOrder ?? right.index),
+        )
+        .map(({ index }) => index);
+      const excludedInitialIndexes = new Set(
+        sameTurnCandidateIndexes.slice(
+          0,
+          Math.max(0, sameTurnCandidateIndexes.length - localSteeredCount),
+        ),
+      );
+      const sameTurnMatchedIndexes = orderedMatchedIndexes.filter(
+        (index) =>
+          sameTurnCandidateIndexes.includes(index) &&
+          !excludedInitialIndexes.has(index),
+      );
+      if (sameTurnMatchedIndexes.length > 0) {
+        return sameTurnMatchedIndexes[0];
+      }
+    }
+    return orderedMatchedIndexes[0];
+  }
+  return matchedIndexes[0];
+}
+
+function countSteeredLocalMessages(
+  messages: ChatMessageRecord[],
+): ReadonlyMap<string, number> {
+  const counts = new Map<string, number>();
+  for (const message of messages) {
+    const key = getSteeredMessageGroupKey(message);
+    if (!key) {
+      continue;
+    }
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  return counts;
+}
+
+function getSteeredMessageGroupKey(message: ChatMessageRecord): string | null {
+  if (message.eventType !== "chat.message.steered" || !message.itemId) {
+    return null;
+  }
+  return `${message.itemId}\0${message.text}`;
 }
 
 function shouldDeduplicateLocalMessage(
-  codexMessage: ChatMessageRecord,
+  codexMessage: InternalChatMessageRecord,
   localMessage: ChatMessageRecord,
 ): boolean {
   if (codexMessage.role !== localMessage.role) {
     return false;
   }
-  if (codexMessage.itemId && localMessage.itemId) {
+  if (
+    localMessage.eventType !== "chat.message.steered" &&
+    codexMessage.itemId &&
+    localMessage.itemId
+  ) {
     return codexMessage.itemId === localMessage.itemId;
   }
   if (messageFingerprint(codexMessage) !== messageFingerprint(localMessage)) {
     return false;
   }
-  return isCodexMessageAtOrAfterLocalMessage(codexMessage, localMessage);
+  if (isCodexMessageAtOrAfterLocalMessage(codexMessage, localMessage)) {
+    return true;
+  }
+  return isRelaxedSteeredCodexMatch(codexMessage, localMessage);
+}
+
+function isRelaxedSteeredCodexMatch(
+  codexMessage: InternalChatMessageRecord,
+  localMessage: ChatMessageRecord,
+): boolean {
+  if (
+    localMessage.eventType !== "chat.message.steered" ||
+    !localMessage.itemId ||
+    codexMessage.codexItemSource !== "item"
+  ) {
+    return false;
+  }
+  const codexItemIndex = getCodexTurnItemIndex(
+    codexMessage,
+    localMessage.itemId,
+  );
+  return codexItemIndex !== null;
+}
+
+function stripInternalCodexMessageMetadata(
+  message: InternalChatMessageRecord,
+): ChatMessageRecord {
+  const publicMessage: InternalChatMessageRecord = { ...message };
+  delete publicMessage.codexOrder;
+  delete publicMessage.codexItemSource;
+  delete publicMessage.mergeSortBucket;
+  delete publicMessage.mergeSortIndex;
+  return publicMessage;
+}
+
+function getCodexTurnItemIndex(
+  message: ChatMessageRecord,
+  turnId: string,
+): number | null {
+  const marker = `_codex_${turnId}_`;
+  const markerIndex = message.id.lastIndexOf(marker);
+  if (markerIndex === -1) {
+    return null;
+  }
+  const itemIndex = Number(message.id.slice(markerIndex + marker.length));
+  return Number.isInteger(itemIndex) && itemIndex >= 0 ? itemIndex : null;
 }
 
 function isCodexMessageAtOrAfterLocalMessage(

--- a/packages/web/src/routes/home.tsx
+++ b/packages/web/src/routes/home.tsx
@@ -2919,12 +2919,20 @@ function EmptyTimeline({
 function MessageCard({ message }: { message: VisibleMessageRecord }) {
   const isUser = message.role === "user";
   const isError = message.role === "error";
+  const deliveryState = getMessageDeliveryState(message);
 
   return (
     <article
       className={cn(
         isUser &&
-          "ml-auto max-w-[78%] rounded-[var(--radius-lg)] border border-transparent bg-[var(--chat-user-bg)] px-4 py-3 text-[var(--chat-user-fg)] shadow-[var(--shadow-xs)]",
+          "ml-auto max-w-[78%] rounded-[var(--radius-lg)] border px-4 py-3 shadow-[var(--shadow-xs)]",
+        isUser &&
+          !deliveryState &&
+          "border-transparent bg-[var(--chat-user-bg)] text-[var(--chat-user-fg)]",
+        deliveryState === "queued" &&
+          "border-[var(--semantic-warning-border)] bg-[var(--semantic-warning-bg)] text-[var(--semantic-warning-fg)]",
+        deliveryState === "steered" &&
+          "border-[var(--semantic-info-border)] bg-[var(--semantic-info-bg)] text-[var(--semantic-info-fg)]",
         message.role === "assistant" &&
           "mr-auto max-w-[82%] px-2 py-1 text-[var(--text-primary)]",
         isError &&
@@ -2934,6 +2942,37 @@ function MessageCard({ message }: { message: VisibleMessageRecord }) {
       <pre className="whitespace-pre-wrap break-words font-sans text-[length:var(--font-size-md)] leading-[var(--line-height-relaxed)]">
         {message.text}
       </pre>
+      {deliveryState && <MessageDeliveryBadge state={deliveryState} />}
     </article>
   );
+}
+
+function MessageDeliveryBadge({ state }: { state: "queued" | "steered" }) {
+  const isQueued = state === "queued";
+  const label = isQueued ? "Queued for next turn" : "Steered into active turn";
+  const Icon = isQueued ? Clock3 : Send;
+
+  return (
+    <div className="mt-2 flex justify-end">
+      <span className="inline-flex h-6 max-w-full items-center gap-1.5 rounded-[var(--radius-sm)] border border-current/20 bg-[var(--surface-floating)] px-2 text-[length:var(--font-size-xs)] font-medium text-current">
+        <Icon className="size-3.5 shrink-0" />
+        <span className="truncate">{label}</span>
+      </span>
+    </div>
+  );
+}
+
+function getMessageDeliveryState(
+  message: VisibleMessageRecord,
+): "queued" | "steered" | null {
+  if (message.role !== "user") {
+    return null;
+  }
+  if (message.eventType === "chat.message.queued") {
+    return "queued";
+  }
+  if (message.eventType === "chat.message.steered") {
+    return "steered";
+  }
+  return null;
 }


### PR DESCRIPTION
## Summary

- Show queued user messages in the chat timeline with a `Queued for next turn` state badge.
- Persist steered active-turn messages with `chat.message.steered` metadata and render them with a `Steered into active turn` state badge.
- Preserve queued and steered metadata correctly when local messages are merged with Codex thread history, including repeated same-text messages, multiple or missing `turn.input` records, and timestamp fallback cases.

## Why

Queued and steered messages were previously hard to distinguish once they appeared in the timeline. Steered messages also needed durable metadata so the UI could keep showing their delivery state after refreshes and Codex thread reads.

## Validation

- `pnpm --filter @phantompane/server test`
- `pnpm ready`

A review/fix loop with subagents was run until no actionable findings remained.