### PR TITLE
[codex] Create named worktrees from new chat

### DIFF
--- a/packages/codex/src/bridge.test.ts
+++ b/packages/codex/src/bridge.test.ts
@@ -273,13 +273,14 @@ describe("CodexBridge", () => {
 
   it("waits for codex exec processes to close after timeout before rejecting", async () => {
     vi.useFakeTimers();
-    const { bridge, proc } = createBridge();
+    const { bridge, proc, spawnCodexProcess } = createBridge();
 
     try {
       const execPromise = bridge.exec("name this branch", {
         model: "gpt-5.4-mini",
         timeoutMs: 10,
       });
+      await vi.waitFor(() => expect(spawnCodexProcess).toHaveBeenCalledOnce());
       await vi.advanceTimersByTimeAsync(10);
 
       expect(proc.killedSignals).toEqual(["SIGTERM"]);

--- a/packages/codex/src/bridge.test.ts
+++ b/packages/codex/src/bridge.test.ts
@@ -16,6 +16,7 @@ class FakeCodexProcess extends EventEmitter {
   readonly stdin = new PassThrough();
   readonly stdout = new PassThrough();
   readonly stderr = new PassThrough();
+  readonly killedSignals: Array<NodeJS.Signals | number | undefined> = [];
   readonly writes: WrittenMessage[] = [];
 
   constructor() {
@@ -36,6 +37,11 @@ class FakeCodexProcess extends EventEmitter {
   failWithStderr(message: string): void {
     this.stderr.write(message);
     this.emit("exit", 1, null);
+  }
+
+  kill(signal?: NodeJS.Signals | number): boolean {
+    this.killedSignals.push(signal);
+    return true;
   }
 }
 
@@ -263,6 +269,28 @@ describe("CodexBridge", () => {
       id: "99",
       result: { decision: "decline" },
     });
+  });
+
+  it("waits for codex exec processes to close after timeout before rejecting", async () => {
+    vi.useFakeTimers();
+    const { bridge, proc } = createBridge();
+
+    try {
+      const execPromise = bridge.exec("name this branch", {
+        model: "gpt-5.4-mini",
+        timeoutMs: 10,
+      });
+      await vi.advanceTimersByTimeAsync(10);
+
+      expect(proc.killedSignals).toEqual(["SIGTERM"]);
+      await vi.advanceTimersByTimeAsync(2_000);
+      expect(proc.killedSignals).toEqual(["SIGTERM", "SIGKILL"]);
+
+      proc.emit("close", null, "SIGKILL");
+      await expect(execPromise).rejects.toThrow("Codex exec timed out");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("propagates app-server exits to pending requests", async () => {

--- a/packages/codex/src/bridge.test.ts
+++ b/packages/codex/src/bridge.test.ts
@@ -294,6 +294,27 @@ describe("CodexBridge", () => {
     }
   });
 
+  it("rejects codex exec after the kill grace period when close never fires", async () => {
+    vi.useFakeTimers();
+    const { bridge, proc, spawnCodexProcess } = createBridge();
+
+    try {
+      const execPromise = bridge.exec("name this branch", {
+        model: "gpt-5.4-mini",
+        timeoutMs: 10,
+      });
+      await vi.waitFor(() => expect(spawnCodexProcess).toHaveBeenCalledOnce());
+      await vi.advanceTimersByTimeAsync(10);
+
+      expect(proc.killedSignals).toEqual(["SIGTERM"]);
+      await vi.advanceTimersByTimeAsync(2_000);
+      expect(proc.killedSignals).toEqual(["SIGTERM", "SIGKILL"]);
+      await expect(execPromise).rejects.toThrow("Codex exec timed out");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("propagates app-server exits to pending requests", async () => {
     const { bridge, proc } = createBridge();
     const processExitHandler = vi.fn();

--- a/packages/codex/src/bridge.ts
+++ b/packages/codex/src/bridge.ts
@@ -231,6 +231,7 @@ export class CodexBridge {
           proc.kill("SIGTERM");
           killTimeout = setTimeout(() => {
             proc.kill("SIGKILL");
+            settle(() => reject(new Error("Codex exec timed out")));
           }, 2_000);
         }, options.timeoutMs ?? 30_000);
 

--- a/packages/codex/src/bridge.ts
+++ b/packages/codex/src/bridge.ts
@@ -1,4 +1,7 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import readline from "node:readline";
 
 export type JsonValue =
@@ -51,6 +54,12 @@ export interface CodexThreadListOptions {
 
 export interface CodexThreadReadOptions {
   includeTurns?: boolean;
+}
+
+export interface CodexExecOptions {
+  cwd?: string;
+  model: string;
+  timeoutMs?: number;
 }
 
 interface PendingRequest {
@@ -175,6 +184,95 @@ export class CodexBridge {
       roots,
       cancellationToken: null,
     });
+  }
+
+  async exec(prompt: string, options: CodexExecOptions): Promise<string> {
+    const outputDirectory = await mkdtemp(
+      join(tmpdir(), "phantom-codex-exec-"),
+    );
+    const outputPath = join(outputDirectory, "last-message.txt");
+    const args = [
+      "exec",
+      "--model",
+      options.model,
+      "--sandbox",
+      "read-only",
+      "--ephemeral",
+      "--skip-git-repo-check",
+      "--output-last-message",
+      outputPath,
+      prompt,
+    ];
+    let stdout = "";
+    let stderr = "";
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const proc = this.spawnCodexProcess(this.codexBin, args, {
+          cwd: options.cwd,
+          stdio: ["ignore", "pipe", "pipe"],
+        });
+        let isSettled = false;
+        let didTimeout = false;
+        let killTimeout: NodeJS.Timeout | null = null;
+        const settle = (callback: () => void) => {
+          if (isSettled) {
+            return;
+          }
+          isSettled = true;
+          clearTimeout(timeout);
+          if (killTimeout) {
+            clearTimeout(killTimeout);
+          }
+          callback();
+        };
+        const timeout = setTimeout(() => {
+          didTimeout = true;
+          proc.kill("SIGTERM");
+          killTimeout = setTimeout(() => {
+            proc.kill("SIGKILL");
+          }, 2_000);
+        }, options.timeoutMs ?? 30_000);
+
+        proc.stdout.on("data", (chunk: Buffer) => {
+          stdout += chunk.toString("utf8");
+        });
+        proc.stderr.on("data", (chunk: Buffer) => {
+          stderr += chunk.toString("utf8");
+        });
+        proc.on("error", (error) => {
+          settle(() => reject(error));
+        });
+        proc.on("close", (code, signal) => {
+          if (didTimeout) {
+            settle(() => reject(new Error("Codex exec timed out")));
+            return;
+          }
+          if (code === 0) {
+            settle(resolve);
+            return;
+          }
+          const detail = stderr.trim() || stdout.trim();
+          settle(() =>
+            reject(
+              new Error(
+                `Codex exec exited with ${
+                  signal ? `signal ${signal}` : `code ${code ?? 0}`
+                }${detail ? `: ${detail}` : ""}`,
+              ),
+            ),
+          );
+        });
+      });
+
+      try {
+        return await readFile(outputPath, "utf8");
+      } catch {
+        return stdout;
+      }
+    } finally {
+      await rm(outputDirectory, { recursive: true, force: true });
+    }
   }
 
   async listThreads(options: CodexThreadListOptions = {}): Promise<unknown> {

--- a/packages/server/src/rpc.ts
+++ b/packages/server/src/rpc.ts
@@ -18,6 +18,7 @@ const createChatSchema = z
   .object({
     name: z.string().optional(),
     base: z.string().optional(),
+    initialMessage: z.string().optional(),
     worktreeName: z.string().optional(),
     worktreePath: z.string().optional(),
   })
@@ -207,6 +208,7 @@ export const rpcRoutes = new Hono()
         {
           name: body.name,
           base: body.base,
+          initialMessage: body.initialMessage,
           worktreeName: body.worktreeName,
           worktreePath: body.worktreePath,
         },

--- a/packages/server/src/services.test.ts
+++ b/packages/server/src/services.test.ts
@@ -3,12 +3,19 @@ import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, it, vi } from "vitest";
+import { WorktreeAlreadyExistsError } from "@phantompane/core";
 import type { CodexBridge, CodexMessage } from "@phantompane/codex";
 import { ServeStateStore } from "@phantompane/state";
 import type { ChatRecord, ProjectRecord, ServeState } from "@phantompane/state";
 import { ServeServices } from "./services";
 
 const coreMocks = vi.hoisted(() => ({
+  WorktreeAlreadyExistsError: class WorktreeAlreadyExistsError extends Error {
+    constructor(name: string) {
+      super(`Worktree '${name}' already exists`);
+      this.name = "WorktreeAlreadyExistsError";
+    }
+  },
   createContext: vi.fn(),
   deleteBranch: vi.fn(),
   deleteWorktree: vi.fn(),
@@ -18,6 +25,7 @@ const coreMocks = vi.hoisted(() => ({
 }));
 
 const gitMocks = vi.hoisted(() => ({
+  branchExists: vi.fn(),
   getGitRoot: vi.fn(),
   getRemoteDefaultBranch: vi.fn(),
   getRemotes: vi.fn(),
@@ -35,6 +43,7 @@ class FakeCodexBridge {
   readonly notificationHandlers: Array<(message: CodexMessage) => void> = [];
   readonly processExitHandlers: Array<(error: Error) => void> = [];
   readonly serverRequestHandlers: Array<(message: CodexMessage) => void> = [];
+  readonly exec = vi.fn();
   readonly interruptTurn = vi.fn();
   readonly listThreads = vi.fn();
   readonly listModels = vi.fn();
@@ -2012,6 +2021,175 @@ describe("ServeServices", () => {
     strictEqual(coreMocks.runCreateWorktree.mock.calls.length, 0);
     strictEqual(coreMocks.listWorktrees.mock.calls.length, 0);
     strictEqual(codex.startThread.mock.calls.length, 0);
+  });
+
+  it("infers the worktree name from an initial message with codex exec", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+    };
+    const store = new ServeStateStore(await createTemporaryDirectory());
+    await store.save(state);
+    const codex = new FakeCodexBridge();
+    const services = new ServeServices({
+      codex: codex as unknown as CodexBridge,
+      store,
+    });
+    codex.exec.mockResolvedValueOnce("Fix/sidebar-new-chat\n");
+    gitMocks.branchExists.mockResolvedValueOnce({ ok: true, value: false });
+    coreMocks.runCreateWorktree.mockResolvedValueOnce({
+      ok: true,
+      value: {
+        name: "fix/sidebar-new-chat",
+        path: "/repo/.git/phantom/worktrees/fix/sidebar-new-chat",
+      },
+    });
+    codex.startThread.mockResolvedValueOnce({ thread: { id: "thread_new" } });
+
+    const chat = await services.createChat("proj_1", {
+      initialMessage: "プロジェクトクリック時に新規チャットへ切り替えて",
+    });
+
+    strictEqual(chat.worktreeName, "fix/sidebar-new-chat");
+    strictEqual(
+      coreMocks.runCreateWorktree.mock.calls[0][0].name,
+      "fix/sidebar-new-chat",
+    );
+    deepStrictEqual(codex.exec.mock.calls[0][1], {
+      cwd: "/repo",
+      model: "gpt-5.4-mini",
+    });
+  });
+
+  it("falls back to generated worktree names when the inferred branch name is invalid", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+    };
+    const store = new ServeStateStore(await createTemporaryDirectory());
+    await store.save(state);
+    const codex = new FakeCodexBridge();
+    const services = new ServeServices({
+      codex: codex as unknown as CodexBridge,
+      store,
+    });
+    codex.exec.mockResolvedValueOnce("fix/sidebar.lock");
+    coreMocks.runCreateWorktree.mockResolvedValueOnce({
+      ok: true,
+      value: {
+        name: "generated-name",
+        path: "/repo/.git/phantom/worktrees/generated-name",
+      },
+    });
+    codex.startThread.mockResolvedValueOnce({ thread: { id: "thread_new" } });
+
+    const chat = await services.createChat("proj_1", {
+      initialMessage: "Fix the sidebar behavior",
+    });
+
+    strictEqual(chat.worktreeName, "generated-name");
+    strictEqual(coreMocks.runCreateWorktree.mock.calls[0][0].name, undefined);
+  });
+
+  it("falls back to generated worktree names when the inferred name already exists", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+    };
+    const store = new ServeStateStore(await createTemporaryDirectory());
+    await store.save(state);
+    const codex = new FakeCodexBridge();
+    const services = new ServeServices({
+      codex: codex as unknown as CodexBridge,
+      store,
+    });
+    codex.exec.mockResolvedValueOnce("fix/sidebar");
+    gitMocks.branchExists.mockResolvedValueOnce({ ok: true, value: false });
+    coreMocks.runCreateWorktree
+      .mockResolvedValueOnce({
+        ok: false,
+        error: new WorktreeAlreadyExistsError("fix/sidebar"),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        value: {
+          name: "generated-name",
+          path: "/repo/.git/phantom/worktrees/generated-name",
+        },
+      });
+    codex.startThread.mockResolvedValueOnce({ thread: { id: "thread_new" } });
+
+    const chat = await services.createChat("proj_1", {
+      initialMessage: "Fix the sidebar behavior",
+    });
+
+    strictEqual(chat.worktreeName, "generated-name");
+    strictEqual(
+      coreMocks.runCreateWorktree.mock.calls[0][0].name,
+      "fix/sidebar",
+    );
+    strictEqual(coreMocks.runCreateWorktree.mock.calls[1][0].name, undefined);
+  });
+
+  it("falls back to generated worktree names when the inferred branch already exists", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+    };
+    const store = new ServeStateStore(await createTemporaryDirectory());
+    await store.save(state);
+    const codex = new FakeCodexBridge();
+    const services = new ServeServices({
+      codex: codex as unknown as CodexBridge,
+      store,
+    });
+    codex.exec.mockResolvedValueOnce("fix/sidebar");
+    gitMocks.branchExists.mockResolvedValueOnce({ ok: true, value: true });
+    coreMocks.runCreateWorktree.mockResolvedValueOnce({
+      ok: true,
+      value: {
+        name: "generated-name",
+        path: "/repo/.git/phantom/worktrees/generated-name",
+      },
+    });
+    codex.startThread.mockResolvedValueOnce({ thread: { id: "thread_new" } });
+
+    const chat = await services.createChat("proj_1", {
+      initialMessage: "Fix the sidebar behavior",
+    });
+
+    strictEqual(chat.worktreeName, "generated-name");
+    strictEqual(coreMocks.runCreateWorktree.mock.calls[0][0].name, undefined);
+  });
+
+  it("falls back to generated worktree names when name inference fails", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+    };
+    const store = new ServeStateStore(await createTemporaryDirectory());
+    await store.save(state);
+    const codex = new FakeCodexBridge();
+    const services = new ServeServices({
+      codex: codex as unknown as CodexBridge,
+      store,
+    });
+    codex.exec.mockRejectedValueOnce(new Error("Codex exec timed out"));
+    coreMocks.runCreateWorktree.mockResolvedValueOnce({
+      ok: true,
+      value: {
+        name: "generated-name",
+        path: "/repo/.git/phantom/worktrees/generated-name",
+      },
+    });
+    codex.startThread.mockResolvedValueOnce({ thread: { id: "thread_new" } });
+
+    const chat = await services.createChat("proj_1", {
+      initialMessage: "Fix the sidebar behavior",
+    });
+
+    strictEqual(chat.worktreeName, "generated-name");
+    strictEqual(coreMocks.runCreateWorktree.mock.calls[0][0].name, undefined);
   });
 
   it("stores a newly created chat without importing existing history", async () => {

--- a/packages/server/src/services.ts
+++ b/packages/server/src/services.ts
@@ -1,6 +1,7 @@
 import { realpath, stat } from "node:fs/promises";
 import { basename, isAbsolute, join, relative, resolve, sep } from "node:path";
 import {
+  branchExists,
   getGitRoot,
   getRemoteDefaultBranch,
   getRemotes,
@@ -14,6 +15,7 @@ import {
   listWorktrees,
   removeWorktree,
   runCreateWorktree,
+  WorktreeAlreadyExistsError,
 } from "@phantompane/core";
 import {
   CodexBridge,
@@ -53,6 +55,7 @@ import type {
 export interface CreateChatInput {
   name?: string;
   base?: string;
+  initialMessage?: string;
   worktreeName?: string;
   worktreePath?: string;
 }
@@ -113,6 +116,81 @@ interface SubmitMessageOptions {
   existingUserMessageId?: string;
   queuedMessageId?: string;
   requireActiveTurn: boolean;
+}
+
+const worktreeNameInferenceModel = "gpt-5.4-mini";
+
+function createWorktreeNameInferencePrompt(message: string): string {
+  return [
+    "Infer a concise Git worktree and branch name from this user request.",
+    "Return exactly one name and nothing else.",
+    "Use lowercase ASCII letters, numbers, hyphens, dots, underscores, and optional slashes.",
+    "Prefer 2-5 words. Use a prefix like feat/, fix/, docs/, refactor/, or chore/ only when it is clearly appropriate.",
+    "Do not include quotes, Markdown, explanations, or code fences.",
+    "",
+    "User request:",
+    message,
+  ].join("\n");
+}
+
+function normalizeInferredWorktreeName(value: string): string | undefined {
+  let name = value
+    .trim()
+    .split(/\r?\n/)
+    .find((line) => line.trim())
+    ?.trim();
+  if (!name) {
+    return undefined;
+  }
+
+  name = name
+    .replace(/^["'`]+|["'`]+$/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9._/-]+/g, "-")
+    .replace(/\/+/g, "/")
+    .replace(/-+/g, "-")
+    .replace(/\.{2,}/g, ".")
+    .replace(/^[./_-]+|[./_-]+$/g, "");
+
+  const segments = name
+    .split("/")
+    .map((segment) => segment.replace(/^[._-]+|[._-]+$/g, ""))
+    .filter(Boolean);
+  name = segments.join("/");
+
+  if (!name) {
+    return undefined;
+  }
+
+  const candidate =
+    name.length > 72 ? name.slice(0, 72).replace(/[./_-]+$/g, "") : name;
+  return isValidInferredWorktreeName(candidate) ? candidate : undefined;
+}
+
+function isValidInferredWorktreeName(name: string): boolean {
+  if (
+    !name ||
+    name === "@" ||
+    name.includes("..") ||
+    name.includes("@{") ||
+    name.includes("//") ||
+    name.endsWith(".") ||
+    /[\s~^:?*[\]\\]/.test(name) ||
+    [...name].some((character) => {
+      const code = character.charCodeAt(0);
+      return code < 32 || code === 127;
+    })
+  ) {
+    return false;
+  }
+
+  return name.split("/").every((segment) => {
+    return (
+      segment.length > 0 &&
+      !segment.startsWith(".") &&
+      !segment.endsWith(".lock")
+    );
+  });
 }
 
 type PendingTurnEvent =
@@ -609,11 +687,37 @@ export class ServeServices {
       return chat;
     }
 
-    const createResult = await runCreateWorktree({
+    const explicitName = input.name?.trim();
+    let inferredName =
+      explicitName ||
+      (input.initialMessage?.trim()
+        ? await this.inferWorktreeName(project.rootPath, input.initialMessage)
+        : undefined);
+    if (!explicitName && inferredName) {
+      const inferredBranchExists = await branchExists(
+        project.rootPath,
+        inferredName,
+      );
+      if (inferredBranchExists.ok && inferredBranchExists.value) {
+        inferredName = undefined;
+      }
+    }
+    let createResult = await runCreateWorktree({
       gitRoot: project.rootPath,
-      name: input.name,
+      name: inferredName,
       base: input.base,
     });
+    if (
+      !createResult.ok &&
+      !explicitName &&
+      inferredName &&
+      createResult.error instanceof WorktreeAlreadyExistsError
+    ) {
+      createResult = await runCreateWorktree({
+        gitRoot: project.rootPath,
+        base: input.base,
+      });
+    }
 
     if (!createResult.ok) {
       throw createResult.error;
@@ -665,6 +769,24 @@ export class ServeServices {
 
     this.eventHub.emit("chat.created", chat, { chatId: chat.id });
     return chat;
+  }
+
+  private async inferWorktreeName(
+    projectRoot: string,
+    message: string,
+  ): Promise<string | undefined> {
+    try {
+      const result = await this.codex.exec(
+        createWorktreeNameInferencePrompt(message),
+        {
+          cwd: projectRoot,
+          model: worktreeNameInferenceModel,
+        },
+      );
+      return normalizeInferredWorktreeName(result);
+    } catch {
+      return undefined;
+    }
   }
 
   async deleteProjectWorktree(

--- a/packages/web/src/api/mutations.ts
+++ b/packages/web/src/api/mutations.ts
@@ -21,6 +21,7 @@ export interface SendMessageInput {
 }
 
 export interface CreateChatInput {
+  initialMessage?: string;
   worktreeName?: string;
   worktreePath?: string;
 }

--- a/packages/web/src/routes/home.tsx
+++ b/packages/web/src/routes/home.tsx
@@ -1461,30 +1461,25 @@ export function HomeRoute() {
     const hasExistingChat = projectChats.some(
       (candidate) => candidate.id === chat.id,
     );
+    const nextProjectChats = hasExistingChat
+      ? projectChats.map((candidate) =>
+          candidate.id === chat.id ? chat : candidate,
+        )
+      : [chat, ...projectChats];
     const nextChatsByProject = {
       ...chatsByProjectRef.current,
-      [chat.projectId]: hasExistingChat
-        ? projectChats.map((candidate) =>
-            candidate.id === chat.id ? chat : candidate,
-          )
-        : [chat, ...projectChats],
+      [chat.projectId]: nextProjectChats,
     };
     chatsByProjectRef.current = nextChatsByProject;
     setChatsByProject(nextChatsByProject);
 
+    const projectWorktrees =
+      worktreesByProjectRef.current[chat.projectId] ?? [];
     const nextWorktreesByProject = {
       ...worktreesByProjectRef.current,
-      [chat.projectId]: (
-        worktreesByProjectRef.current[chat.projectId] ?? []
-      ).map((worktree) =>
-        worktree.path === chat.worktreePath
-          ? {
-              ...worktree,
-              chatId: chat.id,
-              chatStatus: chat.status,
-              chatTitle: chat.title,
-            }
-          : worktree,
+      [chat.projectId]: mergeWorktreesWithChats(
+        projectWorktrees,
+        nextProjectChats,
       ),
     };
     worktreesByProjectRef.current = nextWorktreesByProject;

--- a/packages/web/src/routes/home.tsx
+++ b/packages/web/src/routes/home.tsx
@@ -41,6 +41,7 @@ import {
   sendMessageMutation,
   steerMessageMutation,
   syncWorktreeMutation,
+  type SendMessageInput,
 } from "../api/mutations";
 import {
   authQueryOptions,
@@ -254,6 +255,13 @@ function readSearchParamSet(
   return new Set(values);
 }
 
+function getWorkspaceSelectionKey(
+  projectId: string | null,
+  chatId: string | null,
+): string {
+  return `${projectId ?? ""}\u0000${chatId ?? ""}`;
+}
+
 function writeNullableSearchParam(
   searchParams: URLSearchParams,
   key: string,
@@ -397,7 +405,10 @@ export function HomeRoute() {
     searchParams,
     searchParamKeys.chat,
   );
-  const workspaceSelectionKey = `${requestedProjectId ?? ""}\u0000${selectedChatId ?? ""}`;
+  const workspaceSelectionKey = getWorkspaceSelectionKey(
+    requestedProjectId,
+    selectedChatId,
+  );
   const workspaceSelectionKeyRef = useRef(workspaceSelectionKey);
   workspaceSelectionKeyRef.current = workspaceSelectionKey;
   const selectedModelId = readNullableSearchParam(
@@ -655,6 +666,14 @@ export function HomeRoute() {
     });
   }
 
+  function getCurrentUrlWorkspaceSelectionKey(): string {
+    const currentSearchParams = searchParamsRef.current;
+    return getWorkspaceSelectionKey(
+      readNullableSearchParam(currentSearchParams, searchParamKeys.project),
+      readNullableSearchParam(currentSearchParams, searchParamKeys.chat),
+    );
+  }
+
   const selectedChat = useMemo(
     () =>
       findValidatedSelectedChat(
@@ -704,8 +723,13 @@ export function HomeRoute() {
   );
   const hasSelectedContext =
     selectedFiles.length > 0 || selectedSkills.length > 0;
+  const canStartNewProjectChat =
+    Boolean(selectedProject) &&
+    !hasSelectedChat &&
+    Boolean(composerText.trim());
   const canSendMessage =
-    hasSelectedChat && Boolean(composerText.trim() || hasSelectedContext);
+    (hasSelectedChat && Boolean(composerText.trim() || hasSelectedContext)) ||
+    canStartNewProjectChat;
   const primaryComposerMode: ComposerSubmitMode = hasActiveTurn
     ? isChatRunning
       ? "steer"
@@ -720,7 +744,8 @@ export function HomeRoute() {
     canSendMessage &&
     !isComposerBlocked &&
     (primaryComposerMode !== "steer" || isChatRunning);
-  const canQueueComposerMessage = canSendMessage && !isComposerBlocked;
+  const canQueueComposerMessage =
+    hasSelectedChat && canSendMessage && !isComposerBlocked;
   const canInterruptActiveTurn =
     hasActiveTurn && !isInterrupting && Boolean(selectedChat?.activeTurnId);
   const areComposerOptionsDisabled = !hasSelectedChat || isSendingMessage;
@@ -822,7 +847,7 @@ export function HomeRoute() {
         ) ?? null
       );
     }
-    return projectWorktrees[0] ?? null;
+    return null;
   }, [selectedChat, selectedProjectId, worktreesByProject]);
 
   const chatsByWorktreeByProject = useMemo(() => {
@@ -1340,7 +1365,9 @@ export function HomeRoute() {
       );
       const currentSelectedChatId = selectedChatIdRef.current;
       const currentFileSearchQuery = fileSearchQueryRef.current;
-      const nextChatId = fallbackWorktree?.chatId ?? currentSelectedChatId;
+      const nextChatId = currentSelectedChatId
+        ? (fallbackWorktree?.chatId ?? currentSelectedChatId)
+        : null;
       updateWorkspaceSearchParams(
         {
           projectId,
@@ -1407,7 +1434,9 @@ export function HomeRoute() {
         (chat) => chat.id === currentSelectedChatId,
       )
         ? currentSelectedChatId
-        : (fallbackWorktree?.chatId ?? data.chats[0]?.id ?? null);
+        : currentSelectedChatId
+          ? (fallbackWorktree?.chatId ?? data.chats[0]?.id ?? null)
+          : null;
       updateWorkspaceSearchParams(
         {
           projectId,
@@ -1427,34 +1456,44 @@ export function HomeRoute() {
     }
   }
 
-  async function refreshSelectedChat(chatId: string) {
-    const data = await queryClient.fetchQuery(chatQueryOptions(chatId));
-    const projectChats = chatsByProjectRef.current[data.chat.projectId] ?? [];
+  function upsertChatRecord(chat: ChatRecord) {
+    const projectChats = chatsByProjectRef.current[chat.projectId] ?? [];
+    const hasExistingChat = projectChats.some(
+      (candidate) => candidate.id === chat.id,
+    );
     const nextChatsByProject = {
       ...chatsByProjectRef.current,
-      [data.chat.projectId]: projectChats.map((chat) =>
-        chat.id === chatId ? data.chat : chat,
-      ),
+      [chat.projectId]: hasExistingChat
+        ? projectChats.map((candidate) =>
+            candidate.id === chat.id ? chat : candidate,
+          )
+        : [chat, ...projectChats],
     };
     chatsByProjectRef.current = nextChatsByProject;
     setChatsByProject(nextChatsByProject);
 
     const nextWorktreesByProject = {
       ...worktreesByProjectRef.current,
-      [data.chat.projectId]: (
-        worktreesByProjectRef.current[data.chat.projectId] ?? []
+      [chat.projectId]: (
+        worktreesByProjectRef.current[chat.projectId] ?? []
       ).map((worktree) =>
-        worktree.chatId === chatId
+        worktree.path === chat.worktreePath
           ? {
               ...worktree,
-              chatStatus: data.chat.status,
-              chatTitle: data.chat.title,
+              chatId: chat.id,
+              chatStatus: chat.status,
+              chatTitle: chat.title,
             }
           : worktree,
       ),
     };
     worktreesByProjectRef.current = nextWorktreesByProject;
     setWorktreesByProject(nextWorktreesByProject);
+  }
+
+  async function refreshSelectedChat(chatId: string) {
+    const data = await queryClient.fetchQuery(chatQueryOptions(chatId));
+    upsertChatRecord(data.chat);
   }
 
   async function refreshMessages(
@@ -1548,12 +1587,54 @@ export function HomeRoute() {
     }
   }
 
+  async function createProjectChat(
+    projectId: string,
+    requestWorkspaceSelectionKey: string,
+    input: Parameters<typeof createChatMutation>[1] = {},
+  ): Promise<ChatRecord | null> {
+    const data = await createChatRequest.mutateAsync({ projectId, input });
+    void queryClient.invalidateQueries({
+      queryKey: queryKeys.projectWorktrees(projectId),
+    });
+    void queryClient.invalidateQueries({
+      queryKey: queryKeys.projectChats(projectId),
+    });
+    setExpandedWorktreeKeys((current) =>
+      new Set(current).add(
+        getWorktreeExpansionKey(projectId, data.chat.worktreePath),
+      ),
+    );
+    const didRefreshWorktrees = await refreshWorktrees(projectId, {
+      updateSelection: false,
+    });
+    if (!didRefreshWorktrees) {
+      return data.chat;
+    }
+    const didRefreshChats = await refreshChats(projectId, {
+      updateSelection: false,
+    });
+    if (!didRefreshChats) {
+      return data.chat;
+    }
+    if (getCurrentUrlWorkspaceSelectionKey() !== requestWorkspaceSelectionKey) {
+      return data.chat;
+    }
+    updateWorkspaceSearchParams({
+      projectId,
+      chatId: data.chat.id,
+      clearFileQuery: true,
+    });
+    selectedProjectIdRef.current = projectId;
+    selectedChatIdRef.current = data.chat.id;
+    return data.chat;
+  }
+
   async function createChat(
     projectId: string,
     worktree?: ProjectWorktreeRecord,
-  ) {
+  ): Promise<ChatRecord | null> {
     if (isBusy || createChatInFlightRef.current) {
-      return;
+      return null;
     }
 
     setError(null);
@@ -1569,48 +1650,19 @@ export function HomeRoute() {
     }
     setIsBusy(true);
     try {
-      const data = await createChatRequest.mutateAsync({
+      return await createProjectChat(
         projectId,
-        input: worktree
+        requestWorkspaceSelectionKey,
+        worktree
           ? {
               worktreeName: worktree.name,
               worktreePath: worktree.path,
             }
           : {},
-      });
-      void queryClient.invalidateQueries({
-        queryKey: queryKeys.projectWorktrees(projectId),
-      });
-      void queryClient.invalidateQueries({
-        queryKey: queryKeys.projectChats(projectId),
-      });
-      setExpandedWorktreeKeys((current) =>
-        new Set(current).add(
-          getWorktreeExpansionKey(projectId, data.chat.worktreePath),
-        ),
       );
-      const didRefreshWorktrees = await refreshWorktrees(projectId, {
-        updateSelection: false,
-      });
-      if (!didRefreshWorktrees) {
-        return;
-      }
-      const didRefreshChats = await refreshChats(projectId, {
-        updateSelection: false,
-      });
-      if (!didRefreshChats) {
-        return;
-      }
-      if (workspaceSelectionKeyRef.current !== requestWorkspaceSelectionKey) {
-        return;
-      }
-      updateWorkspaceSearchParams({
-        projectId,
-        chatId: data.chat.id,
-        clearFileQuery: true,
-      });
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
+      return null;
     } finally {
       createChatInFlightRef.current = false;
       setCreatingProjectId(null);
@@ -1727,34 +1779,7 @@ export function HomeRoute() {
     await submitComposer("send");
   }
 
-  async function submitComposer(mode: ComposerSubmitMode) {
-    if (
-      !selectedChatId ||
-      !canSendMessage ||
-      isSendingMessage ||
-      pendingSendChatIdsRef.current.has(selectedChatId) ||
-      (mode === "steer" && !selectedChat?.activeTurnId)
-    ) {
-      return;
-    }
-    setError(null);
-    const requestChatId = selectedChatId;
-    const requestChatVersion = selectedChatVersionRef.current;
-    const requestId = sendMessageRequestIdRef.current + 1;
-    sendMessageRequestIdRef.current = requestId;
-    const isCurrentSendRequest = () =>
-      selectedChatIdRef.current === requestChatId &&
-      selectedChatVersionRef.current === requestChatVersion &&
-      sendMessageRequestIdRef.current === requestId;
-    const composerInput = composerText;
-    const text =
-      composerInput.trim().length > 0
-        ? composerInput
-        : getContextOnlyMessage({
-            hasFiles: selectedFiles.length > 0,
-            hasSkills: selectedSkills.length > 0,
-          });
-    setComposerText("");
+  function createComposerMessageInput(text: string): SendMessageInput {
     const turnModel = selectedModel?.id ?? selectedModel?.model;
     const turnEffort =
       selectedModel &&
@@ -1770,6 +1795,134 @@ export function HomeRoute() {
       name: skill.name,
       path: skill.path,
     }));
+    return {
+      effort: turnEffort,
+      files,
+      model: turnModel,
+      skills: selectedSkillItems,
+      text,
+    };
+  }
+
+  async function submitNewProjectChat(
+    projectId: string,
+    input: SendMessageInput,
+    composerInput: string,
+    requestWorkspaceSelectionKey: string,
+  ) {
+    let createdChatId: string | null = null;
+    const isRequestWorkspaceSelected = () =>
+      getCurrentUrlWorkspaceSelectionKey() === requestWorkspaceSelectionKey;
+    const isCreatedChatSelected = () =>
+      createdChatId !== null &&
+      getCurrentUrlWorkspaceSelectionKey() ===
+        getWorkspaceSelectionKey(projectId, createdChatId);
+    createChatInFlightRef.current = true;
+    setCreatingProjectId(projectId);
+    setIsBusy(true);
+    try {
+      const chat = await createProjectChat(
+        projectId,
+        requestWorkspaceSelectionKey,
+        {
+          initialMessage: input.text,
+        },
+      );
+      if (!chat) {
+        if (isRequestWorkspaceSelected()) {
+          setComposerText(composerInput);
+        }
+        return;
+      }
+
+      createdChatId = chat.id;
+      pendingSendChatIdsRef.current.add(chat.id);
+      pendingComposerModesByChatRef.current.set(chat.id, "send");
+      const sentData = await sendMessageRequest.mutateAsync({
+        chatId: chat.id,
+        input,
+      });
+      upsertChatRecord(sentData.chat);
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.messages(chat.id),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.chat(chat.id),
+      });
+      if (isCreatedChatSelected()) {
+        setSelectedFiles([]);
+        setSelectedSkillPaths(new Set());
+        setFileSearchQuery("");
+        await refreshMessages(chat.id);
+      }
+    } catch (err) {
+      if (
+        createdChatId ? isCreatedChatSelected() : isRequestWorkspaceSelected()
+      ) {
+        setComposerText(composerInput);
+        setError(err instanceof Error ? err.message : String(err));
+      }
+    } finally {
+      if (createdChatId) {
+        pendingSendChatIdsRef.current.delete(createdChatId);
+        pendingComposerModesByChatRef.current.delete(createdChatId);
+      }
+      createChatInFlightRef.current = false;
+      setCreatingProjectId(null);
+      setIsBusy(false);
+    }
+  }
+
+  async function submitComposer(mode: ComposerSubmitMode) {
+    const requestChatId = validatedSelectedChatId;
+    const isStartingNewProjectChat =
+      !requestChatId && Boolean(selectedProjectId);
+    if (
+      (!requestChatId && (!selectedProjectId || mode !== "send")) ||
+      !canSendMessage ||
+      isSendingMessage ||
+      (isStartingNewProjectChat && (isBusy || createChatInFlightRef.current)) ||
+      (requestChatId && pendingSendChatIdsRef.current.has(requestChatId)) ||
+      (mode === "steer" && !selectedChat?.activeTurnId)
+    ) {
+      return;
+    }
+    setError(null);
+    const requestChatVersion = selectedChatVersionRef.current;
+    const requestId = sendMessageRequestIdRef.current + 1;
+    sendMessageRequestIdRef.current = requestId;
+    const isCurrentSendRequest = () =>
+      requestChatId !== null &&
+      selectedChatIdRef.current === requestChatId &&
+      selectedChatVersionRef.current === requestChatVersion &&
+      sendMessageRequestIdRef.current === requestId;
+    const composerInput = composerText;
+    const text =
+      composerInput.trim().length > 0
+        ? composerInput
+        : getContextOnlyMessage({
+            hasFiles: selectedFiles.length > 0,
+            hasSkills: selectedSkills.length > 0,
+          });
+    setComposerText("");
+    const messageInput = createComposerMessageInput(text);
+    if (!requestChatId) {
+      if (!selectedProjectId) {
+        return;
+      }
+      setIsSendingMessage(true);
+      setPendingComposerMode("send");
+      await submitNewProjectChat(
+        selectedProjectId,
+        messageInput,
+        composerInput,
+        workspaceSelectionKeyRef.current,
+      );
+      setIsSendingMessage(false);
+      setPendingComposerMode(null);
+      return;
+    }
+
     pendingSendChatIdsRef.current.add(requestChatId);
     pendingComposerModesByChatRef.current.set(requestChatId, mode);
     setIsSendingMessage(true);
@@ -1783,13 +1936,7 @@ export function HomeRoute() {
             : sendMessageRequest;
       await mutation.mutateAsync({
         chatId: requestChatId,
-        input: {
-          effort: turnEffort,
-          files,
-          model: turnModel,
-          skills: selectedSkillItems,
-          text,
-        },
+        input: messageInput,
       });
       void queryClient.invalidateQueries({
         queryKey: queryKeys.messages(requestChatId),
@@ -1836,11 +1983,15 @@ export function HomeRoute() {
     if (!action) {
       return;
     }
-    if (!selectedChatId || !canSendMessage || isSendingMessage) {
+    if (
+      (!validatedSelectedChatId && !selectedProjectId) ||
+      !canSendMessage ||
+      isSendingMessage
+    ) {
       return;
     }
     const submitMode = getComposerSubmitModeForEnter(action, selectedChat);
-    if (!submitMode) {
+    if (!submitMode || (!validatedSelectedChatId && submitMode !== "send")) {
       return;
     }
     event.preventDefault();
@@ -1913,6 +2064,19 @@ export function HomeRoute() {
         searchParamKeys.expandedProject,
         next,
       );
+    });
+  }
+
+  function selectProject(projectId: string) {
+    setComposerText("");
+    setSelectedFiles([]);
+    setSelectedSkillPaths(new Set());
+    setFileSearchResults([]);
+    setSkills([]);
+    updateWorkspaceSearchParams({
+      projectId,
+      chatId: null,
+      clearFileQuery: true,
     });
   }
 
@@ -2027,20 +2191,31 @@ export function HomeRoute() {
 
                     return (
                       <SidebarMenuItem key={project.id}>
-                        <div className="group/project flex items-center rounded-[var(--radius-sm)]">
-                          <SidebarMenuButton
+                        <div className="group/project flex items-center gap-0.5 rounded-[var(--radius-sm)]">
+                          <button
                             aria-expanded={isProjectExpanded}
-                            className="min-h-8 flex-1 group-data-[state=collapsed]/sidebar:flex-none"
+                            aria-label={`${isProjectExpanded ? "Collapse" : "Expand"} ${project.name}`}
+                            className="inline-flex size-7 shrink-0 items-center justify-center rounded-[var(--radius-sm)] text-[var(--icon-color-default)] outline-none transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:shadow-[var(--state-focus-ring)] group-data-[state=collapsed]/sidebar:hidden"
                             onClick={() => toggleProject(project.id)}
-                            title={project.name}
+                            title={isProjectExpanded ? "Collapse" : "Expand"}
                             type="button"
                           >
                             <ChevronRight
                               className={cn(
-                                "size-4 shrink-0 text-[var(--icon-color-default)] transition-transform duration-[var(--motion-duration-fast)] group-data-[state=collapsed]/sidebar:hidden",
+                                "size-4 transition-transform duration-[var(--motion-duration-fast)]",
                                 isProjectExpanded && "rotate-90",
                               )}
                             />
+                          </button>
+                          <SidebarMenuButton
+                            className="min-h-8 flex-1 group-data-[state=collapsed]/sidebar:flex-none"
+                            isActive={
+                              selectedProjectId === project.id && !selectedChat
+                            }
+                            onClick={() => selectProject(project.id)}
+                            title={project.name}
+                            type="button"
+                          >
                             <FolderGit2 className="size-4 text-[var(--icon-color-default)]" />
                             <span className="min-w-0 flex-1 group-data-[state=collapsed]/sidebar:hidden">
                               <span className="block truncate font-medium">
@@ -2419,7 +2594,11 @@ export function HomeRoute() {
           <div className="min-w-0 flex-1">
             <div className="flex min-w-0 items-center gap-2">
               <p className="truncate text-[length:var(--font-size-xl)] font-semibold leading-tight">
-                {selectedWorktree?.name ?? selectedProject?.name ?? "Workspace"}
+                {selectedChat
+                  ? (selectedWorktree?.name ?? selectedChat.worktreeName)
+                  : selectedProject
+                    ? "New chat"
+                    : "Workspace"}
               </p>
               {selectedChat && <StatusBadge status={selectedChat.status} />}
             </div>
@@ -2484,7 +2663,12 @@ export function HomeRoute() {
         )}
 
         <section
-          aria-busy={isMessagesLoading || isSendingMessage || hasActiveTurn}
+          aria-busy={
+            isMessagesLoading ||
+            isSendingMessage ||
+            hasActiveTurn ||
+            Boolean(creatingProjectId)
+          }
           className="min-h-0 flex-1 overflow-y-auto px-4 py-4"
           ref={chatTimelineRef}
           onScroll={scheduleSelectedChatScrollPositionSave}
@@ -2551,13 +2735,15 @@ export function HomeRoute() {
                 </Label>
                 <Textarea
                   className="min-h-12 border-0 bg-transparent px-2 py-2 shadow-none focus-visible:shadow-none"
-                  disabled={!hasSelectedChat}
+                  disabled={!selectedProject || isSendingMessage}
                   enterKeyHint="enter"
                   id="composer"
                   placeholder={
                     hasSelectedChat
                       ? "Ask Codex to work in this worktree"
-                      : "Create or select a worktree to start"
+                      : selectedProject
+                        ? "Ask Codex to create a worktree and start"
+                        : "Select a project to start"
                   }
                   rows={2}
                   value={composerText}
@@ -2566,7 +2752,7 @@ export function HomeRoute() {
                 />
               </div>
               <div className="flex shrink-0 items-end gap-1.5">
-                {primaryComposerMode !== "queue" && (
+                {hasSelectedChat && primaryComposerMode !== "queue" && (
                   <Button
                     aria-label={
                       pendingComposerMode === "queue"
@@ -2944,16 +3130,20 @@ function EmptyTimeline({
           <h2 className="text-[length:var(--font-size-xl)] font-semibold">
             {hasChat
               ? "No messages yet"
-              : hasWorktree
-                ? "Select chat history"
-                : "Select a worktree"}
+              : selectedProject
+                ? "New chat"
+                : hasWorktree
+                  ? "Select chat history"
+                  : "Select a project"}
           </h2>
           <p className="mt-1 text-[length:var(--font-size-md)] text-muted-foreground">
             {hasChat
               ? "Send a message to start a focused Codex session."
-              : hasWorktree
-                ? "Choose a chat history for this worktree."
-                : "Create a worktree under a project to begin a Codex session."}
+              : selectedProject
+                ? "Send a message to create a named worktree and start Codex."
+                : hasWorktree
+                  ? "Choose a chat history for this worktree."
+                  : "Select a project to begin a Codex session."}
           </p>
         </div>
         {!selectedProject && (

--- a/packages/web/src/routes/home.tsx
+++ b/packages/web/src/routes/home.tsx
@@ -724,9 +724,7 @@ export function HomeRoute() {
   const hasSelectedContext =
     selectedFiles.length > 0 || selectedSkills.length > 0;
   const canStartNewProjectChat =
-    Boolean(selectedProject) &&
-    !hasSelectedChat &&
-    Boolean(composerText.trim());
+    Boolean(selectedProject) && !selectedChatId && Boolean(composerText.trim());
   const canSendMessage =
     (hasSelectedChat && Boolean(composerText.trim() || hasSelectedContext)) ||
     canStartNewProjectChat;
@@ -1603,13 +1601,13 @@ export function HomeRoute() {
       updateSelection: false,
     });
     if (!didRefreshWorktrees) {
-      return data.chat;
+      return null;
     }
     const didRefreshChats = await refreshChats(projectId, {
       updateSelection: false,
     });
     if (!didRefreshChats) {
-      return data.chat;
+      return null;
     }
     if (getCurrentUrlWorkspaceSelectionKey() !== requestWorkspaceSelectionKey) {
       return data.chat;


### PR DESCRIPTION
## Summary

- Switch project selection to a new-chat view instead of auto-selecting an existing chat.
- Create the worktree/chat on first submit and immediately send the initial message.
- Infer the worktree branch name from the initial message with `codex exec --model gpt-5.4-mini`, with validation and fallback behavior for failures or collisions.

## Validation

- `pnpm ready`

## Notes

- Added server and Codex bridge coverage for name inference, fallback paths, and exec timeout handling.
- UI behavior was reviewed by subagents; remaining coverage gap is no direct component/e2e test for the project-click new-chat flow.