### PR TITLE
[codex] show Codex rich events

### DIFF
--- a/packages/codex/src/events.test.ts
+++ b/packages/codex/src/events.test.ts
@@ -1,0 +1,36 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "vitest";
+import { mapCodexMethodToEvent, summarizeCodexEvent } from "./events.ts";
+
+describe("Codex event mapping", () => {
+  it("maps rich app-server notifications to dedicated Phantom events", () => {
+    strictEqual(
+      mapCodexMethodToEvent("turn/plan/updated"),
+      "agent.plan.updated",
+    );
+    strictEqual(
+      mapCodexMethodToEvent("item/commandExecution/outputDelta"),
+      "agent.command.output",
+    );
+    strictEqual(
+      mapCodexMethodToEvent("item/reasoning/summaryTextDelta"),
+      "agent.reasoning.updated",
+    );
+    strictEqual(mapCodexMethodToEvent("guardianWarning"), "agent.warning");
+  });
+
+  it("summarizes rich notifications for compatibility messages", () => {
+    strictEqual(
+      summarizeCodexEvent("turn/plan/updated", {
+        plan: [{ step: "Inspect", status: "completed" }],
+      }),
+      "plan updated: 1 step",
+    );
+    strictEqual(
+      summarizeCodexEvent("item/fileChange/patchUpdated", {
+        changes: [{ path: "a.ts", kind: "modify", diff: "" }],
+      }),
+      "file patch updated: 1 file",
+    );
+  });
+});

--- a/packages/codex/src/events.ts
+++ b/packages/codex/src/events.ts
@@ -82,6 +82,34 @@ export function mapCodexMethodToEvent(method: string): string {
   if (method === "turn/completed") {
     return "agent.turn.completed";
   }
+  if (method === "turn/plan/updated" || method === "item/plan/delta") {
+    return "agent.plan.updated";
+  }
+  if (method === "turn/diff/updated") {
+    return "agent.diff.updated";
+  }
+  if (
+    method === "item/commandExecution/outputDelta" ||
+    method === "command/exec/outputDelta"
+  ) {
+    return "agent.command.output";
+  }
+  if (
+    method === "item/fileChange/patchUpdated" ||
+    method === "item/fileChange/outputDelta"
+  ) {
+    return "agent.file.updated";
+  }
+  if (method.startsWith("item/reasoning/")) {
+    return "agent.reasoning.updated";
+  }
+  if (
+    method === "warning" ||
+    method === "guardianWarning" ||
+    method === "configWarning"
+  ) {
+    return "agent.warning";
+  }
   if (method.startsWith("item/") && method.endsWith("/requestApproval")) {
     return "agent.approval.requested";
   }
@@ -102,6 +130,40 @@ export function mapCodexMethodToEvent(method: string): string {
 
 export function summarizeCodexEvent(method: string, params: unknown): string {
   const object = getParamObject(params);
+  if (method === "turn/plan/updated") {
+    const plan = Array.isArray(object?.plan) ? object.plan : [];
+    return `plan updated: ${plan.length} step${plan.length === 1 ? "" : "s"}`;
+  }
+  if (method === "turn/diff/updated") {
+    const diff = typeof object?.diff === "string" ? object.diff : "";
+    return diff ? "diff updated" : "diff cleared";
+  }
+  if (
+    method === "item/commandExecution/outputDelta" ||
+    method === "command/exec/outputDelta"
+  ) {
+    return "command output";
+  }
+  if (method === "item/fileChange/patchUpdated") {
+    const changes = Array.isArray(object?.changes) ? object.changes : [];
+    return `file patch updated: ${changes.length} file${
+      changes.length === 1 ? "" : "s"
+    }`;
+  }
+  if (method === "item/fileChange/outputDelta") {
+    return "file change output";
+  }
+  if (method.startsWith("item/reasoning/")) {
+    return "reasoning updated";
+  }
+  if (method === "warning" || method === "guardianWarning") {
+    return typeof object?.message === "string" ? object.message : "Warning";
+  }
+  if (method === "configWarning") {
+    return typeof object?.summary === "string"
+      ? object.summary
+      : "Configuration warning";
+  }
   if (method === "item/started" || method === "item/completed") {
     const item = getParamObject(object?.item);
     const type = typeof item?.type === "string" ? item.type : "item";

--- a/packages/server/src/services.test.ts
+++ b/packages/server/src/services.test.ts
@@ -5040,6 +5040,107 @@ describe("ServeServices", () => {
     );
   });
 
+  it("stores rich Codex events as structured timeline messages", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "running", activeTurnId: "turn_1" })],
+    };
+    const { codex, services, store } = await createHarness(state);
+    const emitSpy = vi.spyOn(services.eventHub, "emit");
+
+    codex.emitNotification({
+      method: "turn/plan/updated",
+      params: {
+        threadId: "thread_1",
+        turnId: "turn_1",
+        explanation: "Working through the change",
+        plan: [{ step: "Inspect code", status: "completed" }],
+      },
+    });
+    codex.emitNotification({
+      method: "turn/plan/updated",
+      params: {
+        threadId: "thread_1",
+        turnId: "turn_1",
+        explanation: "Working through the change",
+        plan: [
+          { step: "Inspect code", status: "completed" },
+          { step: "Patch UI", status: "inProgress" },
+        ],
+      },
+    });
+    codex.emitNotification({
+      method: "item/commandExecution/outputDelta",
+      params: {
+        threadId: "thread_1",
+        turnId: "turn_1",
+        itemId: "cmd_1",
+        delta: "first",
+      },
+    });
+    codex.emitNotification({
+      method: "item/commandExecution/outputDelta",
+      params: {
+        threadId: "thread_1",
+        turnId: "turn_1",
+        itemId: "cmd_1",
+        delta: " second",
+      },
+    });
+    codex.emitNotification({
+      method: "item/fileChange/patchUpdated",
+      params: {
+        threadId: "thread_1",
+        turnId: "turn_1",
+        itemId: "patch_1",
+        changes: [{ path: "src/app.ts", kind: "modify", diff: "@@ patch" }],
+      },
+    });
+
+    await vi.waitFor(async () => {
+      strictEqual((await store.load()).messages.length, 3);
+    });
+
+    const savedState = await store.load();
+    const planMessage = savedState.messages.find(
+      (message) => message.eventType === "turn/plan/updated",
+    );
+    const commandMessage = savedState.messages.find(
+      (message) => message.eventType === "item/commandExecution/outputDelta",
+    );
+    const patchMessage = savedState.messages.find(
+      (message) => message.eventType === "item/fileChange/patchUpdated",
+    );
+
+    strictEqual(planMessage?.role, "event");
+    strictEqual(planMessage?.text, "plan updated: 2 steps");
+    deepStrictEqual(
+      (planMessage?.eventData as { plan?: unknown[] } | undefined)?.plan,
+      [
+        { step: "Inspect code", status: "completed" },
+        { step: "Patch UI", status: "inProgress" },
+      ],
+    );
+    strictEqual(commandMessage?.text, "first second");
+    strictEqual(
+      (commandMessage?.eventData as { text?: string } | undefined)?.text,
+      "first second",
+    );
+    deepStrictEqual(
+      (patchMessage?.eventData as { changes?: unknown[] } | undefined)?.changes,
+      [{ path: "src/app.ts", kind: "modify", diff: "@@ patch" }],
+    );
+    strictEqual(
+      emitSpy.mock.calls.some((call) => call[0] === "agent.plan.updated"),
+      true,
+    );
+    strictEqual(
+      emitSpy.mock.calls.some((call) => call[0] === "agent.command.output"),
+      true,
+    );
+  });
+
   it("keeps pending stream order when new notifications arrive during replay", async () => {
     const state = {
       ...createTestState(),

--- a/packages/server/src/services.test.ts
+++ b/packages/server/src/services.test.ts
@@ -5141,6 +5141,65 @@ describe("ServeServices", () => {
     );
   });
 
+  it("ignores empty reasoning summary parts before summary text arrives", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "running", activeTurnId: "turn_1" })],
+    };
+    const { codex, store } = await createHarness(state);
+
+    codex.emitNotification({
+      method: "item/reasoning/summaryPartAdded",
+      params: {
+        threadId: "thread_1",
+        turnId: "turn_1",
+        itemId: "reasoning_1",
+        summaryIndex: 0,
+      },
+    });
+    codex.emitNotification({
+      method: "item/reasoning/summaryTextDelta",
+      params: {
+        threadId: "thread_1",
+        turnId: "turn_1",
+        itemId: "reasoning_1",
+        summaryIndex: 0,
+        delta: "First",
+      },
+    });
+    codex.emitNotification({
+      method: "item/reasoning/summaryTextDelta",
+      params: {
+        threadId: "thread_1",
+        turnId: "turn_1",
+        itemId: "reasoning_1",
+        summaryIndex: 0,
+        delta: " second",
+      },
+    });
+
+    await vi.waitFor(async () => {
+      strictEqual((await store.load()).messages.length, 1);
+    });
+
+    const savedState = await store.load();
+    strictEqual(
+      savedState.messages.some(
+        (message) => message.eventType === "item/reasoning/summaryPartAdded",
+      ),
+      false,
+    );
+    const reasoningMessage = savedState.messages[0];
+    strictEqual(reasoningMessage?.eventType, "item/reasoning/summaryTextDelta");
+    strictEqual(reasoningMessage?.text, "First second");
+    deepStrictEqual(reasoningMessage?.eventData, {
+      kind: "summaryText",
+      summaryIndex: 0,
+      text: "First second",
+    });
+  });
+
   it("keeps pending stream order when new notifications arrive during replay", async () => {
     const state = {
       ...createTestState(),

--- a/packages/server/src/services.test.ts
+++ b/packages/server/src/services.test.ts
@@ -5127,6 +5127,27 @@ describe("ServeServices", () => {
       },
     });
     codex.emitNotification({
+      method: "command/exec/outputDelta",
+      params: {
+        threadId: "thread_1",
+        turnId: "turn_1",
+        processId: "proc_2",
+        stream: "stdout",
+        deltaBase64: Buffer.from("log").toString("base64"),
+        capReached: false,
+      },
+    });
+    codex.emitNotification({
+      method: "command/exec/outputDelta",
+      params: {
+        threadId: "thread_1",
+        turnId: "turn_1",
+        processId: "proc_2",
+        stream: "stdout",
+        capReached: true,
+      },
+    });
+    codex.emitNotification({
       method: "item/fileChange/patchUpdated",
       params: {
         threadId: "thread_1",
@@ -5152,7 +5173,7 @@ describe("ServeServices", () => {
     });
 
     await vi.waitFor(async () => {
-      strictEqual((await store.load()).messages.length, 4);
+      strictEqual((await store.load()).messages.length, 5);
     });
 
     const savedState = await store.load();
@@ -5167,6 +5188,9 @@ describe("ServeServices", () => {
     );
     const emptyCommandMessage = savedState.messages.find(
       (message) => message.itemId === "cmd_empty",
+    );
+    const shellCommandMessage = savedState.messages.find(
+      (message) => message.eventType === "command/exec/outputDelta",
     );
 
     strictEqual(planMessage?.role, "event");
@@ -5209,6 +5233,12 @@ describe("ServeServices", () => {
       "item/commandExecution/outputDelta",
     );
     strictEqual(emptyCommandMessage?.text, "");
+    strictEqual(shellCommandMessage?.text, "log");
+    strictEqual(
+      (shellCommandMessage?.eventData as { capReached?: boolean } | undefined)
+        ?.capReached,
+      true,
+    );
     deepStrictEqual(
       (patchMessage?.eventData as { changes?: unknown[] } | undefined)?.changes,
       [{ path: "src/app.ts", kind: "modify", diff: "@@ final patch" }],

--- a/packages/server/src/services.test.ts
+++ b/packages/server/src/services.test.ts
@@ -5052,7 +5052,6 @@ describe("ServeServices", () => {
     codex.emitNotification({
       method: "turn/plan/updated",
       params: {
-        threadId: "thread_1",
         turnId: "turn_1",
         explanation: "Working through the change",
         plan: [{ step: "Inspect code", status: "completed" }],
@@ -5061,7 +5060,6 @@ describe("ServeServices", () => {
     codex.emitNotification({
       method: "turn/plan/updated",
       params: {
-        threadId: "thread_1",
         turnId: "turn_1",
         explanation: "Working through the change",
         plan: [
@@ -5089,6 +5087,46 @@ describe("ServeServices", () => {
       },
     });
     codex.emitNotification({
+      method: "item/completed",
+      params: {
+        threadId: "thread_1",
+        turnId: "turn_1",
+        item: {
+          type: "commandExecution",
+          id: "cmd_1",
+          command: "pnpm test",
+          cwd: "/repo",
+          processId: "proc_1",
+          source: "agent",
+          status: "completed",
+          commandActions: [],
+          aggregatedOutput: null,
+          exitCode: 0,
+          durationMs: 42,
+        },
+      },
+    });
+    codex.emitNotification({
+      method: "item/completed",
+      params: {
+        threadId: "thread_1",
+        turnId: "turn_1",
+        item: {
+          type: "commandExecution",
+          id: "cmd_empty",
+          command: "true",
+          cwd: "/repo",
+          processId: null,
+          source: "agent",
+          status: "completed",
+          commandActions: [],
+          aggregatedOutput: null,
+          exitCode: 0,
+          durationMs: 1,
+        },
+      },
+    });
+    codex.emitNotification({
       method: "item/fileChange/patchUpdated",
       params: {
         threadId: "thread_1",
@@ -5097,9 +5135,24 @@ describe("ServeServices", () => {
         changes: [{ path: "src/app.ts", kind: "modify", diff: "@@ patch" }],
       },
     });
+    codex.emitNotification({
+      method: "item/completed",
+      params: {
+        threadId: "thread_1",
+        turnId: "turn_1",
+        item: {
+          type: "fileChange",
+          id: "patch_1",
+          changes: [
+            { path: "src/app.ts", kind: "modify", diff: "@@ final patch" },
+          ],
+          status: "completed",
+        },
+      },
+    });
 
     await vi.waitFor(async () => {
-      strictEqual((await store.load()).messages.length, 3);
+      strictEqual((await store.load()).messages.length, 4);
     });
 
     const savedState = await store.load();
@@ -5111,6 +5164,9 @@ describe("ServeServices", () => {
     );
     const patchMessage = savedState.messages.find(
       (message) => message.eventType === "item/fileChange/patchUpdated",
+    );
+    const emptyCommandMessage = savedState.messages.find(
+      (message) => message.itemId === "cmd_empty",
     );
 
     strictEqual(planMessage?.role, "event");
@@ -5128,8 +5184,38 @@ describe("ServeServices", () => {
       "first second",
     );
     deepStrictEqual(
+      {
+        command: (
+          commandMessage?.eventData as { command?: unknown } | undefined
+        )?.command,
+        durationMs: (
+          commandMessage?.eventData as { durationMs?: unknown } | undefined
+        )?.durationMs,
+        exitCode: (
+          commandMessage?.eventData as { exitCode?: unknown } | undefined
+        )?.exitCode,
+        status: (commandMessage?.eventData as { status?: unknown } | undefined)
+          ?.status,
+      },
+      {
+        command: "pnpm test",
+        durationMs: 42,
+        exitCode: 0,
+        status: "completed",
+      },
+    );
+    strictEqual(
+      emptyCommandMessage?.eventType,
+      "item/commandExecution/outputDelta",
+    );
+    strictEqual(emptyCommandMessage?.text, "");
+    deepStrictEqual(
       (patchMessage?.eventData as { changes?: unknown[] } | undefined)?.changes,
-      [{ path: "src/app.ts", kind: "modify", diff: "@@ patch" }],
+      [{ path: "src/app.ts", kind: "modify", diff: "@@ final patch" }],
+    );
+    strictEqual(
+      (patchMessage?.eventData as { status?: string } | undefined)?.status,
+      "completed",
     );
     strictEqual(
       emitSpy.mock.calls.some((call) => call[0] === "agent.plan.updated"),

--- a/packages/server/src/services.test.ts
+++ b/packages/server/src/services.test.ts
@@ -5040,6 +5040,48 @@ describe("ServeServices", () => {
     );
   });
 
+  it("buffers threadless turn events until a new turn is committed", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat()],
+    };
+    const { codex, services, store } = await createHarness(state);
+    codex.resumeThread.mockResolvedValueOnce({});
+    codex.startTurn.mockImplementationOnce(async () => {
+      codex.emitNotification({
+        method: "turn/plan/updated",
+        params: {
+          turnId: "turn_1",
+          explanation: "Starting quickly",
+          plan: [{ step: "Inspect code", status: "inProgress" }],
+        },
+      });
+      return { turn: { id: "turn_1" } };
+    });
+
+    await services.sendMessage("chat_1", { text: "hello" });
+
+    await vi.waitFor(async () => {
+      strictEqual((await store.load()).messages.length, 2);
+    });
+
+    const savedState = await store.load();
+    const planMessage = savedState.messages.find(
+      (message) => message.eventType === "turn/plan/updated",
+    );
+    deepStrictEqual(
+      savedState.messages.map((message) => message.role),
+      ["user", "event"],
+    );
+    strictEqual(savedState.chats[0]?.activeTurnId, "turn_1");
+    strictEqual(planMessage?.text, "plan updated: 1 step");
+    deepStrictEqual(
+      (planMessage?.eventData as { plan?: unknown[] } | undefined)?.plan,
+      [{ step: "Inspect code", status: "inProgress" }],
+    );
+  });
+
   it("stores rich Codex events as structured timeline messages", async () => {
     const state = {
       ...createTestState(),

--- a/packages/server/src/services.ts
+++ b/packages/server/src/services.ts
@@ -2352,14 +2352,11 @@ export class ServeServices {
     }
 
     if (method.startsWith("item/reasoning/")) {
-      const eventData = createReasoningEventData(method, params);
-      const delta =
-        method === "item/reasoning/summaryPartAdded"
-          ? "Reasoning summary added"
-          : (getRecordString(params, "delta") ?? "");
+      const delta = getRecordString(params, "delta") ?? "";
       if (!delta) {
         return;
       }
+      const eventData = createReasoningEventData(method, params);
       await this.appendRichEventMessage({
         chatId,
         delta,

--- a/packages/server/src/services.ts
+++ b/packages/server/src/services.ts
@@ -204,9 +204,11 @@ function isValidInferredWorktreeName(name: string): boolean {
   });
 }
 
-type PendingTurnEvent =
-  | { kind: "notification"; message: CodexMessage }
-  | { kind: "serverRequest"; message: CodexMessage };
+interface PendingTurnEvent {
+  kind: "notification" | "serverRequest";
+  message: CodexMessage;
+  order: number;
+}
 
 type CodexTurnItemSource = "input" | "item";
 type InternalChatMessageRecord = ChatMessageRecord & {
@@ -245,6 +247,12 @@ export class ServeServices {
     string,
     PendingTurnEventBuffer
   >();
+  private readonly pendingTurnEventsByTurnId = new Map<
+    string,
+    PendingTurnEvent[]
+  >();
+  private readonly pendingTurnThreadsByTurnId = new Map<string, string>();
+  private pendingTurnEventOrder = 0;
   private readonly pendingChatTurns = new Set<string>();
   private readonly drainingQueuedMessageChatIds = new Set<string>();
   private readonly pendingQueuedMessageDrainChatIds = new Set<string>();
@@ -1389,6 +1397,8 @@ export class ServeServices {
             : await this.codex.startTurn(threadId, text, chat.worktreePath);
           const turnId = extractTurnId(turnResult);
           if (turnId) {
+            this.pendingTurnThreadsByTurnId.set(turnId, threadId);
+            this.attachPendingTurnEventsForTurn(threadId, turnId);
             this.activeTurnChatIds.add(chatId);
             nextStatus = "running";
             nextActiveTurnId = turnId;
@@ -1461,6 +1471,12 @@ export class ServeServices {
       }
       clearPendingChatTurn();
       if (pendingTurnThreadId) {
+        if (nextActiveTurnId) {
+          this.attachPendingTurnEventsForTurn(
+            pendingTurnThreadId,
+            nextActiveTurnId,
+          );
+        }
         await this.flushPendingTurnEvents(pendingTurnThreadId);
       }
 
@@ -1650,6 +1666,8 @@ export class ServeServices {
     this.loadedThreadIds.clear();
     this.approvalRequests.clear();
     this.pendingTurnEvents.clear();
+    this.pendingTurnEventsByTurnId.clear();
+    this.pendingTurnThreadsByTurnId.clear();
     this.pendingChatTurns.clear();
     this.activeTurnChatIds.clear();
 
@@ -1688,12 +1706,12 @@ export class ServeServices {
 
   private async handleCodexNotification(message: CodexMessage): Promise<void> {
     const threadId = extractThreadIdFromParams(message.params);
+    const pendingEvent = this.createPendingTurnEvent("notification", message);
+    if (threadId && this.bufferPendingTurnEvent(threadId, pendingEvent)) {
+      return;
+    }
     if (
-      threadId &&
-      this.bufferPendingTurnEvent(threadId, {
-        kind: "notification",
-        message,
-      })
+      await this.bufferPendingTurnEventByTurnId(message.params, pendingEvent)
     ) {
       return;
     }
@@ -1731,10 +1749,10 @@ export class ServeServices {
     const threadId = extractThreadIdFromParams(message.params);
     if (
       threadId &&
-      this.bufferPendingTurnEvent(threadId, {
-        kind: "serverRequest",
-        message,
-      })
+      this.bufferPendingTurnEvent(
+        threadId,
+        this.createPendingTurnEvent("serverRequest", message),
+      )
     ) {
       return;
     }
@@ -2021,9 +2039,11 @@ export class ServeServices {
     const pendingTurnEvents = this.pendingTurnEvents.get(threadId);
     if (!pendingTurnEvents || pendingTurnEvents.discard) {
       this.pendingTurnEvents.delete(threadId);
+      this.deletePendingTurnThreadMappings(threadId);
       return;
     }
     pendingTurnEvents.flushing = true;
+    pendingTurnEvents.events.sort((a, b) => a.order - b.order);
     while (!pendingTurnEvents.discard && pendingTurnEvents.events.length > 0) {
       const pendingEvent = pendingTurnEvents.events.shift();
       if (!pendingEvent) {
@@ -2038,7 +2058,19 @@ export class ServeServices {
     pendingTurnEvents.flushing = false;
     if (this.pendingTurnEvents.get(threadId) === pendingTurnEvents) {
       this.pendingTurnEvents.delete(threadId);
+      this.deletePendingTurnThreadMappings(threadId);
     }
+  }
+
+  private createPendingTurnEvent(
+    kind: PendingTurnEvent["kind"],
+    message: CodexMessage,
+  ): PendingTurnEvent {
+    return {
+      kind,
+      message,
+      order: this.pendingTurnEventOrder++,
+    };
   }
 
   private bufferPendingTurnEvent(
@@ -2062,6 +2094,77 @@ export class ServeServices {
     return true;
   }
 
+  private async bufferPendingTurnEventByTurnId(
+    params: unknown,
+    event: PendingTurnEvent,
+  ): Promise<boolean> {
+    const turnId = extractTurnIdFromParams(params);
+    if (!turnId) {
+      return false;
+    }
+
+    const threadId = this.pendingTurnThreadsByTurnId.get(turnId);
+    if (threadId) {
+      return this.bufferPendingTurnEvent(threadId, event);
+    }
+
+    if (!this.hasPendingTurnStartup()) {
+      return false;
+    }
+
+    const state = await this.store.load();
+    if (state.chats.some((chat) => chat.activeTurnId === turnId)) {
+      return false;
+    }
+
+    const existingEvents = this.pendingTurnEventsByTurnId.get(turnId);
+    if (existingEvents) {
+      existingEvents.push(event);
+      return true;
+    }
+
+    const events = [event];
+    this.pendingTurnEventsByTurnId.set(turnId, events);
+    const cleanup = setTimeout(() => {
+      if (this.pendingTurnEventsByTurnId.get(turnId) === events) {
+        this.pendingTurnEventsByTurnId.delete(turnId);
+      }
+    }, 30000);
+    cleanup.unref?.();
+    return true;
+  }
+
+  private hasPendingTurnStartup(): boolean {
+    for (const pendingTurnEvents of this.pendingTurnEvents.values()) {
+      if (!pendingTurnEvents.discard) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private attachPendingTurnEventsForTurn(
+    threadId: string,
+    turnId: string,
+  ): void {
+    const events = this.pendingTurnEventsByTurnId.get(turnId);
+    if (!events) {
+      return;
+    }
+    this.pendingTurnEventsByTurnId.delete(turnId);
+    for (const event of events) {
+      this.bufferPendingTurnEvent(threadId, event);
+    }
+  }
+
+  private deletePendingTurnThreadMappings(threadId: string): void {
+    for (const [turnId, mappedThreadId] of this.pendingTurnThreadsByTurnId) {
+      if (mappedThreadId === threadId) {
+        this.pendingTurnThreadsByTurnId.delete(turnId);
+      }
+    }
+  }
+
   private discardPendingTurnEvents(threadId: string): void {
     const pendingTurnEvents = this.pendingTurnEvents.get(threadId);
     if (!pendingTurnEvents) {
@@ -2078,6 +2181,7 @@ export class ServeServices {
       }
     }
     pendingTurnEvents.discard = true;
+    this.deletePendingTurnThreadMappings(threadId);
     pendingTurnEvents.events = [];
     const cleanup = setTimeout(() => {
       if (this.pendingTurnEvents.get(threadId) === pendingTurnEvents) {

--- a/packages/server/src/services.ts
+++ b/packages/server/src/services.ts
@@ -2329,13 +2329,22 @@ export class ServeServices {
       method === "command/exec/outputDelta"
     ) {
       const delta = extractCommandOutputDelta(method, params);
+      const eventData = createCommandOutputEventData(method, params);
       if (!delta) {
+        if (hasCommandOutputMetadataUpdate(method, params)) {
+          await this.mergeRichEventMessage({
+            chatId,
+            eventData,
+            eventType: method,
+            itemId: getCommandOutputItemId(method, params),
+          });
+        }
         return;
       }
       await this.appendRichEventMessage({
         chatId,
         delta,
-        eventData: createCommandOutputEventData(method, params),
+        eventData,
         eventType: method,
         itemId: getCommandOutputItemId(method, params),
       });
@@ -3979,6 +3988,17 @@ function createCommandOutputEventData(
     };
   }
   return { kind: "commandExecutionOutput" };
+}
+
+function hasCommandOutputMetadataUpdate(
+  method: string,
+  params: unknown,
+): boolean {
+  return (
+    method === "command/exec/outputDelta" &&
+    isRecord(params) &&
+    params.capReached === true
+  );
 }
 
 function createCommandLifecycleEventData(

--- a/packages/server/src/services.ts
+++ b/packages/server/src/services.ts
@@ -2267,6 +2267,123 @@ export class ServeServices {
       return;
     }
 
+    if (method === "turn/plan/updated") {
+      const eventData = normalizePlanEventData(params);
+      await this.upsertRichEventMessage({
+        chatId,
+        eventData,
+        eventType: method,
+        itemId: extractTurnIdFromParams(params) ?? method,
+        text: summarizeCodexEvent(method, params),
+      });
+      return;
+    }
+
+    if (method === "item/plan/delta") {
+      const delta = getRecordString(params, "delta") ?? "";
+      if (!delta) {
+        return;
+      }
+      await this.appendRichEventMessage({
+        chatId,
+        delta,
+        eventData: { kind: "planDelta" },
+        eventType: method,
+        itemId: getRecordString(params, "itemId") ?? method,
+      });
+      return;
+    }
+
+    if (method === "turn/diff/updated") {
+      const eventData = normalizeDiffEventData(params);
+      await this.upsertRichEventMessage({
+        chatId,
+        eventData,
+        eventType: method,
+        itemId: extractTurnIdFromParams(params) ?? method,
+        text: summarizeDiffEvent(eventData),
+      });
+      return;
+    }
+
+    if (
+      method === "item/commandExecution/outputDelta" ||
+      method === "command/exec/outputDelta"
+    ) {
+      const delta = extractCommandOutputDelta(method, params);
+      if (!delta) {
+        return;
+      }
+      await this.appendRichEventMessage({
+        chatId,
+        delta,
+        eventData: createCommandOutputEventData(method, params),
+        eventType: method,
+        itemId: getCommandOutputItemId(method, params),
+      });
+      return;
+    }
+
+    if (method === "item/fileChange/patchUpdated") {
+      const eventData = normalizeFilePatchEventData(params);
+      await this.upsertRichEventMessage({
+        chatId,
+        eventData,
+        eventType: method,
+        itemId: getRecordString(params, "itemId") ?? method,
+        text: summarizeFilePatchEvent(eventData),
+      });
+      return;
+    }
+
+    if (method === "item/fileChange/outputDelta") {
+      const delta = getRecordString(params, "delta") ?? "";
+      if (!delta) {
+        return;
+      }
+      await this.appendRichEventMessage({
+        chatId,
+        delta,
+        eventData: { kind: "fileChangeOutput" },
+        eventType: method,
+        itemId: getRecordString(params, "itemId") ?? method,
+      });
+      return;
+    }
+
+    if (method.startsWith("item/reasoning/")) {
+      const eventData = createReasoningEventData(method, params);
+      const delta =
+        method === "item/reasoning/summaryPartAdded"
+          ? "Reasoning summary added"
+          : (getRecordString(params, "delta") ?? "");
+      if (!delta) {
+        return;
+      }
+      await this.appendRichEventMessage({
+        chatId,
+        delta,
+        eventData,
+        eventType: method,
+        itemId: getReasoningEventItemId(method, params),
+      });
+      return;
+    }
+
+    if (
+      method === "warning" ||
+      method === "guardianWarning" ||
+      method === "configWarning"
+    ) {
+      await this.addRichEventMessage({
+        chatId,
+        eventData: params,
+        eventType: method,
+        text: summarizeCodexEvent(method, params),
+      });
+      return;
+    }
+
     if (
       method === "item/started" ||
       method === "item/completed" ||
@@ -2287,6 +2404,119 @@ export class ServeServices {
         ],
       }));
     }
+  }
+
+  private async addRichEventMessage({
+    chatId,
+    eventData,
+    eventType,
+    itemId,
+    text,
+  }: {
+    chatId: string;
+    eventData: unknown;
+    eventType: string;
+    itemId?: string;
+    text: string;
+  }): Promise<void> {
+    await this.store.update((state) => ({
+      ...state,
+      messages: [
+        ...state.messages,
+        createMessage(chatId, "event", text, eventType, itemId, eventData),
+      ],
+    }));
+  }
+
+  private async upsertRichEventMessage({
+    chatId,
+    eventData,
+    eventType,
+    itemId,
+    text,
+  }: {
+    chatId: string;
+    eventData: unknown;
+    eventType: string;
+    itemId: string;
+    text: string;
+  }): Promise<void> {
+    await this.store.update((state) => {
+      const existingMessage = state.messages.find(
+        (message) =>
+          message.chatId === chatId &&
+          message.role === "event" &&
+          message.eventType === eventType &&
+          message.itemId === itemId,
+      );
+      if (!existingMessage) {
+        return {
+          ...state,
+          messages: [
+            ...state.messages,
+            createMessage(chatId, "event", text, eventType, itemId, eventData),
+          ],
+        };
+      }
+      return {
+        ...state,
+        messages: state.messages.map((message) =>
+          message.id === existingMessage.id
+            ? { ...message, eventData, text }
+            : message,
+        ),
+      };
+    });
+  }
+
+  private async appendRichEventMessage({
+    chatId,
+    delta,
+    eventData,
+    eventType,
+    itemId,
+  }: {
+    chatId: string;
+    delta: string;
+    eventData: Record<string, unknown>;
+    eventType: string;
+    itemId: string;
+  }): Promise<void> {
+    await this.store.update((state) => {
+      const existingMessage = state.messages.find(
+        (message) =>
+          message.chatId === chatId &&
+          message.role === "event" &&
+          message.eventType === eventType &&
+          message.itemId === itemId,
+      );
+      const text = `${existingMessage?.text ?? ""}${delta}`;
+      const nextEventData = { ...eventData, text };
+      if (!existingMessage) {
+        return {
+          ...state,
+          messages: [
+            ...state.messages,
+            createMessage(
+              chatId,
+              "event",
+              text,
+              eventType,
+              itemId,
+              nextEventData,
+            ),
+          ],
+        };
+      }
+      return {
+        ...state,
+        messages: state.messages.map((message) =>
+          message.id === existingMessage.id
+            ? { ...message, eventData: nextEventData, text }
+            : message,
+        ),
+      };
+    });
   }
 
   private requireProject(state: ServeState, projectId: string): ProjectRecord {
@@ -2314,8 +2544,9 @@ function createMessage(
   text: string,
   eventType?: string,
   itemId?: string,
+  eventData?: unknown,
 ): ChatMessageRecord {
-  return {
+  const message: ChatMessageRecord = {
     id: createRecordId("msg"),
     chatId,
     role,
@@ -2324,6 +2555,7 @@ function createMessage(
     itemId,
     createdAt: createTimestamp(),
   };
+  return eventData === undefined ? message : { ...message, eventData };
 }
 
 function createQueuedMessage(
@@ -3532,6 +3764,177 @@ function normalizeFileRecords(value: unknown): CodexFileRecord[] {
     .filter((file): file is CodexFileRecord => Boolean(file));
 }
 
+interface RichPlanStep {
+  status: "completed" | "inProgress" | "pending";
+  step: string;
+}
+
+interface PlanEventData {
+  explanation: string | null;
+  plan: RichPlanStep[];
+}
+
+interface DiffEventData {
+  diff: string;
+  files: string[];
+}
+
+interface FilePatchEventData {
+  changes: Array<{
+    diff: string;
+    kind: string;
+    path: string;
+  }>;
+}
+
+function normalizePlanEventData(params: unknown): PlanEventData {
+  const explanation = getRecordString(params, "explanation") ?? null;
+  const plan = (getRecordArray(params, "plan") ?? [])
+    .map((step) => {
+      const text = getRecordString(step, "step");
+      const status = getRecordString(step, "status");
+      if (
+        !text ||
+        (status !== "pending" &&
+          status !== "inProgress" &&
+          status !== "completed")
+      ) {
+        return null;
+      }
+      return { step: text, status };
+    })
+    .filter((step): step is RichPlanStep => Boolean(step));
+  return { explanation, plan };
+}
+
+function normalizeDiffEventData(params: unknown): DiffEventData {
+  const diff = getRecordString(params, "diff") ?? "";
+  return {
+    diff,
+    files: extractDiffFilePaths(diff),
+  };
+}
+
+function normalizeFilePatchEventData(params: unknown): FilePatchEventData {
+  const changes = (getRecordArray(params, "changes") ?? [])
+    .map((change) => {
+      const path = getRecordString(change, "path");
+      if (!path) {
+        return null;
+      }
+      return {
+        path,
+        kind: getRecordString(change, "kind") ?? "update",
+        diff: getRecordString(change, "diff") ?? "",
+      };
+    })
+    .filter((change): change is FilePatchEventData["changes"][number] =>
+      Boolean(change),
+    );
+  return { changes };
+}
+
+function summarizeDiffEvent(eventData: DiffEventData): string {
+  if (eventData.files.length === 0) {
+    return eventData.diff ? "Diff updated" : "Diff cleared";
+  }
+  return `Diff updated: ${eventData.files.length} file${
+    eventData.files.length === 1 ? "" : "s"
+  }`;
+}
+
+function summarizeFilePatchEvent(eventData: FilePatchEventData): string {
+  if (eventData.changes.length === 0) {
+    return "File patch updated";
+  }
+  return `File patch updated: ${eventData.changes.length} file${
+    eventData.changes.length === 1 ? "" : "s"
+  }`;
+}
+
+function extractCommandOutputDelta(method: string, params: unknown): string {
+  if (method === "command/exec/outputDelta") {
+    const encoded = getRecordString(params, "deltaBase64");
+    return encoded ? Buffer.from(encoded, "base64").toString("utf8") : "";
+  }
+  return getRecordString(params, "delta") ?? "";
+}
+
+function createCommandOutputEventData(
+  method: string,
+  params: unknown,
+): Record<string, unknown> {
+  if (method === "command/exec/outputDelta") {
+    return {
+      kind: "commandExecOutput",
+      processId: getRecordString(params, "processId") ?? null,
+      stream: getRecordString(params, "stream") ?? "stdout",
+      capReached: Boolean(isRecord(params) && params.capReached === true),
+    };
+  }
+  return { kind: "commandExecutionOutput" };
+}
+
+function getCommandOutputItemId(method: string, params: unknown): string {
+  if (method === "command/exec/outputDelta") {
+    const processId = getRecordString(params, "processId") ?? "process";
+    const stream = getRecordString(params, "stream") ?? "stdout";
+    return `${processId}:${stream}`;
+  }
+  return getRecordString(params, "itemId") ?? method;
+}
+
+function createReasoningEventData(
+  method: string,
+  params: unknown,
+): Record<string, unknown> {
+  if (method === "item/reasoning/summaryTextDelta") {
+    return {
+      kind: "summaryText",
+      summaryIndex: getRecordNumber(params, "summaryIndex") ?? null,
+    };
+  }
+  if (method === "item/reasoning/summaryPartAdded") {
+    return {
+      kind: "summaryPart",
+      summaryIndex: getRecordNumber(params, "summaryIndex") ?? null,
+    };
+  }
+  return {
+    kind: "text",
+    contentIndex: getRecordNumber(params, "contentIndex") ?? null,
+  };
+}
+
+function getReasoningEventItemId(method: string, params: unknown): string {
+  const itemId = getRecordString(params, "itemId") ?? "reasoning";
+  if (method === "item/reasoning/summaryTextDelta") {
+    return `${itemId}:summary:${getRecordNumber(params, "summaryIndex") ?? 0}`;
+  }
+  if (method === "item/reasoning/summaryPartAdded") {
+    return `${itemId}:summary-part:${
+      getRecordNumber(params, "summaryIndex") ?? 0
+    }`;
+  }
+  return `${itemId}:text:${getRecordNumber(params, "contentIndex") ?? 0}`;
+}
+
+function extractDiffFilePaths(diff: string): string[] {
+  const files = new Set<string>();
+  for (const line of diff.split(/\r?\n/)) {
+    const diffMatch = /^diff --git a\/(.+) b\/(.+)$/.exec(line);
+    if (diffMatch?.[2]) {
+      files.add(diffMatch[2]);
+      continue;
+    }
+    const nextFileMatch = /^\+\+\+ b\/(.+)$/.exec(line);
+    if (nextFileMatch?.[1]) {
+      files.add(nextFileMatch[1]);
+    }
+  }
+  return [...files];
+}
+
 function getReasoningEfforts(model: Record<string, unknown>): string[] {
   const supported = model.supportedReasoningEfforts;
   if (!Array.isArray(supported)) {
@@ -3577,6 +3980,16 @@ function getRecordString(value: unknown, key: string): string | undefined {
   }
   const candidate = value[key];
   return typeof candidate === "string" ? candidate : undefined;
+}
+
+function getRecordNumber(value: unknown, key: string): number | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const candidate = value[key];
+  return typeof candidate === "number" && Number.isFinite(candidate)
+    ? candidate
+    : undefined;
 }
 
 function getStringArray(value: unknown): string[] {

--- a/packages/server/src/services.ts
+++ b/packages/server/src/services.ts
@@ -1702,8 +1702,7 @@ export class ServeServices {
 
   private async processCodexNotification(message: CodexMessage): Promise<void> {
     const method = message.method ?? "unknown";
-    const threadId = extractThreadIdFromParams(message.params);
-    const chat = threadId ? await this.findChatByThreadId(threadId) : null;
+    const chat = await this.findChatByCodexParams(message.params);
     const eventType = mapCodexMethodToEvent(method);
 
     if (chat) {
@@ -2095,6 +2094,25 @@ export class ServeServices {
     return state.chats.find((chat) => chat.codexThreadId === threadId) ?? null;
   }
 
+  private async findChatByCodexParams(
+    params: unknown,
+  ): Promise<ChatRecord | null> {
+    const threadId = extractThreadIdFromParams(params);
+    if (threadId) {
+      const chat = await this.findChatByThreadId(threadId);
+      if (chat) {
+        return chat;
+      }
+    }
+
+    const turnId = extractTurnIdFromParams(params);
+    if (!turnId) {
+      return null;
+    }
+    const state = await this.store.load();
+    return state.chats.find((chat) => chat.activeTurnId === turnId) ?? null;
+  }
+
   private async applyCodexStateChange(
     chatId: string,
     method: string,
@@ -2381,6 +2399,37 @@ export class ServeServices {
       return;
     }
 
+    if (method === "item/started" || method === "item/completed") {
+      const item = getRecordObject(params, "item");
+      const itemId = getRecordString(item, "id");
+      const itemType = getRecordString(item, "type");
+      if (item && itemId && itemType === "commandExecution") {
+        await this.mergeRichEventMessage({
+          chatId,
+          eventData: createCommandLifecycleEventData(method, item),
+          eventType: "item/commandExecution/outputDelta",
+          itemId,
+          text: getRecordString(item, "aggregatedOutput"),
+        });
+        return;
+      }
+      if (item && itemId && itemType === "fileChange") {
+        const eventData = normalizeFilePatchEventData(item);
+        await this.upsertRichEventMessage({
+          chatId,
+          eventData: {
+            ...eventData,
+            lifecycleEventType: method,
+            status: getRecordString(item, "status") ?? null,
+          },
+          eventType: "item/fileChange/patchUpdated",
+          itemId,
+          text: summarizeFilePatchEvent(eventData),
+        });
+        return;
+      }
+    }
+
     if (
       method === "item/started" ||
       method === "item/completed" ||
@@ -2488,7 +2537,10 @@ export class ServeServices {
           message.itemId === itemId,
       );
       const text = `${existingMessage?.text ?? ""}${delta}`;
-      const nextEventData = { ...eventData, text };
+      const existingEventData = isRecord(existingMessage?.eventData)
+        ? existingMessage.eventData
+        : {};
+      const nextEventData = { ...existingEventData, ...eventData, text };
       if (!existingMessage) {
         return {
           ...state,
@@ -2510,6 +2562,63 @@ export class ServeServices {
         messages: state.messages.map((message) =>
           message.id === existingMessage.id
             ? { ...message, eventData: nextEventData, text }
+            : message,
+        ),
+      };
+    });
+  }
+
+  private async mergeRichEventMessage({
+    chatId,
+    eventData,
+    eventType,
+    itemId,
+    text,
+  }: {
+    chatId: string;
+    eventData: Record<string, unknown>;
+    eventType: string;
+    itemId: string;
+    text?: string;
+  }): Promise<void> {
+    await this.store.update((state) => {
+      const existingMessage = state.messages.find(
+        (message) =>
+          message.chatId === chatId &&
+          message.role === "event" &&
+          message.eventType === eventType &&
+          message.itemId === itemId,
+      );
+      const existingEventData = isRecord(existingMessage?.eventData)
+        ? existingMessage.eventData
+        : {};
+      const nextText = text ?? existingMessage?.text ?? "";
+      const nextEventData = {
+        ...existingEventData,
+        ...eventData,
+        text: nextText,
+      };
+      if (!existingMessage) {
+        return {
+          ...state,
+          messages: [
+            ...state.messages,
+            createMessage(
+              chatId,
+              "event",
+              nextText,
+              eventType,
+              itemId,
+              nextEventData,
+            ),
+          ],
+        };
+      }
+      return {
+        ...state,
+        messages: state.messages.map((message) =>
+          message.id === existingMessage.id
+            ? { ...message, eventData: nextEventData, text: nextText }
             : message,
         ),
       };
@@ -3870,6 +3979,23 @@ function createCommandOutputEventData(
     };
   }
   return { kind: "commandExecutionOutput" };
+}
+
+function createCommandLifecycleEventData(
+  method: string,
+  item: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    kind: "commandExecution",
+    lifecycleEventType: method,
+    command: getRecordString(item, "command") ?? null,
+    cwd: getRecordString(item, "cwd") ?? null,
+    processId: getRecordString(item, "processId") ?? null,
+    source: getRecordString(item, "source") ?? null,
+    status: getRecordString(item, "status") ?? null,
+    exitCode: getRecordNumber(item, "exitCode") ?? null,
+    durationMs: getRecordNumber(item, "durationMs") ?? null,
+  };
 }
 
 function getCommandOutputItemId(method: string, params: unknown): string {

--- a/packages/state/src/types.ts
+++ b/packages/state/src/types.ts
@@ -23,6 +23,7 @@ const chatMessageRecordBaseSchema = z.object({
   role: z.enum(["user", "assistant", "event", "error"]),
   text: z.string(),
   eventType: z.string().optional(),
+  eventData: z.unknown().optional(),
   itemId: z.string().optional(),
   createdAt: z.string(),
 });

--- a/packages/web/src/routes/home.tsx
+++ b/packages/web/src/routes/home.tsx
@@ -2,14 +2,18 @@ import {
   AlertTriangle,
   Bot,
   Brain,
+  CheckCircle2,
   ChevronRight,
+  Circle,
   CircleDot,
   Clock3,
+  FileDiff,
   FileText,
   FolderGit2,
   GitBranch,
   GitPullRequest,
   Inbox,
+  ListChecks,
   MessageSquare,
   MessageSquarePlus,
   MoreHorizontal,
@@ -19,6 +23,7 @@ import {
   Send,
   Sparkles,
   Square,
+  Terminal,
   Trash2,
   X,
 } from "lucide-react";
@@ -126,6 +131,16 @@ import {
   retainRecordsForProjects,
   resolveRefreshedWorktreeChatId,
 } from "./home-url-state";
+import {
+  getCommandEventMeta,
+  getDiffEventData,
+  getFilePatchEventData,
+  getPlanEventData,
+  getRichEventKind,
+  getRichEventText,
+  getWarningEventText,
+  isRichEventMessage,
+} from "./rich-events";
 import type {
   ChatMessageRecord,
   ChatRecord,
@@ -148,6 +163,12 @@ const chatEventNames = [
   "chat.message.deleted",
   "agent.thread.started",
   "agent.turn.started",
+  "agent.plan.updated",
+  "agent.diff.updated",
+  "agent.command.output",
+  "agent.file.updated",
+  "agent.reasoning.updated",
+  "agent.warning",
   "agent.item.updated",
   "agent.item.delta",
   "agent.approval.requested",
@@ -225,7 +246,7 @@ interface RestoredPendingComposerContext {
 }
 
 type VisibleMessageRecord = ChatMessageRecord & {
-  role: "assistant" | "error" | "user";
+  role: "assistant" | "error" | "event" | "user";
 };
 
 interface StoredChatScrollPosition {
@@ -975,7 +996,8 @@ export function HomeRoute() {
   const visibleMessages = useMemo(
     () =>
       messages.filter(
-        (message): message is VisibleMessageRecord => message.role !== "event",
+        (message): message is VisibleMessageRecord =>
+          message.role !== "event" || isRichEventMessage(message),
       ),
     [messages],
   );
@@ -3614,6 +3636,10 @@ function MessageCard({
   onDeletePendingMessage: (message: VisibleMessageRecord) => void;
   onEditPendingMessage: (message: VisibleMessageRecord) => void;
 }) {
+  if (message.role === "event") {
+    return <RichEventCard message={message} />;
+  }
+
   const isUser = message.role === "user";
   const isError = message.role === "error";
   const deliveryState = getMessageDeliveryState(message);
@@ -3649,6 +3675,278 @@ function MessageCard({
         />
       )}
     </article>
+  );
+}
+
+function RichEventCard({ message }: { message: VisibleMessageRecord }) {
+  const kind = getRichEventKind(message);
+  if (kind === "plan") {
+    return <PlanEventCard message={message} />;
+  }
+  if (kind === "diff") {
+    return <DiffEventCard message={message} />;
+  }
+  if (kind === "command") {
+    return <CommandEventCard message={message} />;
+  }
+  if (kind === "file") {
+    return <FileEventCard message={message} />;
+  }
+  if (kind === "reasoning") {
+    return <ReasoningEventCard message={message} />;
+  }
+  if (kind === "warning") {
+    return <WarningEventCard message={message} />;
+  }
+  return null;
+}
+
+function PlanEventCard({ message }: { message: VisibleMessageRecord }) {
+  const { explanation, plan } = getPlanEventData(message);
+  const text = getRichEventText(message);
+  return (
+    <RichEventShell
+      icon={<ListChecks className="size-4" />}
+      meta={`${plan.length} step${plan.length === 1 ? "" : "s"}`}
+      title="Plan updated"
+    >
+      {explanation && (
+        <p className="text-[length:var(--font-size-sm)] text-muted-foreground">
+          {explanation}
+        </p>
+      )}
+      {plan.length > 0 && (
+        <ol className="mt-2 space-y-1">
+          {plan.map((step, index) => {
+            const Icon =
+              step.status === "completed"
+                ? CheckCircle2
+                : step.status === "inProgress"
+                  ? Clock3
+                  : Circle;
+            return (
+              <li
+                className="grid grid-cols-[1rem_minmax(0,1fr)] items-start gap-2 text-[length:var(--font-size-sm)]"
+                key={`${step.step}-${index}`}
+              >
+                <Icon
+                  className={cn(
+                    "mt-0.5 size-3.5",
+                    step.status === "completed" &&
+                      "text-[var(--semantic-success-fg)]",
+                    step.status === "inProgress" &&
+                      "text-[var(--semantic-info-fg)]",
+                    step.status === "pending" && "text-muted-foreground",
+                  )}
+                />
+                <span className="min-w-0 break-words">{step.step}</span>
+              </li>
+            );
+          })}
+        </ol>
+      )}
+      {!explanation && plan.length === 0 && text && (
+        <p className="whitespace-pre-wrap break-words text-[length:var(--font-size-sm)] text-muted-foreground">
+          {text}
+        </p>
+      )}
+    </RichEventShell>
+  );
+}
+
+function DiffEventCard({ message }: { message: VisibleMessageRecord }) {
+  const { diff, files } = getDiffEventData(message);
+  return (
+    <RichEventShell
+      icon={<FileDiff className="size-4" />}
+      meta={`${files.length} file${files.length === 1 ? "" : "s"}`}
+      title="Diff updated"
+    >
+      {files.length > 0 && (
+        <div className="mb-2 flex flex-wrap gap-1.5">
+          {files.slice(0, 6).map((file) => (
+            <span
+              className="max-w-full truncate rounded-[var(--radius-sm)] border border-[var(--border-subtle)] bg-[var(--surface-panel)] px-1.5 py-0.5 font-mono text-[length:var(--font-size-xs)] text-muted-foreground"
+              key={file}
+            >
+              {file}
+            </span>
+          ))}
+          {files.length > 6 && (
+            <span className="text-[length:var(--font-size-xs)] text-muted-foreground">
+              +{files.length - 6}
+            </span>
+          )}
+        </div>
+      )}
+      <CollapsibleCode title="Unified diff" value={diff || message.text} />
+    </RichEventShell>
+  );
+}
+
+function CommandEventCard({ message }: { message: VisibleMessageRecord }) {
+  const output = getRichEventText(message);
+  const meta = getCommandEventMeta(message);
+  return (
+    <RichEventShell
+      icon={<Terminal className="size-4" />}
+      meta={meta.stream ?? "output"}
+      title="Command output"
+    >
+      <CollapsibleCode
+        title={meta.capReached ? "Output truncated" : "Output"}
+        value={output}
+      />
+    </RichEventShell>
+  );
+}
+
+function FileEventCard({ message }: { message: VisibleMessageRecord }) {
+  const changes = getFilePatchEventData(message);
+  const output = getRichEventText(message);
+  if (message.eventType === "item/fileChange/outputDelta") {
+    return (
+      <RichEventShell
+        icon={<FileText className="size-4" />}
+        meta="output"
+        title="File change output"
+      >
+        <CollapsibleCode title="Output" value={output} />
+      </RichEventShell>
+    );
+  }
+  return (
+    <RichEventShell
+      icon={<FileText className="size-4" />}
+      meta={`${changes.length} file${changes.length === 1 ? "" : "s"}`}
+      title="File patch updated"
+    >
+      {changes.length === 0 ? (
+        <p className="text-[length:var(--font-size-sm)] text-muted-foreground">
+          {message.text}
+        </p>
+      ) : (
+        <div className="space-y-2">
+          {changes.map((change) => (
+            <div
+              className="rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--surface-panel)]"
+              key={`${change.kind}:${change.path}`}
+            >
+              <div className="flex min-w-0 items-center gap-2 px-2 py-1.5">
+                <Badge className="shrink-0" variant="secondary">
+                  {change.kind}
+                </Badge>
+                <span className="truncate font-mono text-[length:var(--font-size-xs)]">
+                  {change.path}
+                </span>
+              </div>
+              {change.diff && (
+                <div className="border-t border-[var(--border-subtle)]">
+                  <CollapsibleCode title="Patch" value={change.diff} />
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </RichEventShell>
+  );
+}
+
+function ReasoningEventCard({ message }: { message: VisibleMessageRecord }) {
+  const text = getRichEventText(message);
+  return (
+    <RichEventShell
+      icon={<Brain className="size-4" />}
+      meta="collapsed"
+      title="Reasoning updated"
+    >
+      <details>
+        <summary className="cursor-pointer text-[length:var(--font-size-sm)] text-muted-foreground">
+          Show reasoning
+        </summary>
+        <pre className="mt-2 whitespace-pre-wrap break-words rounded-[var(--radius-md)] bg-[var(--surface-code)] p-2 font-mono text-[length:var(--font-size-xs)] leading-[var(--line-height-relaxed)]">
+          {text}
+        </pre>
+      </details>
+    </RichEventShell>
+  );
+}
+
+function WarningEventCard({ message }: { message: VisibleMessageRecord }) {
+  const warning = getWarningEventText(message);
+  return (
+    <RichEventShell
+      icon={<AlertTriangle className="size-4" />}
+      tone="warning"
+      title="Warning"
+    >
+      <p className="text-[length:var(--font-size-sm)]">{warning.summary}</p>
+      {warning.details && (
+        <p className="mt-1 text-[length:var(--font-size-xs)] text-muted-foreground">
+          {warning.details}
+        </p>
+      )}
+    </RichEventShell>
+  );
+}
+
+function RichEventShell({
+  children,
+  icon,
+  meta,
+  title,
+  tone = "neutral",
+}: {
+  children: ReactNode;
+  icon: ReactNode;
+  meta?: string;
+  title: string;
+  tone?: "neutral" | "warning";
+}) {
+  return (
+    <article
+      className={cn(
+        "w-full rounded-[var(--radius-md)] border bg-[var(--surface-card)] px-3 py-2 text-[var(--text-primary)]",
+        tone === "neutral" && "border-[var(--border-subtle)]",
+        tone === "warning" &&
+          "border-[var(--semantic-warning-border)] bg-[var(--semantic-warning-bg)] text-[var(--semantic-warning-fg)]",
+      )}
+    >
+      <div className="mb-2 flex min-w-0 items-center gap-2">
+        <span className="shrink-0 text-muted-foreground">{icon}</span>
+        <p className="min-w-0 flex-1 truncate text-[length:var(--font-size-sm)] font-semibold">
+          {title}
+        </p>
+        {meta && (
+          <span className="shrink-0 text-[length:var(--font-size-xs)] text-muted-foreground">
+            {meta}
+          </span>
+        )}
+      </div>
+      {children}
+    </article>
+  );
+}
+
+function CollapsibleCode({ title, value }: { title: string; value: string }) {
+  const trimmedValue = value.trimEnd();
+  if (!trimmedValue) {
+    return (
+      <p className="text-[length:var(--font-size-sm)] text-muted-foreground">
+        No output
+      </p>
+    );
+  }
+  return (
+    <details open={trimmedValue.length < 1200}>
+      <summary className="cursor-pointer text-[length:var(--font-size-sm)] text-muted-foreground">
+        {title}
+      </summary>
+      <pre className="mt-2 max-h-72 overflow-auto whitespace-pre-wrap break-words rounded-[var(--radius-md)] bg-[var(--surface-code)] p-2 font-mono text-[length:var(--font-size-xs)] leading-[var(--line-height-relaxed)]">
+        {trimmedValue}
+      </pre>
+    </details>
   );
 }
 

--- a/packages/web/src/routes/home.tsx
+++ b/packages/web/src/routes/home.tsx
@@ -134,6 +134,7 @@ import {
 import {
   getCommandEventMeta,
   getDiffEventData,
+  getFileEventMeta,
   getFilePatchEventData,
   getPlanEventData,
   getRichEventKind,
@@ -3790,9 +3791,36 @@ function CommandEventCard({ message }: { message: VisibleMessageRecord }) {
   return (
     <RichEventShell
       icon={<Terminal className="size-4" />}
-      meta={meta.stream ?? "output"}
-      title="Command output"
+      meta={meta.status ?? meta.stream ?? "output"}
+      title={meta.command ? "Command execution" : "Command output"}
     >
+      {meta.command && (
+        <p
+          className="mb-2 min-w-0 break-words font-mono text-[length:var(--font-size-xs)] text-muted-foreground"
+          title={meta.cwd ?? undefined}
+        >
+          {meta.command}
+        </p>
+      )}
+      {(meta.status || meta.exitCode !== null || meta.durationMs !== null) && (
+        <div className="mb-2 flex flex-wrap gap-1.5">
+          {meta.status && (
+            <Badge variant={getStatusBadgeVariant(meta.status)}>
+              {meta.status}
+            </Badge>
+          )}
+          {meta.exitCode !== null && (
+            <Badge variant={meta.exitCode === 0 ? "success" : "danger"}>
+              exit {meta.exitCode}
+            </Badge>
+          )}
+          {meta.durationMs !== null && (
+            <Badge variant="secondary">
+              {formatDurationMs(meta.durationMs)}
+            </Badge>
+          )}
+        </div>
+      )}
       <CollapsibleCode
         title={meta.capReached ? "Output truncated" : "Output"}
         value={output}
@@ -3803,6 +3831,7 @@ function CommandEventCard({ message }: { message: VisibleMessageRecord }) {
 
 function FileEventCard({ message }: { message: VisibleMessageRecord }) {
   const changes = getFilePatchEventData(message);
+  const meta = getFileEventMeta(message);
   const output = getRichEventText(message);
   if (message.eventType === "item/fileChange/outputDelta") {
     return (
@@ -3818,9 +3847,22 @@ function FileEventCard({ message }: { message: VisibleMessageRecord }) {
   return (
     <RichEventShell
       icon={<FileText className="size-4" />}
-      meta={`${changes.length} file${changes.length === 1 ? "" : "s"}`}
+      meta={
+        meta.status ??
+        `${changes.length} file${changes.length === 1 ? "" : "s"}`
+      }
       title="File patch updated"
     >
+      {meta.status && (
+        <div className="mb-2 flex flex-wrap gap-1.5">
+          <Badge variant={getStatusBadgeVariant(meta.status)}>
+            {meta.status}
+          </Badge>
+          <Badge variant="secondary">
+            {changes.length} file{changes.length === 1 ? "" : "s"}
+          </Badge>
+        </div>
+      )}
       {changes.length === 0 ? (
         <p className="text-[length:var(--font-size-sm)] text-muted-foreground">
           {message.text}
@@ -3851,6 +3893,30 @@ function FileEventCard({ message }: { message: VisibleMessageRecord }) {
       )}
     </RichEventShell>
   );
+}
+
+function getStatusBadgeVariant(
+  status: string,
+): "danger" | "info" | "secondary" | "success" | "warning" {
+  if (status === "completed") {
+    return "success";
+  }
+  if (status === "failed") {
+    return "danger";
+  }
+  if (status === "declined") {
+    return "warning";
+  }
+  if (status === "inProgress") {
+    return "info";
+  }
+  return "secondary";
+}
+
+function formatDurationMs(durationMs: number): string {
+  return durationMs >= 1000
+    ? `${(durationMs / 1000).toFixed(1)}s`
+    : `${durationMs}ms`;
 }
 
 function ReasoningEventCard({ message }: { message: VisibleMessageRecord }) {

--- a/packages/web/src/routes/rich-events.test.ts
+++ b/packages/web/src/routes/rich-events.test.ts
@@ -35,6 +35,18 @@ describe("rich event helpers", () => {
       "plan",
     );
     strictEqual(
+      getRichEventKind(
+        createMessage({ eventType: "item/reasoning/summaryTextDelta" }),
+      ),
+      "reasoning",
+    );
+    strictEqual(
+      isRichEventMessage(
+        createMessage({ eventType: "item/reasoning/summaryPartAdded" }),
+      ),
+      false,
+    );
+    strictEqual(
       isRichEventMessage(createMessage({ eventType: "item/completed" })),
       false,
     );

--- a/packages/web/src/routes/rich-events.test.ts
+++ b/packages/web/src/routes/rich-events.test.ts
@@ -1,7 +1,9 @@
 import { deepStrictEqual, strictEqual } from "node:assert";
 import { describe, it } from "vitest";
 import {
+  getCommandEventMeta,
   getDiffEventData,
+  getFileEventMeta,
   getPlanEventData,
   getRichEventKind,
   getRichEventText,
@@ -101,6 +103,42 @@ describe("rich event helpers", () => {
         }),
       ),
       "hello\nworld\n",
+    );
+  });
+
+  it("returns lifecycle metadata for command and file events", () => {
+    deepStrictEqual(
+      getCommandEventMeta(
+        createMessage({
+          eventType: "item/commandExecution/outputDelta",
+          eventData: {
+            command: "pnpm test",
+            cwd: "/repo",
+            durationMs: 42,
+            exitCode: 0,
+            status: "completed",
+            text: "",
+          },
+        }),
+      ),
+      {
+        capReached: false,
+        command: "pnpm test",
+        cwd: "/repo",
+        durationMs: 42,
+        exitCode: 0,
+        status: "completed",
+        stream: null,
+      },
+    );
+    deepStrictEqual(
+      getFileEventMeta(
+        createMessage({
+          eventType: "item/fileChange/patchUpdated",
+          eventData: { changes: [], status: "failed" },
+        }),
+      ),
+      { status: "failed" },
     );
   });
 });

--- a/packages/web/src/routes/rich-events.test.ts
+++ b/packages/web/src/routes/rich-events.test.ts
@@ -1,0 +1,94 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "vitest";
+import {
+  getDiffEventData,
+  getPlanEventData,
+  getRichEventKind,
+  getRichEventText,
+  isRichEventMessage,
+} from "./rich-events";
+import type { ChatMessageRecord } from "@phantompane/server";
+
+function createMessage(
+  overrides: Partial<ChatMessageRecord> = {},
+): ChatMessageRecord {
+  return {
+    id: "msg_1",
+    chatId: "chat_1",
+    role: "event",
+    text: "event",
+    createdAt: "2026-04-25T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("rich event helpers", () => {
+  it("recognizes renderable Codex rich events", () => {
+    strictEqual(
+      getRichEventKind(
+        createMessage({ eventType: "item/commandExecution/outputDelta" }),
+      ),
+      "command",
+    );
+    strictEqual(
+      getRichEventKind(createMessage({ eventType: "item/plan/delta" })),
+      "plan",
+    );
+    strictEqual(
+      isRichEventMessage(createMessage({ eventType: "item/completed" })),
+      false,
+    );
+  });
+
+  it("normalizes plan event payloads", () => {
+    const data = getPlanEventData(
+      createMessage({
+        eventType: "turn/plan/updated",
+        eventData: {
+          explanation: "working",
+          plan: [
+            { step: "Read code", status: "completed" },
+            { step: "Patch UI", status: "inProgress" },
+            { step: "", status: "pending" },
+          ],
+        },
+      }),
+    );
+
+    deepStrictEqual(data, {
+      explanation: "working",
+      plan: [
+        { step: "Read code", status: "completed" },
+        { step: "Patch UI", status: "inProgress" },
+      ],
+    });
+  });
+
+  it("returns diff files and appended stream text", () => {
+    deepStrictEqual(
+      getDiffEventData(
+        createMessage({
+          eventType: "turn/diff/updated",
+          eventData: {
+            diff: "diff --git a/a.ts b/a.ts",
+            files: ["a.ts"],
+          },
+        }),
+      ),
+      {
+        diff: "diff --git a/a.ts b/a.ts",
+        files: ["a.ts"],
+      },
+    );
+    strictEqual(
+      getRichEventText(
+        createMessage({
+          eventType: "item/commandExecution/outputDelta",
+          text: "fallback",
+          eventData: { text: "hello\nworld\n" },
+        }),
+      ),
+      "hello\nworld\n",
+    );
+  });
+});

--- a/packages/web/src/routes/rich-events.ts
+++ b/packages/web/src/routes/rich-events.ts
@@ -1,0 +1,187 @@
+import type { ChatMessageRecord } from "@phantompane/server";
+
+export type RichEventKind =
+  | "command"
+  | "diff"
+  | "file"
+  | "plan"
+  | "reasoning"
+  | "warning";
+
+export interface RichPlanStep {
+  status: "completed" | "inProgress" | "pending";
+  step: string;
+}
+
+export interface RichFileChange {
+  diff: string;
+  kind: string;
+  path: string;
+}
+
+export function getRichEventKind(
+  message: Pick<ChatMessageRecord, "eventType" | "role">,
+): RichEventKind | null {
+  if (message.role !== "event") {
+    return null;
+  }
+  if (
+    message.eventType === "turn/plan/updated" ||
+    message.eventType === "item/plan/delta"
+  ) {
+    return "plan";
+  }
+  if (message.eventType === "turn/diff/updated") {
+    return "diff";
+  }
+  if (
+    message.eventType === "item/commandExecution/outputDelta" ||
+    message.eventType === "command/exec/outputDelta"
+  ) {
+    return "command";
+  }
+  if (
+    message.eventType === "item/fileChange/patchUpdated" ||
+    message.eventType === "item/fileChange/outputDelta"
+  ) {
+    return "file";
+  }
+  if (message.eventType?.startsWith("item/reasoning/")) {
+    return "reasoning";
+  }
+  if (
+    message.eventType === "warning" ||
+    message.eventType === "guardianWarning" ||
+    message.eventType === "configWarning"
+  ) {
+    return "warning";
+  }
+  return null;
+}
+
+export function isRichEventMessage(
+  message: Pick<ChatMessageRecord, "eventType" | "role">,
+): boolean {
+  return getRichEventKind(message) !== null;
+}
+
+export function getPlanEventData(message: ChatMessageRecord): {
+  explanation: string | null;
+  plan: RichPlanStep[];
+} {
+  const eventData = getEventDataObject(message);
+  const explanation = getString(eventData, "explanation") ?? null;
+  const plan = getObjectArray(eventData, "plan")
+    .map((step) => {
+      const text = getString(step, "step");
+      const status = getString(step, "status");
+      if (
+        !text ||
+        (status !== "completed" &&
+          status !== "inProgress" &&
+          status !== "pending")
+      ) {
+        return null;
+      }
+      return { step: text, status };
+    })
+    .filter((step): step is RichPlanStep => Boolean(step));
+  return { explanation, plan };
+}
+
+export function getDiffEventData(message: ChatMessageRecord): {
+  diff: string;
+  files: string[];
+} {
+  const eventData = getEventDataObject(message);
+  const diff = getString(eventData, "diff") ?? message.text;
+  return {
+    diff,
+    files: getStringArray(eventData, "files").filter(Boolean),
+  };
+}
+
+export function getFilePatchEventData(
+  message: ChatMessageRecord,
+): RichFileChange[] {
+  const eventData = getEventDataObject(message);
+  return getObjectArray(eventData, "changes")
+    .map((change) => {
+      const path = getString(change, "path");
+      if (!path) {
+        return null;
+      }
+      return {
+        path,
+        kind: getString(change, "kind") ?? "update",
+        diff: getString(change, "diff") ?? "",
+      };
+    })
+    .filter((change): change is RichFileChange => Boolean(change));
+}
+
+export function getRichEventText(message: ChatMessageRecord): string {
+  return getString(getEventDataObject(message), "text") ?? message.text;
+}
+
+export function getWarningEventText(message: ChatMessageRecord): {
+  details: string | null;
+  summary: string;
+} {
+  const eventData = getEventDataObject(message);
+  const summary =
+    getString(eventData, "message") ??
+    getString(eventData, "summary") ??
+    message.text;
+  return {
+    summary,
+    details: getString(eventData, "details") ?? null,
+  };
+}
+
+export function getCommandEventMeta(message: ChatMessageRecord): {
+  capReached: boolean;
+  stream: string | null;
+} {
+  const eventData = getEventDataObject(message);
+  return {
+    capReached: eventData?.capReached === true,
+    stream: getString(eventData, "stream") ?? null,
+  };
+}
+
+function getEventDataObject(
+  message: ChatMessageRecord,
+): Record<string, unknown> | null {
+  return isRecord(message.eventData) ? message.eventData : null;
+}
+
+function getObjectArray(
+  value: Record<string, unknown> | null,
+  key: string,
+): Array<Record<string, unknown>> {
+  const candidate = value?.[key];
+  return Array.isArray(candidate) ? candidate.filter(isRecord) : [];
+}
+
+function getString(
+  value: Record<string, unknown> | null,
+  key: string,
+): string | undefined {
+  const candidate = value?.[key];
+  return typeof candidate === "string" ? candidate : undefined;
+}
+
+function getStringArray(
+  value: Record<string, unknown> | null,
+  key: string,
+): string[] {
+  const candidate = value?.[key];
+  return Array.isArray(candidate)
+    ? candidate.filter((item): item is string => typeof item === "string")
+    : [];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}

--- a/packages/web/src/routes/rich-events.ts
+++ b/packages/web/src/routes/rich-events.ts
@@ -46,7 +46,10 @@ export function getRichEventKind(
   ) {
     return "file";
   }
-  if (message.eventType?.startsWith("item/reasoning/")) {
+  if (
+    message.eventType?.startsWith("item/reasoning/") &&
+    message.eventType !== "item/reasoning/summaryPartAdded"
+  ) {
     return "reasoning";
   }
   if (

--- a/packages/web/src/routes/rich-events.ts
+++ b/packages/web/src/routes/rich-events.ts
@@ -144,12 +144,31 @@ export function getWarningEventText(message: ChatMessageRecord): {
 
 export function getCommandEventMeta(message: ChatMessageRecord): {
   capReached: boolean;
+  command: string | null;
+  cwd: string | null;
+  durationMs: number | null;
+  exitCode: number | null;
   stream: string | null;
+  status: string | null;
 } {
   const eventData = getEventDataObject(message);
   return {
     capReached: eventData?.capReached === true,
+    command: getString(eventData, "command") ?? null,
+    cwd: getString(eventData, "cwd") ?? null,
+    durationMs: getNumber(eventData, "durationMs") ?? null,
+    exitCode: getNumber(eventData, "exitCode") ?? null,
     stream: getString(eventData, "stream") ?? null,
+    status: getString(eventData, "status") ?? null,
+  };
+}
+
+export function getFileEventMeta(message: ChatMessageRecord): {
+  status: string | null;
+} {
+  const eventData = getEventDataObject(message);
+  return {
+    status: getString(eventData, "status") ?? null,
   };
 }
 
@@ -173,6 +192,16 @@ function getString(
 ): string | undefined {
   const candidate = value?.[key];
   return typeof candidate === "string" ? candidate : undefined;
+}
+
+function getNumber(
+  value: Record<string, unknown> | null,
+  key: string,
+): number | undefined {
+  const candidate = value?.[key];
+  return typeof candidate === "number" && Number.isFinite(candidate)
+    ? candidate
+    : undefined;
 }
 
 function getStringArray(


### PR DESCRIPTION
## Summary

- Map Codex rich app-server notifications to dedicated Phantom event categories.
- Persist plan, diff, command output, file change, reasoning, and warning events as structured chat timeline messages.
- Render rich event rows in the web timeline with compact plan, diff, command output, file patch, reasoning, and warning views.

## Validation

- `pnpm ready`

## Notes

- `DESIGN.md` was consulted for the UI treatment; rich events use compact, low-saturation timeline rows.