### PR TITLE
[codex] stabilize chat message ordering

### DIFF
--- a/packages/server/src/services.test.ts
+++ b/packages/server/src/services.test.ts
@@ -1094,6 +1094,388 @@ describe("ServeServices", () => {
     );
   });
 
+  it("deduplicates live assistant deltas when Codex history uses different item ids", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat()],
+      messages: [
+        {
+          id: "msg_live_delta",
+          chatId: "chat_1",
+          role: "assistant" as const,
+          text: "I updated the page.",
+          eventType: "item/agentMessage/delta",
+          itemId: "msg_live_item_id",
+          createdAt: "2026-04-25T00:01:00.000Z",
+        },
+      ],
+    };
+    const { codex, services } = await createHarness(state);
+    codex.readThread.mockResolvedValueOnce({
+      thread: {
+        turns: [
+          {
+            id: "turn_1",
+            createdAt: "2026-04-25T00:02:00.000Z",
+            items: [
+              {
+                id: "item-2",
+                type: "assistantMessage",
+                text: "I updated the page.",
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const messages = await services.getMessages("chat_1");
+
+    deepStrictEqual(
+      messages.map((message) => [
+        message.id,
+        message.role,
+        message.text,
+        message.eventType,
+      ]),
+      [
+        [
+          "chat_1_codex_turn_1_0",
+          "assistant",
+          "I updated the page.",
+          undefined,
+        ],
+      ],
+    );
+  });
+
+  it("keeps fuller live assistant delta text while same-item Codex history is stale", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat()],
+      messages: [
+        {
+          id: "msg_live_delta",
+          chatId: "chat_1",
+          role: "assistant" as const,
+          text: "hello world",
+          eventType: "item/agentMessage/delta",
+          itemId: "item-2",
+          createdAt: "2026-04-25T00:01:00.000Z",
+        },
+      ],
+    };
+    const { codex, services } = await createHarness(state);
+    codex.readThread.mockResolvedValueOnce({
+      thread: {
+        turns: [
+          {
+            id: "turn_1",
+            createdAt: "2026-04-25T00:02:00.000Z",
+            items: [
+              {
+                id: "item-2",
+                type: "assistantMessage",
+                text: "hello",
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const messages = await services.getMessages("chat_1");
+
+    deepStrictEqual(
+      messages.map((message) => [
+        message.id,
+        message.role,
+        message.text,
+        message.eventType,
+      ]),
+      [
+        [
+          "msg_live_delta",
+          "assistant",
+          "hello world",
+          "item/agentMessage/delta",
+        ],
+      ],
+    );
+  });
+
+  it("keeps older live assistant deltas when a later turn repeats the same text", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat()],
+      messages: [
+        {
+          id: "msg_old_live_delta",
+          chatId: "chat_1",
+          role: "assistant" as const,
+          text: "repeat",
+          eventType: "item/agentMessage/delta",
+          itemId: "msg_old_live_item",
+          createdAt: "2026-04-25T00:01:00.000Z",
+        },
+        {
+          id: "msg_later_user",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "next",
+          createdAt: "2026-04-25T00:02:00.000Z",
+        },
+      ],
+    };
+    const { codex, services } = await createHarness(state);
+    codex.readThread.mockResolvedValueOnce({
+      thread: {
+        turns: [
+          {
+            id: "turn_2",
+            createdAt: "2026-04-25T00:03:00.000Z",
+            input: [{ text: "next" }],
+            items: [
+              {
+                id: "item-9",
+                type: "assistantMessage",
+                text: "repeat",
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const messages = await services.getMessages("chat_1");
+
+    deepStrictEqual(
+      messages.map((message) => [
+        message.id,
+        message.role,
+        message.text,
+        message.eventType,
+      ]),
+      [
+        [
+          "msg_old_live_delta",
+          "assistant",
+          "repeat",
+          "item/agentMessage/delta",
+        ],
+        ["chat_1_codex_turn_2_0", "user", "next", undefined],
+        ["chat_1_codex_turn_2_1", "assistant", "repeat", undefined],
+      ],
+    );
+  });
+
+  it("deduplicates older live assistant deltas before a later repeated response", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat()],
+      messages: [
+        {
+          id: "msg_old_live_delta",
+          chatId: "chat_1",
+          role: "assistant" as const,
+          text: "repeat",
+          eventType: "item/agentMessage/delta",
+          itemId: "msg_old_live_item",
+          createdAt: "2026-04-25T00:01:00.000Z",
+        },
+        {
+          id: "msg_later_user",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "next",
+          createdAt: "2026-04-25T00:02:00.000Z",
+        },
+      ],
+    };
+    const { codex, services } = await createHarness(state);
+    codex.readThread.mockResolvedValueOnce({
+      thread: {
+        turns: [
+          {
+            id: "turn_1",
+            createdAt: "2026-04-25T00:03:00.000Z",
+            items: [
+              {
+                id: "item-2",
+                type: "assistantMessage",
+                text: "repeat",
+              },
+            ],
+          },
+          {
+            id: "turn_2",
+            createdAt: "2026-04-25T00:04:00.000Z",
+            input: [{ text: "next" }],
+            items: [
+              {
+                id: "item-9",
+                type: "assistantMessage",
+                text: "repeat",
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const messages = await services.getMessages("chat_1");
+
+    deepStrictEqual(
+      messages.map((message) => [
+        message.id,
+        message.role,
+        message.text,
+        message.eventType,
+      ]),
+      [
+        ["chat_1_codex_turn_1_0", "assistant", "repeat", undefined],
+        ["chat_1_codex_turn_2_0", "user", "next", undefined],
+        ["chat_1_codex_turn_2_1", "assistant", "repeat", undefined],
+      ],
+    );
+  });
+
+  it("deduplicates live assistant deltas when a later queued message exists", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat()],
+      messages: [
+        {
+          id: "msg_live_delta",
+          chatId: "chat_1",
+          role: "assistant" as const,
+          text: "done",
+          eventType: "item/agentMessage/delta",
+          itemId: "msg_live_item",
+          createdAt: "2026-04-25T00:01:00.000Z",
+        },
+        {
+          id: "msg_queued",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "next",
+          eventType: "chat.message.queued",
+          createdAt: "2026-04-25T00:02:00.000Z",
+        },
+      ],
+    };
+    const { codex, services } = await createHarness(state);
+    codex.readThread.mockResolvedValueOnce({
+      thread: {
+        turns: [
+          {
+            id: "turn_1",
+            createdAt: "2026-04-25T00:03:00.000Z",
+            items: [
+              {
+                id: "item-2",
+                type: "assistantMessage",
+                text: "done",
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const messages = await services.getMessages("chat_1");
+
+    deepStrictEqual(
+      messages.map((message) => [
+        message.id,
+        message.role,
+        message.text,
+        message.eventType,
+      ]),
+      [
+        ["msg_queued", "user", "next", "chat.message.queued"],
+        ["chat_1_codex_turn_1_0", "assistant", "done", undefined],
+      ],
+    );
+  });
+
+  it("keeps older live assistant deltas when a later steer repeats the same text", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat()],
+      messages: [
+        {
+          id: "msg_old_live_delta",
+          chatId: "chat_1",
+          role: "assistant" as const,
+          text: "repeat",
+          eventType: "item/agentMessage/delta",
+          itemId: "msg_old_live_item",
+          createdAt: "2026-04-25T00:01:00.000Z",
+        },
+        {
+          id: "msg_steered",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "adjust",
+          eventType: "chat.message.steered",
+          itemId: "turn_1",
+          createdAt: "2026-04-25T00:02:00.000Z",
+        },
+      ],
+    };
+    const { codex, services } = await createHarness(state);
+    codex.readThread.mockResolvedValueOnce({
+      thread: {
+        turns: [
+          {
+            id: "turn_1",
+            createdAt: "2026-04-25T00:03:00.000Z",
+            items: [
+              {
+                id: "item-8",
+                type: "userMessage",
+                text: "adjust",
+              },
+              {
+                id: "item-9",
+                type: "assistantMessage",
+                text: "repeat",
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const messages = await services.getMessages("chat_1");
+
+    deepStrictEqual(
+      messages.map((message) => [
+        message.id,
+        message.role,
+        message.text,
+        message.eventType,
+      ]),
+      [
+        [
+          "msg_old_live_delta",
+          "assistant",
+          "repeat",
+          "item/agentMessage/delta",
+        ],
+        ["chat_1_codex_turn_1_0", "user", "adjust", "chat.message.steered"],
+        ["chat_1_codex_turn_1_1", "assistant", "repeat", undefined],
+      ],
+    );
+  });
+
   it("preserves steered message metadata when Codex history uses the turn timestamp", async () => {
     const state = {
       ...createTestState(),

--- a/packages/server/src/services.ts
+++ b/packages/server/src/services.ts
@@ -2383,6 +2383,8 @@ function mergeCodexAndLocalMessages(
   const mergedCodexMessages = [...codexMessages];
   const unmatchedCodexMessageIndexes = codexMessages.map((_, index) => index);
   const steeredLocalMessageCounts = countSteeredLocalMessages(localMessages);
+  const liveAssistantDeltaCodexOrderLimits =
+    findLiveAssistantDeltaCodexOrderLimits(localMessages, mergedCodexMessages);
   const retainedLocalMessages = localMessages.filter((message) => {
     if (message.role === "event" || message.role === "error") {
       return true;
@@ -2390,23 +2392,43 @@ function mergeCodexAndLocalMessages(
     if (message.eventType === "chat.message.queued") {
       return true;
     }
+    const staleLiveAssistantDeltaIndex =
+      findStaleLiveAssistantDeltaCodexMessageIndex(
+        unmatchedCodexMessageIndexes,
+        mergedCodexMessages,
+        message,
+      );
+    if (staleLiveAssistantDeltaIndex !== undefined) {
+      const staleCodexMessage =
+        mergedCodexMessages[staleLiveAssistantDeltaIndex];
+      if (staleCodexMessage) {
+        mergedCodexMessages[staleLiveAssistantDeltaIndex] = {
+          ...message,
+          codexOrder: staleCodexMessage.codexOrder,
+          codexItemSource: staleCodexMessage.codexItemSource,
+        };
+      }
+      unmatchedCodexMessageIndexes.splice(
+        unmatchedCodexMessageIndexes.indexOf(staleLiveAssistantDeltaIndex),
+        1,
+      );
+      return false;
+    }
     const matchedCodexIndex = findDeduplicatedCodexMessageIndex(
       unmatchedCodexMessageIndexes,
       mergedCodexMessages,
       message,
       steeredLocalMessageCounts,
+      liveAssistantDeltaCodexOrderLimits,
     );
     if (matchedCodexIndex === undefined) {
       return true;
     }
     const matchedCodexMessage = mergedCodexMessages[matchedCodexIndex];
-    if (message.eventType && matchedCodexMessage) {
+    if (message.eventType === "chat.message.steered" && matchedCodexMessage) {
       mergedCodexMessages[matchedCodexIndex] = {
         ...matchedCodexMessage,
-        createdAt:
-          message.eventType === "chat.message.steered"
-            ? message.createdAt
-            : matchedCodexMessage.createdAt,
+        createdAt: message.createdAt,
         eventType: message.eventType,
       };
     }
@@ -2469,11 +2491,16 @@ function findDeduplicatedCodexMessageIndex(
   codexMessages: InternalChatMessageRecord[],
   localMessage: ChatMessageRecord,
   steeredLocalMessageCounts: ReadonlyMap<string, number>,
+  liveAssistantDeltaCodexOrderLimits: ReadonlyMap<string, number>,
 ): number | undefined {
   const matchedIndexes = unmatchedCodexMessageIndexes.filter((index) => {
     const codexMessage = codexMessages[index];
     return codexMessage
-      ? shouldDeduplicateLocalMessage(codexMessage, localMessage)
+      ? shouldDeduplicateLocalMessage(
+          codexMessage,
+          localMessage,
+          liveAssistantDeltaCodexOrderLimits,
+        )
       : false;
   });
   if (localMessage.eventType === "chat.message.steered") {
@@ -2520,6 +2547,24 @@ function findDeduplicatedCodexMessageIndex(
   return matchedIndexes[0];
 }
 
+function findStaleLiveAssistantDeltaCodexMessageIndex(
+  unmatchedCodexMessageIndexes: number[],
+  codexMessages: InternalChatMessageRecord[],
+  localMessage: ChatMessageRecord,
+): number | undefined {
+  if (!isLiveAssistantDeltaMessage(localMessage) || !localMessage.itemId) {
+    return undefined;
+  }
+  return unmatchedCodexMessageIndexes.find((index) => {
+    const codexMessage = codexMessages[index];
+    return (
+      codexMessage?.role === "assistant" &&
+      codexMessage.itemId === localMessage.itemId &&
+      !isCodexLiveAssistantMessageFresh(codexMessage, localMessage)
+    );
+  });
+}
+
 function countSteeredLocalMessages(
   messages: ChatMessageRecord[],
 ): ReadonlyMap<string, number> {
@@ -2544,16 +2589,40 @@ function getSteeredMessageGroupKey(message: ChatMessageRecord): string | null {
 function shouldDeduplicateLocalMessage(
   codexMessage: InternalChatMessageRecord,
   localMessage: ChatMessageRecord,
+  liveAssistantDeltaCodexOrderLimits: ReadonlyMap<string, number>,
 ): boolean {
   if (codexMessage.role !== localMessage.role) {
     return false;
+  }
+  if (isLiveAssistantDeltaMessage(localMessage)) {
+    if (
+      codexMessage.itemId &&
+      localMessage.itemId &&
+      codexMessage.itemId === localMessage.itemId
+    ) {
+      return isCodexLiveAssistantMessageFresh(codexMessage, localMessage);
+    }
+    const codexOrderLimit = liveAssistantDeltaCodexOrderLimits.get(
+      localMessage.id,
+    );
+    if (
+      codexOrderLimit !== undefined &&
+      (codexMessage.codexOrder ?? 0) >= codexOrderLimit
+    ) {
+      return false;
+    }
   }
   if (
     localMessage.eventType !== "chat.message.steered" &&
     codexMessage.itemId &&
     localMessage.itemId
   ) {
-    return codexMessage.itemId === localMessage.itemId;
+    if (codexMessage.itemId === localMessage.itemId) {
+      return true;
+    }
+    if (!isLiveAssistantDeltaMessage(localMessage)) {
+      return false;
+    }
   }
   if (messageFingerprint(codexMessage) !== messageFingerprint(localMessage)) {
     return false;
@@ -2562,6 +2631,79 @@ function shouldDeduplicateLocalMessage(
     return true;
   }
   return isRelaxedSteeredCodexMatch(codexMessage, localMessage);
+}
+
+function isLiveAssistantDeltaMessage(message: ChatMessageRecord): boolean {
+  return (
+    message.role === "assistant" &&
+    message.eventType === "item/agentMessage/delta"
+  );
+}
+
+function isCodexLiveAssistantMessageFresh(
+  codexMessage: ChatMessageRecord,
+  localMessage: ChatMessageRecord,
+): boolean {
+  return (
+    codexMessage.text === localMessage.text ||
+    codexMessage.text.startsWith(localMessage.text)
+  );
+}
+
+function findLiveAssistantDeltaCodexOrderLimits(
+  messages: ChatMessageRecord[],
+  codexMessages: InternalChatMessageRecord[],
+): ReadonlyMap<string, number> {
+  const codexOrderLimits = new Map<string, number>();
+  for (const [index, message] of messages.entries()) {
+    if (!isLiveAssistantDeltaMessage(message)) {
+      continue;
+    }
+    const laterUserMessage = messages
+      .slice(index + 1)
+      .find(isLiveAssistantDeltaBoundaryUserMessage);
+    if (!laterUserMessage) {
+      continue;
+    }
+    const boundaryCodexMessage = codexMessages
+      .filter(
+        (codexMessage) =>
+          codexMessage.role === "user" &&
+          isCodexBoundaryUserMessage(codexMessage, laterUserMessage),
+      )
+      .sort(
+        (left, right) => (left.codexOrder ?? 0) - (right.codexOrder ?? 0),
+      )[0];
+    if (boundaryCodexMessage?.codexOrder !== undefined) {
+      codexOrderLimits.set(message.id, boundaryCodexMessage.codexOrder);
+    }
+  }
+  return codexOrderLimits;
+}
+
+function isLiveAssistantDeltaBoundaryUserMessage(
+  message: ChatMessageRecord,
+): boolean {
+  return (
+    message.role === "user" &&
+    (!message.eventType || message.eventType === "chat.message.steered")
+  );
+}
+
+function isCodexBoundaryUserMessage(
+  codexMessage: InternalChatMessageRecord,
+  localMessage: ChatMessageRecord,
+): boolean {
+  if (messageFingerprint(codexMessage) !== messageFingerprint(localMessage)) {
+    return false;
+  }
+  if (localMessage.eventType === "chat.message.steered") {
+    return (
+      isCodexMessageAtOrAfterLocalMessage(codexMessage, localMessage) ||
+      isRelaxedSteeredCodexMatch(codexMessage, localMessage)
+    );
+  }
+  return isCodexMessageAtOrAfterLocalMessage(codexMessage, localMessage);
 }
 
 function isRelaxedSteeredCodexMatch(

--- a/packages/web/src/routes/home.tsx
+++ b/packages/web/src/routes/home.tsx
@@ -491,6 +491,7 @@ export function HomeRoute() {
   const selectedChatVersionRef = useRef(0);
   const chatsByProjectRef = useRef(chatsByProject);
   const worktreesByProjectRef = useRef(worktreesByProject);
+  const messagesRefreshRequestIdRef = useRef(0);
   const sendMessageRequestIdRef = useRef(0);
   const pendingSendChatIdsRef = useRef<Set<string>>(new Set());
   const pendingComposerModesByChatRef = useRef<Map<string, ComposerSubmitMode>>(
@@ -1461,17 +1462,25 @@ export function HomeRoute() {
     chatId: string,
     options: { showLoading?: boolean } = {},
   ) {
+    const requestId = messagesRefreshRequestIdRef.current + 1;
+    messagesRefreshRequestIdRef.current = requestId;
     if (options.showLoading) {
       setIsMessagesLoading(true);
     }
     try {
       const data = await queryClient.fetchQuery(messagesQueryOptions(chatId));
-      if (selectedChatIdRef.current === chatId) {
+      if (
+        selectedChatIdRef.current === chatId &&
+        messagesRefreshRequestIdRef.current === requestId
+      ) {
         setMessages(data.messages);
         setMessagesChatId(chatId);
       }
     } catch (err) {
-      if (selectedChatIdRef.current === chatId) {
+      if (
+        selectedChatIdRef.current === chatId &&
+        messagesRefreshRequestIdRef.current === requestId
+      ) {
         setError(err instanceof Error ? err.message : String(err));
       }
     } finally {


### PR DESCRIPTION
## Summary

- Prevent stale chat message fetches from overwriting newer timeline state in the web UI.
- Deduplicate live assistant delta messages against Codex thread history even when their item IDs use different formats.
- Add a server regression test for live assistant delta/history deduplication.

## Root Cause

The chat timeline could receive multiple overlapping refreshes from SSE events. Older responses were allowed to update `messages` after newer responses. Separately, server-side message merging treated assistant messages with different live-vs-history item IDs as distinct before falling back to content matching, so the same assistant text could appear twice.

## Validation

- `pnpm --filter @phantompane/server test`
- `pnpm --filter @phantompane/web typecheck`
- `pnpm ready`