### PR TITLE
[codex] allow editing pending chat messages

### DIFF
--- a/packages/server/src/rpc.ts
+++ b/packages/server/src/rpc.ts
@@ -57,6 +57,35 @@ const sendMessageSchema = z.object({
   skills: z.array(contextItemSchema).optional(),
 });
 
+const chatMessageSchema = z.object({
+  id: z.string().min(1),
+  chatId: z.string().min(1),
+  role: z.enum(["user"]),
+  text: z.string(),
+  eventType: z.literal("chat.message.queued"),
+  itemId: z.string().optional(),
+  createdAt: z.string().min(1),
+});
+
+const queuedMessageSchema = z.object({
+  id: z.string().min(1),
+  chatId: z.string().min(1),
+  messageId: z.string().min(1),
+  text: z.string().min(1),
+  effort: z.string().optional(),
+  files: z.array(contextItemSchema).optional(),
+  model: z.string().optional(),
+  skills: z.array(contextItemSchema).optional(),
+  createdAt: z.string().min(1),
+});
+
+const restorePendingMessageSchema = z.object({
+  message: chatMessageSchema,
+  messageIndex: z.number().int().nonnegative(),
+  queuedMessage: queuedMessageSchema,
+  queuedMessageIndex: z.number().int().nonnegative(),
+});
+
 const steerMessageSchema = sendMessageSchema;
 const queueMessageSchema = sendMessageSchema;
 
@@ -314,6 +343,33 @@ export const rpcRoutes = new Hono()
       return handleApiError(c, error);
     }
   })
+  .delete("/chats/:chatId/messages/:messageId", async (c) => {
+    try {
+      const result = await getServeServices().deletePendingMessage(
+        c.req.param("chatId"),
+        c.req.param("messageId"),
+      );
+      return c.json(result, 200);
+    } catch (error) {
+      return handleApiError(c, error);
+    }
+  })
+  .post(
+    "/chats/:chatId/messages/:messageId/restore",
+    jsonBody(restorePendingMessageSchema),
+    async (c) => {
+      try {
+        const body = c.req.valid("json");
+        const result = await getServeServices().restorePendingMessage(
+          c.req.param("chatId"),
+          body,
+        );
+        return c.json(result, 200);
+      } catch (error) {
+        return handleApiError(c, error);
+      }
+    },
+  )
   .post("/chats/:chatId/interrupt", async (c) => {
     try {
       await getServeServices().interruptChat(c.req.param("chatId"));

--- a/packages/server/src/services.test.ts
+++ b/packages/server/src/services.test.ts
@@ -1479,13 +1479,13 @@ describe("ServeServices", () => {
           "repeat",
           "item/agentMessage/delta",
         ],
-        ["chat_1_codex_turn_1_0", "user", "adjust", "chat.message.steered"],
+        ["chat_1_codex_turn_1_0", "user", "adjust", undefined],
         ["chat_1_codex_turn_1_1", "assistant", "repeat", undefined],
       ],
     );
   });
 
-  it("preserves steered message metadata when Codex history uses the turn timestamp", async () => {
+  it("uses the local timestamp for a consumed steered message", async () => {
     const state = {
       ...createTestState(),
       projects: [createProject()],
@@ -1538,10 +1538,66 @@ describe("ServeServices", () => {
           "chat_1_codex_turn_1_1",
           "user",
           "adjust course",
-          "chat.message.steered",
+          undefined,
           "2026-04-25T00:01:00.000Z",
         ],
       ],
+    );
+  });
+
+  it("clears stale steered state when thread history cannot be read after the turn ends", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "idle", activeTurnId: null })],
+      messages: [
+        {
+          id: "msg_steered",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "adjust course",
+          eventType: "chat.message.steered",
+          itemId: "turn_1",
+          createdAt: "2026-04-25T00:01:00.000Z",
+        },
+      ],
+    };
+    const { codex, services } = await createHarness(state);
+    codex.readThread.mockRejectedValueOnce(new Error("read failed"));
+
+    const messages = await services.getMessages("chat_1");
+
+    deepStrictEqual(
+      messages.map((message) => [message.id, message.text, message.eventType]),
+      [["msg_steered", "adjust course", undefined]],
+    );
+  });
+
+  it("clears stale steered state when thread history has no messages after the turn ends", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "idle", activeTurnId: null })],
+      messages: [
+        {
+          id: "msg_steered",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "adjust course",
+          eventType: "chat.message.steered",
+          itemId: "turn_1",
+          createdAt: "2026-04-25T00:01:00.000Z",
+        },
+      ],
+    };
+    const { codex, services } = await createHarness(state);
+    codex.readThread.mockResolvedValueOnce({ thread: { turns: [] } });
+
+    const messages = await services.getMessages("chat_1");
+
+    deepStrictEqual(
+      messages.map((message) => [message.id, message.text, message.eventType]),
+      [["msg_steered", "adjust course", undefined]],
     );
   });
 
@@ -1599,7 +1655,7 @@ describe("ServeServices", () => {
     );
   });
 
-  it("attaches steered metadata to the later matching Codex item", async () => {
+  it("matches a consumed steered message to the later Codex item", async () => {
     const state = {
       ...createTestState(),
       projects: [createProject()],
@@ -1652,7 +1708,7 @@ describe("ServeServices", () => {
           "chat_1_codex_turn_1_1",
           "user",
           "repeat",
-          "chat.message.steered",
+          undefined,
           "2026-04-25T00:01:00.000Z",
         ],
       ],
@@ -1724,21 +1780,21 @@ describe("ServeServices", () => {
           "chat_1_codex_turn_1_1",
           "user",
           "repeat",
-          "chat.message.steered",
+          undefined,
           "2026-04-25T00:01:00.000Z",
         ],
         [
           "chat_1_codex_turn_1_2",
           "user",
           "repeat",
-          "chat.message.steered",
+          undefined,
           "2026-04-25T00:02:00.000Z",
         ],
       ],
     );
   });
 
-  it("does not attach steered metadata to repeated initial Codex input", async () => {
+  it("does not match a steered message to repeated initial Codex input", async () => {
     const state = {
       ...createTestState(),
       projects: [createProject()],
@@ -1810,7 +1866,7 @@ describe("ServeServices", () => {
           "chat_1_codex_turn_1_2",
           "user",
           "repeat",
-          "chat.message.steered",
+          undefined,
           "2026-04-25T00:01:00.000Z",
           false,
           false,
@@ -1821,7 +1877,7 @@ describe("ServeServices", () => {
     );
   });
 
-  it("matches steered Codex item metadata when a turn has no input records", async () => {
+  it("matches a steered Codex item when a turn has no input records", async () => {
     const state = {
       ...createTestState(),
       projects: [createProject()],
@@ -1871,7 +1927,7 @@ describe("ServeServices", () => {
           "chat_1_codex_turn_1_0",
           "user",
           "repeat",
-          "chat.message.steered",
+          undefined,
           "2026-04-25T00:01:00.000Z",
         ],
         [
@@ -1885,7 +1941,7 @@ describe("ServeServices", () => {
     );
   });
 
-  it("does not attach steered metadata to the first same-text item when a turn has no input records", async () => {
+  it("does not match a steered message to the first same-text item when a turn has no input records", async () => {
     const state = {
       ...createTestState(),
       projects: [createProject()],
@@ -1940,7 +1996,7 @@ describe("ServeServices", () => {
           "chat_1_codex_turn_1_1",
           "user",
           "repeat",
-          "chat.message.steered",
+          undefined,
           "2026-04-25T00:01:00.000Z",
         ],
       ],
@@ -2004,21 +2060,21 @@ describe("ServeServices", () => {
           "chat_1_codex_turn_1_0",
           "user",
           "repeat",
-          "chat.message.steered",
+          undefined,
           "2026-04-25T00:01:00.000Z",
         ],
         [
           "chat_1_codex_turn_1_1",
           "user",
           "repeat",
-          "chat.message.steered",
+          undefined,
           "2026-04-25T00:02:00.000Z",
         ],
       ],
     );
   });
 
-  it("keeps Codex item order when steered metadata uses the local timestamp", async () => {
+  it("keeps Codex item order when a consumed steered message uses the local timestamp", async () => {
     const state = {
       ...createTestState(),
       projects: [createProject()],
@@ -2074,7 +2130,7 @@ describe("ServeServices", () => {
           "chat_1_codex_turn_1_1",
           "user",
           "adjust course",
-          "chat.message.steered",
+          undefined,
           "2026-04-25T00:01:00.000Z",
         ],
         [
@@ -4635,6 +4691,415 @@ describe("ServeServices", () => {
     strictEqual(savedState.chats[0]?.status, "idle");
     strictEqual(codex.startTurn.mock.calls.length, 0);
     strictEqual(codex.steerTurn.mock.calls.length, 0);
+  });
+
+  it("deletes queued messages before they are sent", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "running", activeTurnId: "turn_1" })],
+      messages: [
+        {
+          id: "msg_queued",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "queued draft",
+          eventType: "chat.message.queued",
+          createdAt: timestamp,
+        },
+      ],
+      queuedMessages: [
+        {
+          id: "queue_1",
+          chatId: "chat_1",
+          messageId: "msg_queued",
+          text: "queued draft",
+          createdAt: timestamp,
+        },
+      ],
+    };
+    const { services, store } = await createHarness(state);
+    const emitSpy = vi.spyOn(services.eventHub, "emit");
+
+    const result = await services.deletePendingMessage("chat_1", "msg_queued");
+
+    strictEqual(result.message.text, "queued draft");
+    strictEqual(result.queuedMessage.text, "queued draft");
+    const savedState = await store.load();
+    strictEqual(savedState.messages.length, 0);
+    strictEqual(savedState.queuedMessages.length, 0);
+    strictEqual(
+      emitSpy.mock.calls.some((call) => call[0] === "chat.message.deleted"),
+      true,
+    );
+  });
+
+  it("restores deleted pending messages without submitting them while the chat is blocked", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "running", activeTurnId: "turn_1" })],
+      messages: [],
+      queuedMessages: [],
+    };
+    const { codex, services, store } = await createHarness(state);
+    markChatActiveInCurrentProcess(services, "chat_1");
+    const emitSpy = vi.spyOn(services.eventHub, "emit");
+
+    const result = await services.restorePendingMessage("chat_1", {
+      message: {
+        id: "msg_queued",
+        chatId: "chat_1",
+        role: "user",
+        text: "queued draft",
+        eventType: "chat.message.queued",
+        createdAt: timestamp,
+      },
+      messageIndex: 0,
+      queuedMessage: {
+        id: "queue_1",
+        chatId: "chat_1",
+        messageId: "msg_queued",
+        text: "queued draft",
+        model: "gpt-5.2",
+        createdAt: timestamp,
+      },
+      queuedMessageIndex: 0,
+    });
+
+    strictEqual(result.queuedMessage.model, "gpt-5.2");
+    const savedState = await store.load();
+    strictEqual(savedState.messages.length, 1);
+    strictEqual(savedState.queuedMessages.length, 1);
+    strictEqual(codex.startTurn.mock.calls.length, 0);
+    strictEqual(
+      emitSpy.mock.calls.some((call) => call[0] === "chat.message.created"),
+      true,
+    );
+  });
+
+  it("restarts queued drain after restoring a pending message into an idle chat", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "idle", activeTurnId: null })],
+      messages: [],
+      queuedMessages: [],
+    };
+    const { codex, services, store } = await createHarness(state);
+    codex.startTurn.mockResolvedValueOnce({ turn: { id: "turn_2" } });
+
+    await services.restorePendingMessage("chat_1", {
+      message: {
+        id: "msg_queued",
+        chatId: "chat_1",
+        role: "user",
+        text: "queued draft",
+        eventType: "chat.message.queued",
+        createdAt: timestamp,
+      },
+      messageIndex: 0,
+      queuedMessage: {
+        id: "queue_1",
+        chatId: "chat_1",
+        messageId: "msg_queued",
+        text: "queued draft",
+        createdAt: timestamp,
+      },
+      queuedMessageIndex: 0,
+    });
+
+    const savedState = await store.load();
+    strictEqual(savedState.queuedMessages.length, 0);
+    strictEqual(savedState.messages[0]?.eventType, undefined);
+    deepStrictEqual(codex.startTurn.mock.calls[0], [
+      "thread_1",
+      "queued draft",
+      "/repo/.git/phantom/worktrees/worktree",
+    ]);
+  });
+
+  it("restores deleted pending messages to their original queue order", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "running", activeTurnId: "turn_1" })],
+      messages: [
+        {
+          id: "msg_later",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "later queued draft",
+          eventType: "chat.message.queued",
+          createdAt: timestamp,
+        },
+      ],
+      queuedMessages: [
+        {
+          id: "queue_later",
+          chatId: "chat_1",
+          messageId: "msg_later",
+          text: "later queued draft",
+          createdAt: timestamp,
+        },
+      ],
+    };
+    const { services, store } = await createHarness(state);
+    markChatActiveInCurrentProcess(services, "chat_1");
+
+    await services.restorePendingMessage("chat_1", {
+      message: {
+        id: "msg_earlier",
+        chatId: "chat_1",
+        role: "user",
+        text: "earlier queued draft",
+        eventType: "chat.message.queued",
+        createdAt: timestamp,
+      },
+      messageIndex: 0,
+      queuedMessage: {
+        id: "queue_earlier",
+        chatId: "chat_1",
+        messageId: "msg_earlier",
+        text: "earlier queued draft",
+        createdAt: timestamp,
+      },
+      queuedMessageIndex: 0,
+    });
+
+    const savedState = await store.load();
+    deepStrictEqual(
+      savedState.queuedMessages.map((message) => message.id),
+      ["queue_earlier", "queue_later"],
+    );
+    deepStrictEqual(
+      savedState.messages.map((message) => message.id),
+      ["msg_earlier", "msg_later"],
+    );
+  });
+
+  it("does not delete steered messages after they are sent to Codex", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "running", activeTurnId: "turn_1" })],
+      messages: [
+        {
+          id: "msg_steered",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "steered draft",
+          eventType: "chat.message.steered",
+          itemId: "turn_1",
+          createdAt: timestamp,
+        },
+      ],
+    };
+    const { services, store } = await createHarness(state);
+
+    await rejects(
+      services.deletePendingMessage("chat_1", "msg_steered"),
+      /Message is not pending/,
+    );
+
+    strictEqual((await store.load()).messages.length, 1);
+  });
+
+  it("does not delete messages after pending delivery completes", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "running", activeTurnId: "turn_1" })],
+      messages: [
+        {
+          id: "msg_sent",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "already sent",
+          createdAt: timestamp,
+        },
+      ],
+    };
+    const { services, store } = await createHarness(state);
+
+    await rejects(
+      services.deletePendingMessage("chat_1", "msg_sent"),
+      /Message is not pending/,
+    );
+
+    strictEqual((await store.load()).messages.length, 1);
+  });
+
+  it("does not delete queued messages once promotion starts", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "running", activeTurnId: "turn_1" })],
+      messages: [
+        {
+          id: "msg_queued",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "promoting",
+          eventType: "chat.message.queued",
+          createdAt: timestamp,
+        },
+      ],
+    };
+    const { services, store } = await createHarness(state);
+
+    await rejects(
+      services.deletePendingMessage("chat_1", "msg_queued"),
+      /Queued message is already being sent/,
+    );
+
+    strictEqual((await store.load()).messages.length, 1);
+  });
+
+  it("does not delete queued messages after drain claims them", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "running", activeTurnId: "turn_1" })],
+      messages: [
+        {
+          id: "msg_queued",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "promoting with context",
+          eventType: "chat.message.queued",
+          createdAt: timestamp,
+        },
+      ],
+      queuedMessages: [
+        {
+          id: "queue_1",
+          chatId: "chat_1",
+          messageId: "msg_queued",
+          text: "promoting with context",
+          skills: [{ name: "review", path: "/skills/review/SKILL.md" }],
+          createdAt: timestamp,
+        },
+      ],
+    };
+    const { codex, services, store } = await createHarness(state);
+    markChatActiveInCurrentProcess(services, "chat_1");
+    let resolveSkills!: (value: unknown) => void;
+    codex.listSkills.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveSkills = resolve;
+        }),
+    );
+    codex.resumeThread.mockResolvedValueOnce({});
+    codex.startTurn.mockResolvedValueOnce({ turn: { id: "turn_2" } });
+
+    codex.emitNotification({
+      method: "turn/completed",
+      params: {
+        threadId: "thread_1",
+        turn: { id: "turn_1", status: "completed" },
+      },
+    });
+
+    await vi.waitFor(async () => {
+      strictEqual(codex.listSkills.mock.calls.length, 1);
+      const savedState = await store.load();
+      strictEqual(savedState.queuedMessages.length, 0);
+      strictEqual(savedState.messages[0]?.eventType, undefined);
+    });
+    await rejects(
+      services.deletePendingMessage("chat_1", "msg_queued"),
+      /Message is not pending/,
+    );
+    await services.sendMessage("chat_1", { text: "new during claimed drain" });
+    let savedState = await store.load();
+    strictEqual(savedState.queuedMessages.length, 1);
+    strictEqual(savedState.queuedMessages[0]?.text, "new during claimed drain");
+    strictEqual(codex.startTurn.mock.calls.length, 0);
+
+    resolveSkills({
+      skills: [
+        {
+          enabled: true,
+          name: "review",
+          path: "/skills/review/SKILL.md",
+        },
+      ],
+    });
+    await vi.waitFor(() => {
+      strictEqual(codex.startTurn.mock.calls.length, 1);
+    });
+    savedState = await store.load();
+    strictEqual(savedState.queuedMessages.length, 1);
+  });
+
+  it("re-runs queued drain after enqueueing during an active drain that fails", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "running", activeTurnId: "turn_1" })],
+      messages: [
+        {
+          id: "msg_queued",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "promoting with context",
+          eventType: "chat.message.queued",
+          createdAt: timestamp,
+        },
+      ],
+      queuedMessages: [
+        {
+          id: "queue_1",
+          chatId: "chat_1",
+          messageId: "msg_queued",
+          text: "promoting with context",
+          skills: [{ name: "review", path: "/skills/review/SKILL.md" }],
+          createdAt: timestamp,
+        },
+      ],
+    };
+    const { codex, services, store } = await createHarness(state);
+    markChatActiveInCurrentProcess(services, "chat_1");
+    let rejectSkills!: (reason: unknown) => void;
+    codex.listSkills.mockImplementationOnce(
+      () =>
+        new Promise((_, reject) => {
+          rejectSkills = reject;
+        }),
+    );
+    codex.startTurn.mockResolvedValueOnce({ turn: { id: "turn_3" } });
+    codex.resumeThread.mockResolvedValue({});
+
+    codex.emitNotification({
+      method: "turn/completed",
+      params: {
+        threadId: "thread_1",
+        turn: { id: "turn_1", status: "completed" },
+      },
+    });
+
+    await vi.waitFor(async () => {
+      strictEqual(codex.listSkills.mock.calls.length, 1);
+      const savedState = await store.load();
+      strictEqual(savedState.queuedMessages.length, 0);
+    });
+    await services.sendMessage("chat_1", { text: "new during claimed drain" });
+
+    rejectSkills(new Error("skills failed"));
+    await vi.waitFor(
+      () => {
+        strictEqual(codex.startTurn.mock.calls.length, 1);
+      },
+      { timeout: 3000 },
+    );
+    const savedState = await store.load();
+    strictEqual(savedState.queuedMessages.length, 0);
+    deepStrictEqual(
+      codex.startTurn.mock.calls.map((call) => call[1]),
+      ["new during claimed drain"],
+    );
   });
 
   it("queues a message while a chat is running and starts it after the active turn completes", async () => {

--- a/packages/server/src/services.ts
+++ b/packages/server/src/services.ts
@@ -88,6 +88,13 @@ export interface SendMessageInput {
   text: string;
 }
 
+export interface DeletePendingMessageResult {
+  message: ChatMessageRecord;
+  messageIndex: number;
+  queuedMessage: QueuedMessageRecord;
+  queuedMessageIndex: number;
+}
+
 export interface ApprovalInput {
   decision: "accept" | "acceptForSession" | "decline" | "cancel";
 }
@@ -909,7 +916,7 @@ export class ServeServices {
       (message) => message.chatId === chatId,
     );
     if (!chat.codexThreadId) {
-      return localMessages;
+      return localMessagesWithoutStaleSteeredState(chat, localMessages);
     }
 
     try {
@@ -917,9 +924,12 @@ export class ServeServices {
         includeTurns: true,
       });
       const codexMessages = normalizeCodexThreadMessages(result, chat.id);
+      if (codexMessages.length === 0) {
+        return localMessagesWithoutStaleSteeredState(chat, localMessages);
+      }
       return mergeCodexAndLocalMessages(codexMessages, localMessages);
     } catch {
-      return localMessages;
+      return localMessagesWithoutStaleSteeredState(chat, localMessages);
     }
   }
 
@@ -930,10 +940,13 @@ export class ServeServices {
     await this.resetStaleTransientChatState();
     const state = await this.store.load();
     const chat = this.requireChat(state, chatId);
+    const isDrainingQueuedMessage =
+      this.drainingQueuedMessageChatIds.has(chatId);
     if (
       !isChatInActiveTurn(chat) &&
-      !this.pendingChatTurns.has(chatId) &&
-      state.queuedMessages.some((message) => message.chatId === chatId)
+      (isDrainingQueuedMessage ||
+        (!this.pendingChatTurns.has(chatId) &&
+          state.queuedMessages.some((message) => message.chatId === chatId)))
     ) {
       return this.queueMessage(chatId, input);
     }
@@ -959,20 +972,26 @@ export class ServeServices {
 
     let shouldSubmitImmediately = false;
     let shouldDrainQueuedMessages = false;
+    let shouldRequestPendingDrain = false;
     let queuedUserMessage: ChatMessageRecord | null = null;
     await this.store.update((nextState) => {
       const chat = this.requireChat(nextState, chatId);
       this.assertChatWorktreeIsAvailable(chat);
+      const isDrainingQueuedMessage =
+        this.drainingQueuedMessageChatIds.has(chatId);
       const hasQueuedMessages = nextState.queuedMessages.some(
         (message) => message.chatId === chatId,
       );
       const isQueueBlocked =
-        isChatInActiveTurn(chat) || this.pendingChatTurns.has(chatId);
+        isChatInActiveTurn(chat) ||
+        this.pendingChatTurns.has(chatId) ||
+        isDrainingQueuedMessage;
       if (!isQueueBlocked && !hasQueuedMessages) {
         shouldSubmitImmediately = true;
         return nextState;
       }
       shouldDrainQueuedMessages = !isQueueBlocked;
+      shouldRequestPendingDrain = isDrainingQueuedMessage;
 
       const userMessage = createMessage(
         chat.id,
@@ -996,10 +1015,152 @@ export class ServeServices {
     if (queuedUserMessage) {
       this.eventHub.emit("chat.message.created", queuedUserMessage, { chatId });
     }
+    if (shouldRequestPendingDrain) {
+      this.pendingQueuedMessageDrainChatIds.add(chatId);
+    }
     if (shouldDrainQueuedMessages) {
       await this.drainQueuedMessagesAndReport(chatId);
     }
     return await this.getChat(chatId);
+  }
+
+  async deletePendingMessage(
+    chatId: string,
+    messageId: string,
+  ): Promise<DeletePendingMessageResult> {
+    await this.resetStaleTransientChatState();
+    let deletedMessage: ChatMessageRecord | null = null;
+    let deletedMessageIndex = -1;
+    let deletedQueuedMessage: QueuedMessageRecord | null = null;
+    let deletedQueuedMessageIndex = -1;
+
+    await this.store.update((nextState) => {
+      const chat = this.requireChat(nextState, chatId);
+      this.assertChatWorktreeIsAvailable(chat);
+      const messageIndex = nextState.messages.findIndex(
+        (candidate) =>
+          candidate.id === messageId &&
+          candidate.chatId === chatId &&
+          candidate.role === "user",
+      );
+      const message =
+        messageIndex === -1 ? undefined : nextState.messages[messageIndex];
+      if (!message) {
+        throw new Error("Pending message was not found");
+      }
+      if (message.eventType !== "chat.message.queued") {
+        throw new Error("Message is not pending");
+      }
+      const queuedMessageIndex = nextState.queuedMessages.findIndex(
+        (candidate) =>
+          candidate.chatId === chatId && candidate.messageId === message.id,
+      );
+      const queuedMessage =
+        queuedMessageIndex === -1
+          ? undefined
+          : nextState.queuedMessages[queuedMessageIndex];
+      if (!queuedMessage) {
+        throw new Error("Queued message is already being sent");
+      }
+
+      deletedMessage = message;
+      deletedMessageIndex = messageIndex;
+      deletedQueuedMessage = queuedMessage;
+      deletedQueuedMessageIndex = queuedMessageIndex;
+      return {
+        ...nextState,
+        messages: nextState.messages.filter(
+          (candidate) => candidate.id !== message.id,
+        ),
+        queuedMessages: nextState.queuedMessages.filter(
+          (queuedMessage) =>
+            queuedMessage.chatId !== chatId ||
+            queuedMessage.messageId !== message.id,
+        ),
+      };
+    });
+
+    if (!deletedMessage) {
+      throw new Error("Pending message was not found");
+    }
+    if (!deletedQueuedMessage) {
+      throw new Error("Queued message was not found");
+    }
+    this.eventHub.emit("chat.message.deleted", deletedMessage, { chatId });
+    return {
+      message: deletedMessage,
+      messageIndex: deletedMessageIndex,
+      queuedMessage: deletedQueuedMessage,
+      queuedMessageIndex: deletedQueuedMessageIndex,
+    };
+  }
+
+  async restorePendingMessage(
+    chatId: string,
+    input: DeletePendingMessageResult,
+  ): Promise<DeletePendingMessageResult> {
+    await this.resetStaleTransientChatState();
+    const { message, queuedMessage } = input;
+    let shouldDrainQueuedMessages = false;
+    let shouldRequestPendingDrain = false;
+    if (
+      message.chatId !== chatId ||
+      queuedMessage.chatId !== chatId ||
+      queuedMessage.messageId !== message.id ||
+      message.role !== "user" ||
+      message.eventType !== "chat.message.queued" ||
+      !Number.isInteger(input.messageIndex) ||
+      input.messageIndex < 0 ||
+      !Number.isInteger(input.queuedMessageIndex) ||
+      input.queuedMessageIndex < 0
+    ) {
+      throw new Error("Pending message restore payload is invalid");
+    }
+
+    await this.store.update((nextState) => {
+      const chat = this.requireChat(nextState, chatId);
+      this.assertChatWorktreeIsAvailable(chat);
+      const isDrainingQueuedMessage =
+        this.drainingQueuedMessageChatIds.has(chatId);
+      const isQueueBlocked =
+        isChatInActiveTurn(chat) ||
+        this.pendingChatTurns.has(chatId) ||
+        isDrainingQueuedMessage;
+      shouldDrainQueuedMessages = !isQueueBlocked;
+      shouldRequestPendingDrain = isDrainingQueuedMessage;
+      if (
+        nextState.messages.some((candidate) => candidate.id === message.id) ||
+        nextState.queuedMessages.some(
+          (candidate) =>
+            candidate.id === queuedMessage.id ||
+            candidate.messageId === queuedMessage.messageId,
+        )
+      ) {
+        throw new Error("Pending message was already restored");
+      }
+      return {
+        ...nextState,
+        messages: insertRecordAtIndex(
+          nextState.messages,
+          message,
+          input.messageIndex,
+        ),
+        queuedMessages: insertRecordAtIndex(
+          nextState.queuedMessages,
+          queuedMessage,
+          input.queuedMessageIndex,
+        ),
+      };
+    });
+
+    this.eventHub.emit("chat.message.created", message, { chatId });
+    if (shouldRequestPendingDrain) {
+      this.pendingQueuedMessageDrainChatIds.add(chatId);
+    }
+    if (shouldDrainQueuedMessages) {
+      await this.drainQueuedMessagesAndReport(chatId);
+    }
+    return input;
   }
 
   private async submitMessage(
@@ -1591,28 +1752,65 @@ export class ServeServices {
     if (!queuedMessage) {
       return;
     }
-    const queuedUserMessage = state.messages.find(
-      (message) =>
-        message.id === queuedMessage.messageId &&
-        message.chatId === chatId &&
-        message.role === "user",
-    );
-    if (!queuedUserMessage) {
-      await this.store.update((nextState) => ({
+    const claimedQueuedMessageRef: { current: QueuedMessageRecord | null } = {
+      current: null,
+    };
+    let queuedUserMessageMissing = false;
+    await this.store.update((nextState) => {
+      const nextQueuedMessage = nextState.queuedMessages.find(
+        (message) =>
+          message.id === queuedMessage.id && message.chatId === chatId,
+      );
+      if (!nextQueuedMessage) {
+        return nextState;
+      }
+      const nextQueuedUserMessage = nextState.messages.find(
+        (message) =>
+          message.id === nextQueuedMessage.messageId &&
+          message.chatId === chatId &&
+          message.role === "user",
+      );
+      if (!nextQueuedUserMessage) {
+        queuedUserMessageMissing = true;
+        return {
+          ...nextState,
+          queuedMessages: nextState.queuedMessages.filter(
+            (message) => message.id !== nextQueuedMessage.id,
+          ),
+        };
+      }
+
+      claimedQueuedMessageRef.current = nextQueuedMessage;
+      return {
         ...nextState,
-        queuedMessages: nextState.queuedMessages.filter(
-          (message) => message.id !== queuedMessage.id,
+        messages: nextState.messages.map((message) =>
+          message.id === nextQueuedUserMessage.id
+            ? { ...message, eventType: undefined }
+            : message,
         ),
-      }));
+        queuedMessages: nextState.queuedMessages.filter(
+          (message) => message.id !== nextQueuedMessage.id,
+        ),
+      };
+    });
+    if (queuedUserMessageMissing) {
       await this.drainQueuedMessages(chatId);
       throw new Error("Queued message was not found");
     }
+    const claimedQueuedMessage = claimedQueuedMessageRef.current;
+    if (!claimedQueuedMessage) {
+      await this.drainQueuedMessages(chatId);
+      return;
+    }
 
-    await this.submitMessage(chatId, queuedMessageToSendInput(queuedMessage), {
-      existingUserMessageId: queuedMessage.messageId,
-      queuedMessageId: queuedMessage.id,
-      requireActiveTurn: false,
-    });
+    await this.submitMessage(
+      chatId,
+      queuedMessageToSendInput(claimedQueuedMessage),
+      {
+        existingUserMessageId: claimedQueuedMessage.messageId,
+        requireActiveTurn: false,
+      },
+    );
   }
 
   private async drainQueuedMessagesAndReport(chatId: string): Promise<void> {
@@ -1630,6 +1828,12 @@ export class ServeServices {
         } catch (error) {
           const wasReported = this.isAgentErrorReported(error);
           await this.addAgentErrorMessage(chatId, error);
+          const state = await this.store.load();
+          if (
+            state.queuedMessages.some((message) => message.chatId === chatId)
+          ) {
+            this.pendingQueuedMessageDrainChatIds.add(chatId);
+          }
           if (!wasReported) {
             this.emitAgentError(chatId, error);
           }
@@ -2551,7 +2755,6 @@ function mergeCodexAndLocalMessages(
       mergedCodexMessages[matchedCodexIndex] = {
         ...matchedCodexMessage,
         createdAt: message.createdAt,
-        eventType: message.eventType,
       };
     }
     unmatchedCodexMessageIndexes.splice(
@@ -2563,6 +2766,31 @@ function mergeCodexAndLocalMessages(
   return assignMergedMessageSortKeys(mergedCodexMessages, retainedLocalMessages)
     .sort(compareMergedMessages)
     .map(stripInternalCodexMessageMetadata);
+}
+
+function localMessagesWithoutStaleSteeredState(
+  chat: ChatRecord,
+  localMessages: ChatMessageRecord[],
+): ChatMessageRecord[] {
+  if (isChatInActiveTurn(chat)) {
+    return localMessages;
+  }
+  return localMessages.map((message) =>
+    message.eventType === "chat.message.steered"
+      ? { ...message, eventType: undefined }
+      : message,
+  );
+}
+
+function insertRecordAtIndex<TRecord>(
+  records: TRecord[],
+  record: TRecord,
+  index: number,
+): TRecord[] {
+  if (index >= records.length) {
+    return [...records, record];
+  }
+  return [...records.slice(0, index), record, ...records.slice(index)];
 }
 
 function assignMergedMessageSortKeys(

--- a/packages/web/src/api/mutations.test.ts
+++ b/packages/web/src/api/mutations.test.ts
@@ -3,7 +3,9 @@ import { afterEach, describe, it, vi } from "vitest";
 import {
   answerApprovalMutation,
   createChatMutation,
+  deletePendingMessageMutation,
   queueMessageMutation,
+  restorePendingMessageMutation,
   steerMessageMutation,
 } from "./mutations";
 
@@ -125,5 +127,79 @@ describe("message control mutations", () => {
     await queueMessageMutation("chat/with#hash", { text: "later" });
 
     strictEqual(requestUrl, "/api/chats/chat%2Fwith%23hash/queue");
+  });
+
+  it("encodes pending message delete route params before calling Hono RPC", async () => {
+    let requestUrl: string | undefined;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        requestUrl =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+        return new Response('{"message":{"id":"msg_1","text":"draft"}}', {
+          headers: {
+            "Content-Type": "application/json",
+          },
+          status: 200,
+        });
+      }),
+    );
+
+    await deletePendingMessageMutation("chat/with#hash", "msg/with#hash");
+
+    strictEqual(
+      requestUrl,
+      "/api/chats/chat%2Fwith%23hash/messages/msg%2Fwith%23hash",
+    );
+  });
+
+  it("encodes pending message restore route params before calling Hono RPC", async () => {
+    let requestUrl: string | undefined;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        requestUrl =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+        return new Response('{"message":{"id":"msg_1","text":"draft"}}', {
+          headers: {
+            "Content-Type": "application/json",
+          },
+          status: 200,
+        });
+      }),
+    );
+
+    await restorePendingMessageMutation("chat/with#hash", {
+      message: {
+        id: "msg/with#hash",
+        chatId: "chat/with#hash",
+        role: "user",
+        text: "draft",
+        eventType: "chat.message.queued",
+        createdAt: "2026-05-04T00:00:00.000Z",
+      },
+      messageIndex: 0,
+      queuedMessage: {
+        id: "queue_1",
+        chatId: "chat/with#hash",
+        messageId: "msg/with#hash",
+        text: "draft",
+        createdAt: "2026-05-04T00:00:00.000Z",
+      },
+      queuedMessageIndex: 0,
+    });
+
+    strictEqual(
+      requestUrl,
+      "/api/chats/chat%2Fwith%23hash/messages/msg%2Fwith%23hash/restore",
+    );
   });
 });

--- a/packages/web/src/api/mutations.ts
+++ b/packages/web/src/api/mutations.ts
@@ -1,8 +1,10 @@
 import { api, readRpcJson, routeParam } from "./client";
 import type {
+  ChatMessageRecord,
   ChatRecord,
   CodexTurnContextItem,
   ProjectRecord,
+  QueuedMessageRecord,
 } from "@phantompane/server";
 
 export interface DeleteWorktreeInput {
@@ -24,6 +26,16 @@ export interface CreateChatInput {
   initialMessage?: string;
   worktreeName?: string;
   worktreePath?: string;
+}
+
+export interface PendingMessagePayload {
+  message: ChatMessageRecord & {
+    eventType: "chat.message.queued";
+    role: "user";
+  };
+  messageIndex: number;
+  queuedMessage: QueuedMessageRecord;
+  queuedMessageIndex: number;
 }
 
 export async function addProjectMutation(path: string) {
@@ -77,6 +89,35 @@ export async function sendMessageMutation(
   return readRpcJson<{ chat: ChatRecord }>(
     await api.chats[":chatId"].messages.$post({
       param: { chatId: routeParam(chatId) },
+      json: input,
+    }),
+  );
+}
+
+export async function deletePendingMessageMutation(
+  chatId: string,
+  messageId: string,
+) {
+  return readRpcJson<PendingMessagePayload>(
+    await api.chats[":chatId"].messages[":messageId"].$delete({
+      param: {
+        chatId: routeParam(chatId),
+        messageId: routeParam(messageId),
+      },
+    }),
+  );
+}
+
+export async function restorePendingMessageMutation(
+  chatId: string,
+  input: PendingMessagePayload,
+) {
+  return readRpcJson<PendingMessagePayload>(
+    await api.chats[":chatId"].messages[":messageId"].restore.$post({
+      param: {
+        chatId: routeParam(chatId),
+        messageId: routeParam(input.message.id),
+      },
       json: input,
     }),
   );

--- a/packages/web/src/routes/home-url-state.test.ts
+++ b/packages/web/src/routes/home-url-state.test.ts
@@ -3,6 +3,7 @@ import {
   findValidatedSelectedProjectChat,
   findValidatedSelectedChat,
   getSelectableReasoningEfforts,
+  getSelectedSkillContextItems,
   isShareableFileSearchQuery,
   mergeWorktreesWithChats,
   retainRecordsForProjects,
@@ -104,6 +105,25 @@ describe("getSelectableReasoningEfforts", () => {
     expect(
       getSelectableReasoningEfforts({ supportedReasoningEfforts: [] }),
     ).toEqual([]);
+  });
+});
+
+describe("getSelectedSkillContextItems", () => {
+  it("keeps only selected skills that are currently enabled", () => {
+    expect(
+      getSelectedSkillContextItems(
+        [
+          { enabled: true, name: "review", path: "/skills/review/SKILL.md" },
+          { enabled: false, name: "stale", path: "/skills/stale/SKILL.md" },
+          { enabled: true, name: "unused", path: "/skills/unused/SKILL.md" },
+        ],
+        new Set([
+          "/skills/review/SKILL.md",
+          "/skills/stale/SKILL.md",
+          "/skills/removed/SKILL.md",
+        ]),
+      ),
+    ).toEqual([{ name: "review", path: "/skills/review/SKILL.md" }]);
   });
 });
 

--- a/packages/web/src/routes/home-url-state.ts
+++ b/packages/web/src/routes/home-url-state.ts
@@ -16,6 +16,12 @@ interface ModelReasoningEffortRecord {
   supportedReasoningEfforts: string[];
 }
 
+interface SkillSelectionRecord {
+  enabled: boolean;
+  name: string;
+  path: string;
+}
+
 interface WorktreeChatMergeRecord<TStatus> {
   id: string;
   status: TStatus;
@@ -150,4 +156,18 @@ export function getSelectableReasoningEfforts(
   return selectedModel
     ? selectedModel.supportedReasoningEfforts
     : fallbackReasoningEfforts;
+}
+
+export function getSelectedSkillContextItems<
+  TSkill extends SkillSelectionRecord,
+>(
+  skills: TSkill[],
+  selectedSkillPaths: ReadonlySet<string>,
+): Array<{ name: string; path: string }> {
+  return skills
+    .filter((skill) => skill.enabled && selectedSkillPaths.has(skill.path))
+    .map((skill) => ({
+      name: skill.name,
+      path: skill.path,
+    }));
 }

--- a/packages/web/src/routes/home.tsx
+++ b/packages/web/src/routes/home.tsx
@@ -11,6 +11,7 @@ import {
   MessageSquare,
   MessageSquarePlus,
   MoreHorizontal,
+  Pencil,
   Plus,
   RefreshCw,
   Send,
@@ -35,9 +36,11 @@ import {
   answerApprovalMutation,
   addProjectMutation,
   createChatMutation,
+  deletePendingMessageMutation,
   deleteWorktreeMutation,
   interruptChatMutation,
   queueMessageMutation,
+  restorePendingMessageMutation,
   sendMessageMutation,
   steerMessageMutation,
   syncWorktreeMutation,
@@ -113,6 +116,7 @@ import {
   findValidatedSelectedProjectChat,
   findValidatedSelectedChat,
   getSelectableReasoningEfforts,
+  getSelectedSkillContextItems,
   isShareableFileSearchQuery,
   mergeWorktreesWithChats,
   retainRecordsForProjects,
@@ -124,6 +128,7 @@ import type {
   CodexFileRecord,
   CodexModelRecord,
   CodexSkillRecord,
+  CodexTurnContextItem,
   PhantomEvent,
   ProjectWorktreeRecord,
   ProjectRecord,
@@ -133,6 +138,7 @@ const chatEventNames = [
   "chat.created",
   "chat.updated",
   "chat.message.created",
+  "chat.message.deleted",
   "agent.thread.started",
   "agent.turn.started",
   "agent.item.updated",
@@ -200,6 +206,12 @@ interface PendingApproval {
 interface DeleteWorktreeTarget {
   projectId: string;
   worktreePath: string;
+}
+
+interface RestoredPendingComposerContext {
+  chatId: string;
+  effort: string | null;
+  model: string | null;
 }
 
 type VisibleMessageRecord = ChatMessageRecord & {
@@ -504,6 +516,11 @@ export function HomeRoute() {
   const worktreesByProjectRef = useRef(worktreesByProject);
   const messagesRefreshRequestIdRef = useRef(0);
   const sendMessageRequestIdRef = useRef(0);
+  const composerTextareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const composerTextRef = useRef(composerText);
+  const hasSelectedContextRef = useRef(false);
+  const restoredPendingComposerContextRef =
+    useRef<RestoredPendingComposerContext | null>(null);
   const pendingSendChatIdsRef = useRef<Set<string>>(new Set());
   const pendingComposerModesByChatRef = useRef<Map<string, ComposerSubmitMode>>(
     new Map(),
@@ -554,6 +571,24 @@ export function HomeRoute() {
       chatId: string;
       input: Parameters<typeof sendMessageMutation>[1];
     }) => sendMessageMutation(chatId, input),
+  });
+  const deletePendingMessageRequest = useMutation({
+    mutationFn: ({
+      chatId,
+      messageId,
+    }: {
+      chatId: string;
+      messageId: string;
+    }) => deletePendingMessageMutation(chatId, messageId),
+  });
+  const restorePendingMessageRequest = useMutation({
+    mutationFn: ({
+      chatId,
+      input,
+    }: {
+      chatId: string;
+      input: Parameters<typeof restorePendingMessageMutation>[1];
+    }) => restorePendingMessageMutation(chatId, input),
   });
   const steerMessageRequest = useMutation({
     mutationFn: ({
@@ -719,11 +754,16 @@ export function HomeRoute() {
   );
 
   const selectedSkills = useMemo(
-    () => skills.filter((skill) => selectedSkillPaths.has(skill.path)),
+    () =>
+      skills.filter(
+        (skill) => skill.enabled && selectedSkillPaths.has(skill.path),
+      ),
     [selectedSkillPaths, skills],
   );
   const hasSelectedContext =
     selectedFiles.length > 0 || selectedSkills.length > 0;
+  composerTextRef.current = composerText;
+  hasSelectedContextRef.current = hasSelectedContext;
   const canStartNewProjectChat =
     Boolean(selectedProject) && !selectedChatId && Boolean(composerText.trim());
   const canSendMessage =
@@ -736,6 +776,8 @@ export function HomeRoute() {
     : "send";
   const isComposerBlocked =
     isSendingMessage ||
+    deletePendingMessageRequest.isPending ||
+    restorePendingMessageRequest.isPending ||
     Boolean(
       selectedChatId && pendingSendChatIdsRef.current.has(selectedChatId),
     );
@@ -747,7 +789,7 @@ export function HomeRoute() {
     hasSelectedChat && canSendMessage && !isComposerBlocked;
   const canInterruptActiveTurn =
     hasActiveTurn && !isInterrupting && Boolean(selectedChat?.activeTurnId);
-  const areComposerOptionsDisabled = !hasSelectedChat || isSendingMessage;
+  const areComposerOptionsDisabled = !hasSelectedChat || isComposerBlocked;
   const primaryComposerActionLabel =
     formatComposerModeAction(primaryComposerMode);
   const primaryComposerButtonLabel =
@@ -1781,27 +1823,29 @@ export function HomeRoute() {
     await submitComposer("send");
   }
 
-  function createComposerMessageInput(text: string): SendMessageInput {
-    const turnModel = selectedModel?.id ?? selectedModel?.model;
-    const turnEffort =
-      selectedModel &&
-      selectedEffort &&
-      selectedModelSupportedEfforts.includes(selectedEffort)
+  function createComposerMessageInput(
+    text: string,
+    restoredPendingContext: RestoredPendingComposerContext | null,
+  ): SendMessageInput {
+    const turnModel =
+      selectedModel?.id ??
+      selectedModel?.model ??
+      restoredPendingContext?.model ??
+      undefined;
+    const turnEffort = selectedModel
+      ? selectedEffort && selectedModelSupportedEfforts.includes(selectedEffort)
         ? selectedEffort
-        : null;
+        : null
+      : (restoredPendingContext?.effort ?? null);
     const files = selectedFiles.map((file) => ({
       name: file.relativePath,
       path: file.path,
-    }));
-    const selectedSkillItems = selectedSkills.map((skill) => ({
-      name: skill.name,
-      path: skill.path,
     }));
     return {
       effort: turnEffort,
       files,
       model: turnModel,
-      skills: selectedSkillItems,
+      skills: getSelectedSkillContextItems(skills, selectedSkillPaths),
       text,
     };
   }
@@ -1882,9 +1926,8 @@ export function HomeRoute() {
     if (
       (!requestChatId && (!selectedProjectId || mode !== "send")) ||
       !canSendMessage ||
-      isSendingMessage ||
+      isComposerBlocked ||
       (isStartingNewProjectChat && (isBusy || createChatInFlightRef.current)) ||
-      (requestChatId && pendingSendChatIdsRef.current.has(requestChatId)) ||
       (mode === "steer" && !selectedChat?.activeTurnId)
     ) {
       return;
@@ -1907,7 +1950,15 @@ export function HomeRoute() {
             hasSkills: selectedSkills.length > 0,
           });
     setComposerText("");
-    const messageInput = createComposerMessageInput(text);
+    const restoredPendingContext =
+      requestChatId &&
+      restoredPendingComposerContextRef.current?.chatId === requestChatId
+        ? restoredPendingComposerContextRef.current
+        : null;
+    const messageInput = createComposerMessageInput(
+      text,
+      restoredPendingContext,
+    );
     if (!requestChatId) {
       if (!selectedProjectId) {
         return;
@@ -1924,7 +1975,6 @@ export function HomeRoute() {
       setPendingComposerMode(null);
       return;
     }
-
     pendingSendChatIdsRef.current.add(requestChatId);
     pendingComposerModesByChatRef.current.set(requestChatId, mode);
     setIsSendingMessage(true);
@@ -1943,6 +1993,9 @@ export function HomeRoute() {
       void queryClient.invalidateQueries({
         queryKey: queryKeys.messages(requestChatId),
       });
+      if (restoredPendingComposerContextRef.current?.chatId === requestChatId) {
+        restoredPendingComposerContextRef.current = null;
+      }
       if (!isCurrentSendRequest()) {
         return;
       }
@@ -1969,6 +2022,98 @@ export function HomeRoute() {
         );
       }
     }
+  }
+
+  async function deletePendingMessage(message: VisibleMessageRecord) {
+    if (!selectedChatId || message.chatId !== selectedChatId) {
+      return null;
+    }
+    const requestChatId = selectedChatId;
+    setError(null);
+    try {
+      const data = await deletePendingMessageRequest.mutateAsync({
+        chatId: requestChatId,
+        messageId: message.id,
+      });
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.messages(requestChatId),
+      });
+      await refreshMessages(requestChatId);
+      return data;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      return null;
+    }
+  }
+
+  async function editPendingMessage(message: VisibleMessageRecord) {
+    if (composerText.trim() || hasSelectedContext) {
+      setError("Clear the current message before editing a pending message");
+      composerTextareaRef.current?.focus();
+      return;
+    }
+    const deletedPendingMessage = await deletePendingMessage(message);
+    if (!deletedPendingMessage) {
+      return;
+    }
+    const canRestoreIntoComposer =
+      selectedChatIdRef.current === deletedPendingMessage.message.chatId &&
+      !composerTextRef.current.trim() &&
+      !hasSelectedContextRef.current;
+    if (!canRestoreIntoComposer) {
+      const requeueChatId = deletedPendingMessage.message.chatId;
+      try {
+        await restorePendingMessageRequest.mutateAsync({
+          chatId: requeueChatId,
+          input: deletedPendingMessage,
+        });
+        void queryClient.invalidateQueries({
+          queryKey: queryKeys.messages(requeueChatId),
+        });
+        if (selectedChatIdRef.current === requeueChatId) {
+          await refreshMessages(requeueChatId);
+        }
+        setError(
+          "Pending message was restored to the queue because the composer changed before editing completed",
+        );
+      } catch (err) {
+        setError(
+          `Pending message was deleted but could not be restored: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
+      return;
+    }
+    restoredPendingComposerContextRef.current = {
+      chatId: deletedPendingMessage.message.chatId,
+      effort: deletedPendingMessage.queuedMessage.effort ?? null,
+      model: deletedPendingMessage.queuedMessage.model ?? null,
+    };
+    setComposerText(deletedPendingMessage.message.text);
+    setSelectedFiles(
+      (deletedPendingMessage.queuedMessage.files ?? []).map(
+        contextItemToSelectedFile,
+      ),
+    );
+    setSelectedSkillPaths(
+      new Set(
+        (deletedPendingMessage.queuedMessage.skills ?? []).map(
+          (skill) => skill.path,
+        ),
+      ),
+    );
+    setSearchParamValue(
+      searchParamKeys.model,
+      deletedPendingMessage.queuedMessage.model ?? null,
+    );
+    setSearchParamValue(
+      searchParamKeys.effort,
+      deletedPendingMessage.queuedMessage.effort ?? null,
+    );
+    requestAnimationFrame(() => {
+      composerTextareaRef.current?.focus();
+    });
   }
 
   function handleComposerKeyDown(event: KeyboardEvent<HTMLTextAreaElement>) {
@@ -2687,7 +2832,17 @@ export function HomeRoute() {
           ) : (
             <div className="mx-auto flex max-w-[var(--layout-max-content-width)] flex-col gap-2">
               {visibleMessages.map((message) => (
-                <MessageCard key={message.id} message={message} />
+                <MessageCard
+                  isPendingActionBusy={deletePendingMessageRequest.isPending}
+                  key={message.id}
+                  message={message}
+                  onDeletePendingMessage={(pendingMessage) =>
+                    void deletePendingMessage(pendingMessage)
+                  }
+                  onEditPendingMessage={(pendingMessage) =>
+                    void editPendingMessage(pendingMessage)
+                  }
+                />
               ))}
             </div>
           )}
@@ -2737,7 +2892,7 @@ export function HomeRoute() {
                 </Label>
                 <Textarea
                   className="min-h-12 border-0 bg-transparent px-2 py-2 shadow-none focus-visible:shadow-none"
-                  disabled={!selectedProject || isSendingMessage}
+                  disabled={!selectedProject || isComposerBlocked}
                   enterKeyHint="enter"
                   id="composer"
                   placeholder={
@@ -2748,6 +2903,7 @@ export function HomeRoute() {
                         : "Select a project to start"
                   }
                   rows={2}
+                  ref={composerTextareaRef}
                   value={composerText}
                   onChange={(event) => setComposerText(event.target.value)}
                   onKeyDown={handleComposerKeyDown}
@@ -2818,7 +2974,7 @@ export function HomeRoute() {
                 aria-label="Select model"
                 className="w-36 max-w-full sm:w-40"
                 disabled={
-                  isModelsLoading || models.length === 0 || isSendingMessage
+                  isModelsLoading || models.length === 0 || isComposerBlocked
                 }
                 emptyMessage={isModelsLoading ? "Loading models" : "No models"}
                 icon={<Bot className="size-3.5" />}
@@ -2836,7 +2992,7 @@ export function HomeRoute() {
               <Combobox
                 aria-label="Select reasoning effort"
                 className="w-28 max-w-full"
-                disabled={!selectedModel || isSendingMessage}
+                disabled={!selectedModel || isComposerBlocked}
                 icon={<Brain className="size-3.5" />}
                 options={effortOptions}
                 placeholder="Effort"
@@ -3161,7 +3317,17 @@ function EmptyTimeline({
   );
 }
 
-function MessageCard({ message }: { message: VisibleMessageRecord }) {
+function MessageCard({
+  isPendingActionBusy,
+  message,
+  onDeletePendingMessage,
+  onEditPendingMessage,
+}: {
+  isPendingActionBusy: boolean;
+  message: VisibleMessageRecord;
+  onDeletePendingMessage: (message: VisibleMessageRecord) => void;
+  onEditPendingMessage: (message: VisibleMessageRecord) => void;
+}) {
   const isUser = message.role === "user";
   const isError = message.role === "error";
   const deliveryState = getMessageDeliveryState(message);
@@ -3187,22 +3353,70 @@ function MessageCard({ message }: { message: VisibleMessageRecord }) {
       <pre className="whitespace-pre-wrap break-words font-sans text-[length:var(--font-size-md)] leading-[var(--line-height-relaxed)]">
         {message.text}
       </pre>
-      {deliveryState && <MessageDeliveryBadge state={deliveryState} />}
+      {deliveryState && (
+        <MessageDeliveryBadge
+          isActionBusy={isPendingActionBusy}
+          message={message}
+          state={deliveryState}
+          onDelete={onDeletePendingMessage}
+          onEdit={onEditPendingMessage}
+        />
+      )}
     </article>
   );
 }
 
-function MessageDeliveryBadge({ state }: { state: "queued" | "steered" }) {
+function MessageDeliveryBadge({
+  isActionBusy,
+  message,
+  onDelete,
+  onEdit,
+  state,
+}: {
+  isActionBusy: boolean;
+  message: VisibleMessageRecord;
+  onDelete: (message: VisibleMessageRecord) => void;
+  onEdit: (message: VisibleMessageRecord) => void;
+  state: "queued" | "steered";
+}) {
   const isQueued = state === "queued";
   const label = isQueued ? "Queued for next turn" : "Steered into active turn";
   const Icon = isQueued ? Clock3 : Send;
 
   return (
-    <div className="mt-2 flex justify-end">
+    <div className="mt-2 flex flex-wrap justify-end gap-1.5">
       <span className="inline-flex h-6 max-w-full items-center gap-1.5 rounded-[var(--radius-sm)] border border-current/20 bg-[var(--surface-floating)] px-2 text-[length:var(--font-size-xs)] font-medium text-current">
         <Icon className="size-3.5 shrink-0" />
         <span className="truncate">{label}</span>
       </span>
+      {isQueued && (
+        <>
+          <Button
+            aria-label="Edit pending message"
+            className="size-6 border-current/20 bg-[var(--surface-floating)] text-current hover:bg-[var(--state-hover-bg)]"
+            disabled={isActionBusy}
+            size="icon"
+            title="Edit pending message"
+            type="button"
+            variant="outline"
+            onClick={() => onEdit(message)}
+          >
+            <Pencil className="size-3.5" />
+          </Button>
+          <Button
+            aria-label="Delete pending message"
+            className="size-6 border-current/20 bg-[var(--surface-floating)] text-current hover:bg-[var(--state-hover-bg)]"
+            disabled={isActionBusy}
+            size="icon"
+            title="Delete pending message"
+            type="button"
+            variant="outline"
+            onClick={() => onDelete(message)}
+          >
+            <Trash2 className="size-3.5" />
+          </Button>
+        </>
+      )}
     </div>
   );
 }
@@ -3220,4 +3434,16 @@ function getMessageDeliveryState(
     return "steered";
   }
   return null;
+}
+
+function contextItemToSelectedFile(
+  item: CodexTurnContextItem,
+): CodexFileRecord {
+  return {
+    name: item.name,
+    path: item.path,
+    relativePath: item.name,
+    root: "",
+    score: 0,
+  };
 }


### PR DESCRIPTION
## Summary

- Add a queued pending-message delete endpoint that removes the local user message and queued payload before delivery.
- Add edit/delete controls to queued chat message badges; edit removes the queued message and restores its text, files, skills, model, and effort to the composer.
- Keep steered messages as status-only pending indicators because Codex does not expose cancellation/retraction after `turn/steer` is sent.
- Stop carrying `chat.message.steered` display metadata after Codex history consumes the steered user message, so it returns to the normal chat appearance.

## Impact

Users can retract queued messages before delivery, or edit them by restoring the queued payload into the chat input. Steered messages no longer expose misleading local-only edit/delete controls once the steer request has already been accepted by Codex.

## Validation

- `pnpm --filter @phantompane/server test -- services.test.ts`
- `pnpm --filter @phantompane/web test -- mutations.test.ts`
- `pnpm --filter @phantompane/web typecheck`
- `pnpm --filter @phantompane/server typecheck`
- `pnpm ready`