### PR TITLE
[codex] Fix worktree selection fallback

### DIFF
--- a/packages/web/src/routes/home-url-state.test.ts
+++ b/packages/web/src/routes/home-url-state.test.ts
@@ -4,9 +4,11 @@ import {
   findValidatedSelectedChat,
   getSelectableReasoningEfforts,
   getSelectedSkillContextItems,
+  isKnownWorktreeChat,
   isShareableFileSearchQuery,
   mergeWorktreesWithChats,
   retainRecordsForProjects,
+  resolveRefreshedWorktreeChatId,
 } from "./home-url-state";
 
 describe("isShareableFileSearchQuery", () => {
@@ -178,5 +180,69 @@ describe("mergeWorktreesWithChats", () => {
         chatTitle: "empty",
       },
     ]);
+  });
+});
+
+describe("isKnownWorktreeChat", () => {
+  it("accepts a selected chat exposed by refreshed worktree metadata", () => {
+    expect(
+      isKnownWorktreeChat(
+        [{ chatId: "chat-main" }, { chatId: "chat-feature" }],
+        "chat-feature",
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects absent and empty selected chat ids", () => {
+    const worktrees = [{ chatId: "chat-main" }, { chatId: null }];
+
+    expect(isKnownWorktreeChat(worktrees, "chat-feature")).toBe(false);
+    expect(isKnownWorktreeChat(worktrees, null)).toBe(false);
+  });
+});
+
+describe("resolveRefreshedWorktreeChatId", () => {
+  it("defers fallback while project chats are still loading", () => {
+    expect(
+      resolveRefreshedWorktreeChatId(
+        undefined,
+        [{ chatId: "chat-latest" }],
+        "chat-older",
+        "chat-main",
+      ),
+    ).toBe("chat-older");
+  });
+
+  it("keeps the selected chat when refreshed worktrees still reference it", () => {
+    expect(
+      resolveRefreshedWorktreeChatId(
+        [],
+        [{ chatId: "chat-main" }, { chatId: "chat-feature" }],
+        "chat-feature",
+        "chat-main",
+      ),
+    ).toBe("chat-feature");
+  });
+
+  it("keeps older selected chat history when the chat list contains it", () => {
+    expect(
+      resolveRefreshedWorktreeChatId(
+        [{ id: "chat-older" }],
+        [{ chatId: "chat-feature-latest" }],
+        "chat-older",
+        "chat-main",
+      ),
+    ).toBe("chat-older");
+  });
+
+  it("falls back only when the selected chat is no longer known", () => {
+    expect(
+      resolveRefreshedWorktreeChatId(
+        [{ id: "chat-main" }],
+        [{ chatId: "chat-main" }],
+        "chat-deleted",
+        "chat-main",
+      ),
+    ).toBe("chat-main");
   });
 });

--- a/packages/web/src/routes/home-url-state.ts
+++ b/packages/web/src/routes/home-url-state.ts
@@ -38,6 +38,10 @@ interface WorktreeMergeRecord<TStatus> {
   path: string;
 }
 
+interface WorktreeSelectionRecord {
+  chatId: string | null;
+}
+
 export function isShareableFileSearchQuery(value: string): boolean {
   let query = value.trim();
   if (!query) {
@@ -148,6 +152,43 @@ export function mergeWorktreesWithChats<
       chatTitle: chat.title,
     };
   });
+}
+
+export function isKnownWorktreeChat<TWorktree extends WorktreeSelectionRecord>(
+  worktrees: TWorktree[],
+  selectedChatId: string | null,
+): boolean {
+  return Boolean(
+    selectedChatId &&
+    worktrees.some((worktree) => worktree.chatId === selectedChatId),
+  );
+}
+
+export function resolveRefreshedWorktreeChatId<
+  TChat extends Pick<ChatSelectionRecord, "id">,
+  TWorktree extends WorktreeSelectionRecord,
+>(
+  chats: TChat[] | undefined,
+  worktrees: TWorktree[],
+  selectedChatId: string | null,
+  fallbackChatId: string | null,
+): string | null {
+  if (!selectedChatId) {
+    return null;
+  }
+
+  if (!chats) {
+    return selectedChatId;
+  }
+
+  if (
+    chats.some((chat) => chat.id === selectedChatId) ||
+    isKnownWorktreeChat(worktrees, selectedChatId)
+  ) {
+    return selectedChatId;
+  }
+
+  return fallbackChatId ?? selectedChatId;
 }
 
 export function getSelectableReasoningEfforts(

--- a/packages/web/src/routes/home.tsx
+++ b/packages/web/src/routes/home.tsx
@@ -117,9 +117,11 @@ import {
   findValidatedSelectedChat,
   getSelectableReasoningEfforts,
   getSelectedSkillContextItems,
+  isKnownWorktreeChat,
   isShareableFileSearchQuery,
   mergeWorktreesWithChats,
   retainRecordsForProjects,
+  resolveRefreshedWorktreeChatId,
 } from "./home-url-state";
 import type {
   ChatMessageRecord,
@@ -737,6 +739,13 @@ export function HomeRoute() {
     chatsByProject[selectedProjectId] !== undefined &&
     worktreesByProject[selectedProjectId] !== undefined,
   );
+  const isSelectedChatKnownByWorktree = Boolean(
+    selectedProjectId &&
+    isKnownWorktreeChat(
+      worktreesByProject[selectedProjectId] ?? [],
+      selectedChatId,
+    ),
+  );
   const hasActiveTurn = Boolean(selectedChat?.activeTurnId);
   const isChatRunning = selectedChat?.status === "running" && hasActiveTurn;
 
@@ -1220,6 +1229,7 @@ export function HomeRoute() {
     if (
       !selectedChatId ||
       isSelectedChatValidated ||
+      isSelectedChatKnownByWorktree ||
       !selectedProjectId ||
       !hasLoadedSelectedProjectData
     ) {
@@ -1238,6 +1248,7 @@ export function HomeRoute() {
   }, [
     fileSearchQuery,
     hasLoadedSelectedProjectData,
+    isSelectedChatKnownByWorktree,
     isSelectedChatValidated,
     selectedChatId,
     selectedProjectId,
@@ -1406,9 +1417,12 @@ export function HomeRoute() {
       );
       const currentSelectedChatId = selectedChatIdRef.current;
       const currentFileSearchQuery = fileSearchQueryRef.current;
-      const nextChatId = currentSelectedChatId
-        ? (fallbackWorktree?.chatId ?? currentSelectedChatId)
-        : null;
+      const nextChatId = resolveRefreshedWorktreeChatId(
+        chatsByProjectRef.current[projectId],
+        mergedWorktrees,
+        currentSelectedChatId,
+        fallbackWorktree?.chatId ?? null,
+      );
       updateWorkspaceSearchParams(
         {
           projectId,


### PR DESCRIPTION
## Summary

Fixes the sidebar worktree selection flow in `packages/web` so clicking a worktree in another project keeps that worktree selected instead of being replaced by the project's main worktree.

## Root Cause

When worktrees refreshed, the web route treated the currently selected `chatId` as invalid before the refreshed chat list had validated it, then fell back to the first worktree in the project. Because server worktrees are sorted with the main worktree first, that fallback opened the main worktree.

## Changes

- Preserve selected chats when they are still known through refreshed worktree metadata.
- Only fall back to the project/default worktree chat when the selected chat is genuinely unknown.
- Add URL state regression tests for preserving selected worktree chat IDs and fallback behavior.

## Validation

- `pnpm exec vitest run --root . packages/web/src/routes/home-url-state.test.ts`
- `pnpm ready`