### PR TITLE
[codex] Add GitHub checkout targets to web chat

### DIFF
--- a/packages/core/src/github/checkout.test.ts
+++ b/packages/core/src/github/checkout.test.ts
@@ -5,6 +5,7 @@ import { isErr, isOk } from "@phantompane/utils";
 const getGitHubRepoInfoMock = vi.fn();
 const fetchIssueMock = vi.fn();
 const isPullRequestMock = vi.fn();
+const listGitHubCheckoutTargetsMock = vi.fn();
 const checkoutPullRequestMock = vi.fn();
 const checkoutIssueMock = vi.fn();
 
@@ -12,6 +13,7 @@ vi.doMock("@phantompane/github", () => ({
   getGitHubRepoInfo: getGitHubRepoInfoMock,
   fetchIssue: fetchIssueMock,
   isPullRequest: isPullRequestMock,
+  listGitHubCheckoutTargets: listGitHubCheckoutTargetsMock,
 }));
 
 vi.doMock("./checkout/pr.ts", () => ({
@@ -29,6 +31,7 @@ describe("githubCheckout", () => {
     getGitHubRepoInfoMock.mockClear();
     fetchIssueMock.mockClear();
     isPullRequestMock.mockClear();
+    listGitHubCheckoutTargetsMock.mockClear();
     checkoutPullRequestMock.mockClear();
     checkoutIssueMock.mockClear();
   };
@@ -280,5 +283,49 @@ describe("githubCheckout", () => {
     if (isErr(result)) {
       equal(result.error, expectedError);
     }
+  });
+
+  it("should pass cwd through repo lookup and checkout", async () => {
+    resetMocks();
+    const mockPR = {
+      number: 333,
+      isFromFork: false,
+      head: {
+        ref: "feature",
+        repo: {
+          full_name: "owner/repo",
+        },
+      },
+      base: {
+        repo: {
+          full_name: "owner/repo",
+        },
+      },
+    };
+    const mockIssue = {
+      number: 333,
+      pullRequest: mockPR,
+    };
+
+    getGitHubRepoInfoMock.mockImplementation(async () => ({
+      owner: "test-owner",
+      repo: "test-repo",
+    }));
+    fetchIssueMock.mockImplementation(async () => mockIssue);
+    isPullRequestMock.mockImplementation(() => true);
+    checkoutPullRequestMock.mockImplementation(async () => ({
+      ok: true,
+      value: { message: "Checked out PR #333" },
+    }));
+
+    const result = await githubCheckout({ number: "333", cwd: "/repo" });
+
+    ok(isOk(result));
+    deepEqual(getGitHubRepoInfoMock.mock.calls[0], [{ cwd: "/repo" }]);
+    deepEqual(checkoutPullRequestMock.mock.calls[0], [
+      mockPR,
+      undefined,
+      { cwd: "/repo" },
+    ]);
   });
 });

--- a/packages/core/src/github/checkout.ts
+++ b/packages/core/src/github/checkout.ts
@@ -3,22 +3,33 @@ import {
   fetchIssue,
   getGitHubRepoInfo,
   isPullRequest,
+  listGitHubCheckoutTargets as listGitHubCheckoutTargetsFromApi,
+  type GitHubCheckoutTarget,
 } from "@phantompane/github";
 import { checkoutIssue } from "./checkout/issue.ts";
 import { type CheckoutResult, checkoutPullRequest } from "./checkout/pr.ts";
 
 export type { CheckoutResult } from "./checkout/pr.ts";
+export type { GitHubCheckoutTarget } from "@phantompane/github";
 
 export interface GitHubCheckoutOptions {
   number: string;
   base?: string;
+  cwd?: string;
+}
+
+export interface ListGitHubCheckoutTargetsOptions {
+  cwd?: string;
+  limit?: number;
 }
 
 export async function githubCheckout(
   options: GitHubCheckoutOptions,
 ): Promise<Result<CheckoutResult>> {
-  const { number, base } = options;
-  const { owner, repo } = await getGitHubRepoInfo();
+  const { number, base, cwd } = options;
+  const { owner, repo } = cwd
+    ? await getGitHubRepoInfo({ cwd })
+    : await getGitHubRepoInfo();
 
   // Always fetch from /issues/:number endpoint first
   const issue = await fetchIssue(owner, repo, number);
@@ -40,10 +51,25 @@ export async function githubCheckout(
         ),
       );
     }
-    const result = await checkoutPullRequest(issue.pullRequest);
+    const result = cwd
+      ? await checkoutPullRequest(issue.pullRequest, undefined, { cwd })
+      : await checkoutPullRequest(issue.pullRequest);
     return result;
   }
 
-  const result = await checkoutIssue(issue, base);
+  const result = cwd
+    ? await checkoutIssue(issue, base, { cwd })
+    : await checkoutIssue(issue, base);
   return result;
+}
+
+export async function listGitHubCheckoutTargets(
+  options: ListGitHubCheckoutTargetsOptions = {},
+): Promise<GitHubCheckoutTarget[]> {
+  const { owner, repo } = options.cwd
+    ? await getGitHubRepoInfo({ cwd: options.cwd })
+    : await getGitHubRepoInfo();
+  return listGitHubCheckoutTargetsFromApi(owner, repo, {
+    limit: options.limit,
+  });
 }

--- a/packages/core/src/github/checkout/issue.ts
+++ b/packages/core/src/github/checkout/issue.ts
@@ -42,6 +42,7 @@ export async function checkoutIssue(
       worktree: worktreeName,
       path: existsResult.value.path,
       alreadyExists: true,
+      createdBranch: false,
     });
   }
 
@@ -66,5 +67,6 @@ export async function checkoutIssue(
     message: result.value.message,
     worktree: worktreeName,
     path: result.value.path,
+    createdBranch: true,
   });
 }

--- a/packages/core/src/github/checkout/issue.ts
+++ b/packages/core/src/github/checkout/issue.ts
@@ -6,9 +6,14 @@ import { createWorktree as createWorktreeCore } from "../../worktree/create.ts";
 import { validateWorktreeExists } from "../../worktree/validate.ts";
 import type { CheckoutResult } from "./pr.ts";
 
+export interface CheckoutIssueOptions {
+  cwd?: string;
+}
+
 export async function checkoutIssue(
   issue: GitHubIssue,
   base?: string,
+  options: CheckoutIssueOptions = {},
 ): Promise<Result<CheckoutResult>> {
   if (isPullRequest(issue)) {
     return err(
@@ -18,7 +23,7 @@ export async function checkoutIssue(
     );
   }
 
-  const gitRoot = await getGitRoot();
+  const gitRoot = await getGitRoot({ cwd: options.cwd });
   const context = await createContext(gitRoot);
   const worktreeName = `issues/${issue.number}`;
   const branchName = `issues/${issue.number}`;

--- a/packages/core/src/github/checkout/pr.test.ts
+++ b/packages/core/src/github/checkout/pr.test.ts
@@ -3,6 +3,7 @@ import { describe, it, vi } from "vitest";
 import { isErr, isOk } from "@phantompane/utils";
 
 const getGitRootMock = vi.fn();
+const branchExistsMock = vi.fn();
 const fetchMock = vi.fn();
 const attachWorktreeCoreMock = vi.fn();
 const setUpstreamBranchMock = vi.fn();
@@ -10,6 +11,7 @@ const createContextMock = vi.fn();
 const validateWorktreeExistsMock = vi.fn();
 
 vi.doMock("@phantompane/git", () => ({
+  branchExists: branchExistsMock,
   getGitRoot: getGitRootMock,
   fetch: fetchMock,
   setUpstreamBranch: setUpstreamBranchMock,
@@ -31,6 +33,11 @@ const { checkoutPullRequest } = await import("./pr.ts");
 
 describe("checkoutPullRequest", () => {
   const resetMocks = () => {
+    branchExistsMock.mockClear();
+    branchExistsMock.mockImplementation(async () => ({
+      ok: true,
+      value: false,
+    }));
     getGitRootMock.mockClear();
     fetchMock.mockClear();
     attachWorktreeCoreMock.mockClear();
@@ -98,6 +105,7 @@ describe("checkoutPullRequest", () => {
         "Checked out PR #123 from branch feature-branch",
       );
       equal(result.value.alreadyExists, undefined);
+      equal(result.value.createdBranch, true);
     }
 
     // Verify mocks were called correctly
@@ -160,6 +168,7 @@ describe("checkoutPullRequest", () => {
     if (isOk(result)) {
       equal(result.value.message, "PR #456 is already checked out");
       equal(result.value.alreadyExists, true);
+      equal(result.value.createdBranch, false);
       equal(
         result.value.path,
         `${mockGitRoot}/.git/phantom/worktrees/existing-branch`,
@@ -345,6 +354,59 @@ describe("checkoutPullRequest", () => {
     equal(upstreamArgs[0], mockGitRoot);
     equal(upstreamArgs[1], "contributor/fork-feature");
     equal(upstreamArgs[2], "origin/pull/1234/head");
+  });
+
+  it("should preserve existing local branches when attaching a PR worktree", async () => {
+    resetMocks();
+    const mockGitRoot = "/path/to/repo";
+    const mockPullRequest = {
+      number: 777,
+      isFromFork: false,
+      head: {
+        ref: "existing-local-branch",
+        repo: {
+          full_name: "owner/repo",
+        },
+      },
+      base: {
+        repo: {
+          full_name: "owner/repo",
+        },
+      },
+    };
+
+    getGitRootMock.mockImplementation(async () => mockGitRoot);
+    createContextMock.mockImplementation(async () => ({
+      gitRoot: mockGitRoot,
+      worktreesDirectory: `${mockGitRoot}/.git/phantom/worktrees`,
+    }));
+    validateWorktreeExistsMock.mockImplementation(async () => ({
+      ok: false,
+      error: new Error("Worktree not found"),
+    }));
+    branchExistsMock.mockImplementation(async () => ({
+      ok: true,
+      value: true,
+    }));
+    fetchMock.mockImplementation(async () => ({
+      ok: true,
+      value: undefined,
+    }));
+    attachWorktreeCoreMock.mockImplementation(async () => ({
+      ok: true,
+      value: "/path/to/repo/.git/phantom/worktrees/existing-local-branch",
+    }));
+    setUpstreamBranchMock.mockImplementation(async () => ({
+      ok: true,
+      value: undefined,
+    }));
+
+    const result = await checkoutPullRequest(mockPullRequest);
+
+    ok(isOk(result));
+    if (isOk(result)) {
+      equal(result.value.createdBranch, false);
+    }
   });
 
   it("should handle fetch errors", async () => {

--- a/packages/core/src/github/checkout/pr.ts
+++ b/packages/core/src/github/checkout/pr.ts
@@ -1,4 +1,9 @@
-import { fetch, getGitRoot, setUpstreamBranch } from "@phantompane/git";
+import {
+  branchExists,
+  fetch,
+  getGitRoot,
+  setUpstreamBranch,
+} from "@phantompane/git";
 import type { GitHubPullRequest } from "@phantompane/github";
 import { err, isErr, ok, type Result } from "@phantompane/utils";
 import { createContext } from "../../context.ts";
@@ -10,6 +15,7 @@ export interface CheckoutResult {
   worktree: string;
   path: string;
   alreadyExists?: boolean;
+  createdBranch?: boolean;
 }
 
 export interface CheckoutPullRequestOptions {
@@ -49,8 +55,15 @@ export async function checkoutPullRequest(
       worktree: worktreeName,
       path: existsResult.value.path,
       alreadyExists: true,
+      createdBranch: false,
     });
   }
+
+  const branchExistsResult = await branchExists(context.gitRoot, localBranch);
+  if (isErr(branchExistsResult)) {
+    return err(branchExistsResult.error);
+  }
+  const createdBranch = !branchExistsResult.value;
 
   // Determine the upstream branch for tracking
   const upstream = pullRequest.isFromFork
@@ -108,5 +121,6 @@ export async function checkoutPullRequest(
     message,
     worktree: worktreeName,
     path: attachResult.value,
+    createdBranch,
   });
 }

--- a/packages/core/src/github/checkout/pr.ts
+++ b/packages/core/src/github/checkout/pr.ts
@@ -12,6 +12,10 @@ export interface CheckoutResult {
   alreadyExists?: boolean;
 }
 
+export interface CheckoutPullRequestOptions {
+  cwd?: string;
+}
+
 function getForkWorktreeName(pullRequest: GitHubPullRequest): string {
   const [owner] = pullRequest.head.repo.full_name.split("/");
   if (!owner) {
@@ -25,8 +29,9 @@ export async function checkoutPullRequest(
   worktreeName = pullRequest.isFromFork
     ? getForkWorktreeName(pullRequest)
     : pullRequest.head.ref,
+  options: CheckoutPullRequestOptions = {},
 ): Promise<Result<CheckoutResult>> {
-  const gitRoot = await getGitRoot();
+  const gitRoot = await getGitRoot({ cwd: options.cwd });
   const context = await createContext(gitRoot);
   const localBranch = worktreeName;
 
@@ -57,7 +62,7 @@ export async function checkoutPullRequest(
   const refspec = `${upstream.replace("origin/", "")}:${localBranch}`;
 
   // Fetch the PR to a local branch
-  const fetchResult = await fetch({ refspec });
+  const fetchResult = await fetch({ cwd: gitRoot, refspec });
   if (isErr(fetchResult)) {
     return err(
       new Error(

--- a/packages/github/src/api/checkout-target.test.ts
+++ b/packages/github/src/api/checkout-target.test.ts
@@ -1,0 +1,103 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it, vi } from "vitest";
+
+const createGitHubClientMock = vi.fn();
+
+interface MockCheckoutTargetOctokit {
+  issues: {
+    listForRepo: ReturnType<typeof vi.fn>;
+  };
+}
+
+let mockOctokit: MockCheckoutTargetOctokit | undefined;
+
+vi.doMock("../client.ts", () => ({
+  createGitHubClient: createGitHubClientMock,
+}));
+
+const { listGitHubCheckoutTargets } = await import("./checkout-target.ts");
+
+describe("listGitHubCheckoutTargets", () => {
+  const resetMocks = () => {
+    createGitHubClientMock.mockClear();
+    mockOctokit = undefined;
+  };
+
+  it("maps open issues and pull requests to checkout targets", async () => {
+    resetMocks();
+    mockOctokit = {
+      issues: {
+        listForRepo: vi.fn(async () => ({
+          data: [
+            {
+              number: 42,
+              title: "Fix checkout",
+              html_url: "https://github.com/owner/repo/pull/42",
+              updated_at: "2026-05-04T00:00:00Z",
+              user: { login: "alice" },
+              pull_request: {},
+            },
+            {
+              number: 7,
+              title: "Support issue checkout",
+              html_url: "https://github.com/owner/repo/issues/7",
+              updated_at: "2026-05-03T00:00:00Z",
+              user: null,
+            },
+          ],
+        })),
+      },
+    };
+    createGitHubClientMock.mockImplementation(async () => mockOctokit!);
+
+    const targets = await listGitHubCheckoutTargets("owner", "repo", {
+      limit: 10,
+    });
+
+    deepStrictEqual(mockOctokit!.issues.listForRepo.mock.calls[0]?.[0], {
+      owner: "owner",
+      repo: "repo",
+      state: "open",
+      sort: "updated",
+      direction: "desc",
+      per_page: 10,
+    });
+    deepStrictEqual(targets, [
+      {
+        author: "alice",
+        htmlUrl: "https://github.com/owner/repo/pull/42",
+        kind: "pullRequest",
+        number: 42,
+        title: "Fix checkout",
+        updatedAt: "2026-05-04T00:00:00Z",
+      },
+      {
+        author: null,
+        htmlUrl: "https://github.com/owner/repo/issues/7",
+        kind: "issue",
+        number: 7,
+        title: "Support issue checkout",
+        updatedAt: "2026-05-03T00:00:00Z",
+      },
+    ]);
+  });
+
+  it("uses a compact default limit", async () => {
+    resetMocks();
+    mockOctokit = {
+      issues: {
+        listForRepo: vi.fn(async () => ({
+          data: [],
+        })),
+      },
+    };
+    createGitHubClientMock.mockImplementation(async () => mockOctokit!);
+
+    await listGitHubCheckoutTargets("owner", "repo");
+
+    strictEqual(
+      mockOctokit!.issues.listForRepo.mock.calls[0]?.[0].per_page,
+      30,
+    );
+  });
+});

--- a/packages/github/src/api/checkout-target.ts
+++ b/packages/github/src/api/checkout-target.ts
@@ -1,0 +1,31 @@
+import { createGitHubClient } from "../client.ts";
+import type { GitHubCheckoutTarget } from "./types.ts";
+
+export interface ListGitHubCheckoutTargetsOptions {
+  limit?: number;
+}
+
+export async function listGitHubCheckoutTargets(
+  owner: string,
+  repo: string,
+  options: ListGitHubCheckoutTargetsOptions = {},
+): Promise<GitHubCheckoutTarget[]> {
+  const github = await createGitHubClient();
+  const { data } = await github.issues.listForRepo({
+    owner,
+    repo,
+    state: "open",
+    sort: "updated",
+    direction: "desc",
+    per_page: options.limit ?? 30,
+  });
+
+  return data.map((item) => ({
+    author: item.user?.login ?? null,
+    htmlUrl: item.html_url,
+    kind: item.pull_request ? "pullRequest" : "issue",
+    number: item.number,
+    title: item.title,
+    updatedAt: item.updated_at,
+  }));
+}

--- a/packages/github/src/api/index.ts
+++ b/packages/github/src/api/index.ts
@@ -1,3 +1,4 @@
+export * from "./checkout-target.ts";
 export * from "./issue.ts";
 export * from "./pull-request.ts";
 export * from "./repo-info.ts";

--- a/packages/github/src/api/repo-info.test.ts
+++ b/packages/github/src/api/repo-info.test.ts
@@ -63,6 +63,24 @@ describe("getGitHubRepoInfo", () => {
     deepStrictEqual(args, ["repo", "view", "--json", "owner,name"]);
   });
 
+  it("should run gh in the provided cwd", async () => {
+    resetMocks();
+    execFileMock.mockImplementation(() =>
+      Promise.resolve({
+        stdout: JSON.stringify({
+          owner: { login: "test-owner" },
+          name: "test-repo",
+        }),
+        stderr: "",
+      }),
+    );
+
+    await getGitHubRepoInfo({ cwd: "/repo" });
+
+    const [, , options] = execFileMock.mock.calls[0];
+    deepStrictEqual(options, { cwd: "/repo" });
+  });
+
   it("should throw error when gh command fails", async () => {
     resetMocks();
     execFileMock.mockImplementation(() =>

--- a/packages/github/src/api/repo-info.ts
+++ b/packages/github/src/api/repo-info.ts
@@ -9,18 +9,33 @@ const repoInfoSchema = z.object({
   repo: z.string(),
 });
 
+export interface GetGitHubRepoInfoOptions {
+  cwd?: string;
+}
+
 export async function getGitHubRepoInfo(): Promise<{
+  owner: string;
+  repo: string;
+}>;
+export async function getGitHubRepoInfo(
+  options: GetGitHubRepoInfoOptions,
+): Promise<{
+  owner: string;
+  repo: string;
+}>;
+export async function getGitHubRepoInfo(
+  options: GetGitHubRepoInfoOptions = {},
+): Promise<{
   owner: string;
   repo: string;
 }> {
   try {
-    const { stdout } = await execFileAsync("gh", [
-      "repo",
-      "view",
-      "--json",
-      "owner,name",
-    ]);
-    const data = JSON.parse(stdout);
+    const { stdout } = await execFileAsync(
+      "gh",
+      ["repo", "view", "--json", "owner,name"],
+      options.cwd ? { cwd: options.cwd } : undefined,
+    );
+    const data = JSON.parse(stdout.toString());
     return repoInfoSchema.parse({
       owner: data.owner.login,
       repo: data.name,

--- a/packages/github/src/api/types.ts
+++ b/packages/github/src/api/types.ts
@@ -19,6 +19,15 @@ export interface GitHubIssue {
   pullRequest?: GitHubPullRequest;
 }
 
+export interface GitHubCheckoutTarget {
+  author: string | null;
+  htmlUrl: string;
+  kind: "issue" | "pullRequest";
+  number: number;
+  title: string;
+  updatedAt: string;
+}
+
 export function isPullRequest(
   issue: GitHubIssue,
 ): issue is GitHubIssue & { pullRequest: GitHubPullRequest } {

--- a/packages/server/src/rpc.test.ts
+++ b/packages/server/src/rpc.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, it, vi } from "vitest";
 const services = vi.hoisted(() => ({
   addProject: vi.fn(),
   createChat: vi.fn(),
+  listProjectGitHubCheckoutTargets: vi.fn(),
   listProjects: vi.fn(),
 }));
 
@@ -99,5 +100,75 @@ describe("rpcRoutes", () => {
         message: "Worktree path is required",
       },
     });
+  });
+
+  it("lists GitHub checkout targets through Hono RPC", async () => {
+    services.listProjectGitHubCheckoutTargets.mockResolvedValueOnce({
+      available: true,
+      targets: [
+        {
+          author: "alice",
+          htmlUrl: "https://github.com/owner/repo/pull/42",
+          kind: "pullRequest",
+          number: 42,
+          title: "Fix checkout",
+          updatedAt: "2026-05-04T00:00:00Z",
+        },
+      ],
+    });
+
+    const response = await rpcRoutes.request(
+      "/projects/proj_1/github/checkout-targets",
+    );
+
+    strictEqual(response.status, 200);
+    deepStrictEqual(services.listProjectGitHubCheckoutTargets.mock.calls[0], [
+      "proj_1",
+    ]);
+    deepStrictEqual(await response.json(), {
+      github: {
+        available: true,
+        targets: [
+          {
+            author: "alice",
+            htmlUrl: "https://github.com/owner/repo/pull/42",
+            kind: "pullRequest",
+            number: 42,
+            title: "Fix checkout",
+            updatedAt: "2026-05-04T00:00:00Z",
+          },
+        ],
+      },
+    });
+  });
+
+  it("accepts GitHub checkout targets in chat creation bodies", async () => {
+    services.createChat.mockResolvedValueOnce({
+      id: "chat_1",
+    });
+
+    const response = await rpcRoutes.request("/projects/proj_1/chats", {
+      method: "POST",
+      body: JSON.stringify({
+        githubTargetNumber: 42,
+        initialMessage: "Start from the selected target",
+      }),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+    strictEqual(response.status, 201);
+    deepStrictEqual(services.createChat.mock.calls[0], [
+      "proj_1",
+      {
+        name: undefined,
+        base: undefined,
+        githubTargetNumber: 42,
+        initialMessage: "Start from the selected target",
+        worktreeName: undefined,
+        worktreePath: undefined,
+      },
+    ]);
   });
 });

--- a/packages/server/src/rpc.ts
+++ b/packages/server/src/rpc.ts
@@ -18,6 +18,7 @@ const createChatSchema = z
   .object({
     name: z.string().optional(),
     base: z.string().optional(),
+    githubTargetNumber: z.number().int().positive().optional(),
     initialMessage: z.string().optional(),
     worktreeName: z.string().optional(),
     worktreePath: z.string().optional(),
@@ -35,6 +36,17 @@ const createChatSchema = z
         code: "custom",
         message: "Worktree path is required",
         path: ["worktreePath"],
+      });
+    }
+    if (
+      value.githubTargetNumber !== undefined &&
+      (value.worktreeName !== undefined || value.worktreePath !== undefined)
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        message:
+          "GitHub checkout target cannot be combined with worktree input",
+        path: ["githubTargetNumber"],
       });
     }
   });
@@ -229,6 +241,16 @@ export const rpcRoutes = new Hono()
       return handleApiError(c, error);
     }
   })
+  .get("/projects/:projectId/github/checkout-targets", async (c) => {
+    try {
+      const github = await getServeServices().listProjectGitHubCheckoutTargets(
+        c.req.param("projectId"),
+      );
+      return c.json({ github }, 200);
+    } catch (error) {
+      return handleApiError(c, error);
+    }
+  })
   .post("/projects/:projectId/chats", jsonBody(createChatSchema), async (c) => {
     try {
       const body = c.req.valid("json");
@@ -237,6 +259,7 @@ export const rpcRoutes = new Hono()
         {
           name: body.name,
           base: body.base,
+          githubTargetNumber: body.githubTargetNumber,
           initialMessage: body.initialMessage,
           worktreeName: body.worktreeName,
           worktreePath: body.worktreePath,

--- a/packages/server/src/services.test.ts
+++ b/packages/server/src/services.test.ts
@@ -19,6 +19,8 @@ const coreMocks = vi.hoisted(() => ({
   createContext: vi.fn(),
   deleteBranch: vi.fn(),
   deleteWorktree: vi.fn(),
+  githubCheckout: vi.fn(),
+  listGitHubCheckoutTargets: vi.fn(),
   listWorktrees: vi.fn(),
   removeWorktree: vi.fn(),
   runCreateWorktree: vi.fn(),
@@ -2728,6 +2730,113 @@ describe("ServeServices", () => {
       savedState.chats.map((candidate) => candidate.id),
       [chat.id],
     );
+  });
+
+  it("checks out a GitHub target before starting a new chat", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+    };
+    const { codex, services, store } = await createHarness(state);
+    coreMocks.githubCheckout.mockResolvedValueOnce({
+      ok: true,
+      value: {
+        message: "Checked out PR #42",
+        worktree: "feature",
+        path: "/repo/.git/phantom/worktrees/feature",
+      },
+    });
+    coreMocks.listWorktrees.mockResolvedValueOnce({
+      ok: true,
+      value: {
+        worktrees: [
+          {
+            name: "feature",
+            path: "/repo/.git/phantom/worktrees/feature",
+            pathToDisplay: ".git/phantom/worktrees/feature",
+            branch: "feature",
+            isClean: true,
+          },
+        ],
+      },
+    });
+    codex.startThread.mockResolvedValueOnce({ thread: { id: "thread_new" } });
+
+    const chat = await services.createChat("proj_1", {
+      githubTargetNumber: 42,
+      initialMessage: "Implement this PR feedback",
+    });
+
+    deepStrictEqual(coreMocks.githubCheckout.mock.calls[0], [
+      {
+        number: "42",
+        base: undefined,
+        cwd: "/repo",
+      },
+    ]);
+    deepStrictEqual(codex.startThread.mock.calls[0], [
+      "/repo/.git/phantom/worktrees/feature",
+    ]);
+    strictEqual(chat.worktreeName, "feature");
+    strictEqual(chat.worktreePath, "/repo/.git/phantom/worktrees/feature");
+    strictEqual(chat.codexThreadId, "thread_new");
+    const savedState = await store.load();
+    strictEqual(savedState.selectedChatId, chat.id);
+  });
+
+  it("lists GitHub checkout targets for a project", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+    };
+    const { services } = await createHarness(state);
+    coreMocks.listGitHubCheckoutTargets.mockResolvedValueOnce([
+      {
+        author: "alice",
+        htmlUrl: "https://github.com/owner/repo/pull/42",
+        kind: "pullRequest",
+        number: 42,
+        title: "Fix checkout",
+        updatedAt: "2026-05-04T00:00:00Z",
+      },
+    ]);
+
+    const result = await services.listProjectGitHubCheckoutTargets("proj_1");
+
+    deepStrictEqual(coreMocks.listGitHubCheckoutTargets.mock.calls[0], [
+      { cwd: "/repo" },
+    ]);
+    deepStrictEqual(result, {
+      available: true,
+      targets: [
+        {
+          author: "alice",
+          htmlUrl: "https://github.com/owner/repo/pull/42",
+          kind: "pullRequest",
+          number: 42,
+          title: "Fix checkout",
+          updatedAt: "2026-05-04T00:00:00Z",
+        },
+      ],
+    });
+  });
+
+  it("hides GitHub checkout targets when GitHub access is unavailable", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+    };
+    const { services } = await createHarness(state);
+    coreMocks.listGitHubCheckoutTargets.mockRejectedValueOnce(
+      new Error("Failed to get GitHub auth token"),
+    );
+
+    const result = await services.listProjectGitHubCheckoutTargets("proj_1");
+
+    deepStrictEqual(result, {
+      available: false,
+      targets: [],
+    });
   });
 
   it("rejects partial existing-worktree chat creation input", async () => {

--- a/packages/server/src/services.test.ts
+++ b/packages/server/src/services.test.ts
@@ -2784,6 +2784,150 @@ describe("ServeServices", () => {
     strictEqual(savedState.selectedChatId, chat.id);
   });
 
+  it("rolls back a newly checked out GitHub worktree when Codex thread startup fails", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+    };
+    const { codex, services } = await createHarness(state);
+    coreMocks.githubCheckout.mockResolvedValueOnce({
+      ok: true,
+      value: {
+        message: "Checked out PR #42",
+        worktree: "feature",
+        path: "/repo/.git/phantom/worktrees/feature",
+        createdBranch: true,
+      },
+    });
+    coreMocks.listWorktrees.mockResolvedValueOnce({
+      ok: true,
+      value: {
+        worktrees: [
+          {
+            name: "feature",
+            path: "/repo/.git/phantom/worktrees/feature",
+            pathToDisplay: ".git/phantom/worktrees/feature",
+            branch: "feature",
+            isClean: true,
+          },
+        ],
+      },
+    });
+    codex.startThread.mockRejectedValueOnce(new Error("Codex unavailable"));
+    coreMocks.removeWorktree.mockResolvedValueOnce(undefined);
+    coreMocks.deleteBranch.mockResolvedValueOnce({
+      ok: true,
+      value: undefined,
+    });
+
+    await rejects(
+      services.createChat("proj_1", {
+        githubTargetNumber: 42,
+        initialMessage: "Implement this PR feedback",
+      }),
+      /Codex unavailable/,
+    );
+
+    deepStrictEqual(coreMocks.removeWorktree.mock.calls[0], [
+      "/repo",
+      "/repo/.git/phantom/worktrees/feature",
+      true,
+    ]);
+    deepStrictEqual(coreMocks.deleteBranch.mock.calls[0], ["/repo", "feature"]);
+  });
+
+  it("keeps existing GitHub checkout branches when rolling back chat startup", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+    };
+    const { codex, services } = await createHarness(state);
+    coreMocks.githubCheckout.mockResolvedValueOnce({
+      ok: true,
+      value: {
+        message: "Checked out PR #42",
+        worktree: "feature",
+        path: "/repo/.git/phantom/worktrees/feature",
+        createdBranch: false,
+      },
+    });
+    coreMocks.listWorktrees.mockResolvedValueOnce({
+      ok: true,
+      value: {
+        worktrees: [
+          {
+            name: "feature",
+            path: "/repo/.git/phantom/worktrees/feature",
+            pathToDisplay: ".git/phantom/worktrees/feature",
+            branch: "feature",
+            isClean: true,
+          },
+        ],
+      },
+    });
+    codex.startThread.mockRejectedValueOnce(new Error("Codex unavailable"));
+    coreMocks.removeWorktree.mockResolvedValueOnce(undefined);
+
+    await rejects(
+      services.createChat("proj_1", {
+        githubTargetNumber: 42,
+        initialMessage: "Implement this PR feedback",
+      }),
+      /Codex unavailable/,
+    );
+
+    deepStrictEqual(coreMocks.removeWorktree.mock.calls[0], [
+      "/repo",
+      "/repo/.git/phantom/worktrees/feature",
+      true,
+    ]);
+    strictEqual(coreMocks.deleteBranch.mock.calls.length, 0);
+  });
+
+  it("does not roll back existing GitHub checkout worktrees when chat startup fails", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+    };
+    const { codex, services } = await createHarness(state);
+    coreMocks.githubCheckout.mockResolvedValueOnce({
+      ok: true,
+      value: {
+        message: "PR #42 is already checked out",
+        worktree: "feature",
+        path: "/repo/.git/phantom/worktrees/feature",
+        alreadyExists: true,
+        createdBranch: false,
+      },
+    });
+    coreMocks.listWorktrees.mockResolvedValueOnce({
+      ok: true,
+      value: {
+        worktrees: [
+          {
+            name: "feature",
+            path: "/repo/.git/phantom/worktrees/feature",
+            pathToDisplay: ".git/phantom/worktrees/feature",
+            branch: "feature",
+            isClean: true,
+          },
+        ],
+      },
+    });
+    codex.startThread.mockRejectedValueOnce(new Error("Codex unavailable"));
+
+    await rejects(
+      services.createChat("proj_1", {
+        githubTargetNumber: 42,
+        initialMessage: "Implement this PR feedback",
+      }),
+      /Codex unavailable/,
+    );
+
+    strictEqual(coreMocks.removeWorktree.mock.calls.length, 0);
+    strictEqual(coreMocks.deleteBranch.mock.calls.length, 0);
+  });
+
   it("lists GitHub checkout targets for a project", async () => {
     const state = {
       ...createTestState(),

--- a/packages/server/src/services.ts
+++ b/packages/server/src/services.ts
@@ -12,7 +12,9 @@ import {
   createContext,
   deleteBranch,
   deleteWorktree as deleteWorktreeCore,
+  githubCheckout,
   listWorktrees,
+  listGitHubCheckoutTargets,
   removeWorktree,
   runCreateWorktree,
   WorktreeAlreadyExistsError,
@@ -43,6 +45,7 @@ import type {
   ChatRecord,
   ChatStatus,
   CodexFileRecord,
+  GitHubCheckoutTargetsResult,
   CodexModelRecord,
   CodexSkillRecord,
   CodexTurnContextItem,
@@ -55,6 +58,7 @@ import type {
 export interface CreateChatInput {
   name?: string;
   base?: string;
+  githubTargetNumber?: number;
   initialMessage?: string;
   worktreeName?: string;
   worktreePath?: string;
@@ -573,6 +577,29 @@ export class ServeServices {
     return threads;
   }
 
+  async listProjectGitHubCheckoutTargets(
+    projectId: string,
+  ): Promise<GitHubCheckoutTargetsResult> {
+    await this.resetStaleTransientChatState();
+    const state = await this.store.load();
+    const project = this.requireProject(state, projectId);
+
+    try {
+      const targets = await listGitHubCheckoutTargets({
+        cwd: project.rootPath,
+      });
+      return {
+        available: true,
+        targets,
+      };
+    } catch {
+      return {
+        available: false,
+        targets: [],
+      };
+    }
+  }
+
   async syncProjectWorktreeBranch(
     projectId: string,
     input: SyncProjectWorktreeBranchInput,
@@ -635,6 +662,63 @@ export class ServeServices {
     };
   }
 
+  private async createExistingWorktreeChat(
+    projectId: string,
+    project: ProjectRecord,
+    input: {
+      worktreeName?: string;
+      worktreePath: string;
+    },
+  ): Promise<ChatRecord> {
+    const targetWorktreePath = input.worktreePath.trim();
+    const targetWorktreeName = input.worktreeName?.trim();
+    if (!targetWorktreePath) {
+      throw new Error("Worktree path is required");
+    }
+    const worktreesResult = await listWorktrees(project.rootPath, {
+      includePrunable: false,
+    });
+    if (!worktreesResult.ok) {
+      throw worktreesResult.error;
+    }
+    const targetWorktree = worktreesResult.value.worktrees.find(
+      (worktree) =>
+        worktree.path === targetWorktreePath &&
+        (!targetWorktreeName || worktree.name === targetWorktreeName),
+    );
+    if (!targetWorktree) {
+      throw new Error(`Worktree '${targetWorktreePath}' not found`);
+    }
+
+    const threadResult = await this.codex.startThread(targetWorktree.path);
+    const codexThreadId = extractThreadId(threadResult);
+    this.loadedThreadIds.add(codexThreadId);
+    const timestamp = createTimestamp();
+    const chat: ChatRecord = {
+      id: createRecordId("chat"),
+      projectId,
+      worktreeName: targetWorktree.name,
+      worktreePath: targetWorktree.path,
+      branchName: targetWorktree.branch,
+      codexThreadId,
+      title: targetWorktree.name,
+      status: "idle",
+      activeTurnId: null,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    };
+
+    await this.store.update((nextState) => ({
+      ...nextState,
+      chats: [...nextState.chats, chat],
+      selectedProjectId: projectId,
+      selectedChatId: chat.id,
+    }));
+
+    this.eventHub.emit("chat.created", chat, { chatId: chat.id });
+    return chat;
+  }
+
   async createChat(
     projectId: string,
     input: CreateChatInput,
@@ -646,52 +730,30 @@ export class ServeServices {
     const targetWorktreeName = input.worktreeName?.trim();
     const hasExistingWorktreeInput =
       input.worktreePath !== undefined || input.worktreeName !== undefined;
-    if (hasExistingWorktreeInput) {
-      if (!targetWorktreePath) {
-        throw new Error("Worktree path is required");
-      }
-      const worktreesResult = await listWorktrees(project.rootPath, {
-        includePrunable: false,
-      });
-      if (!worktreesResult.ok) {
-        throw worktreesResult.error;
-      }
-      const targetWorktree = worktreesResult.value.worktrees.find(
-        (worktree) =>
-          worktree.path === targetWorktreePath &&
-          (!targetWorktreeName || worktree.name === targetWorktreeName),
+    if (input.githubTargetNumber !== undefined && hasExistingWorktreeInput) {
+      throw new Error(
+        "GitHub checkout target cannot be combined with worktree input",
       );
-      if (!targetWorktree) {
-        throw new Error(`Worktree '${targetWorktreePath}' not found`);
+    }
+    if (input.githubTargetNumber !== undefined) {
+      const result = await githubCheckout({
+        number: String(input.githubTargetNumber),
+        base: input.base,
+        cwd: project.rootPath,
+      });
+      if (!result.ok) {
+        throw result.error;
       }
-
-      const threadResult = await this.codex.startThread(targetWorktree.path);
-      const codexThreadId = extractThreadId(threadResult);
-      this.loadedThreadIds.add(codexThreadId);
-      const timestamp = createTimestamp();
-      const chat: ChatRecord = {
-        id: createRecordId("chat"),
-        projectId,
-        worktreeName: targetWorktree.name,
-        worktreePath: targetWorktree.path,
-        branchName: targetWorktree.branch,
-        codexThreadId,
-        title: targetWorktree.name,
-        status: "idle",
-        activeTurnId: null,
-        createdAt: timestamp,
-        updatedAt: timestamp,
-      };
-
-      await this.store.update((nextState) => ({
-        ...nextState,
-        chats: [...nextState.chats, chat],
-        selectedProjectId: projectId,
-        selectedChatId: chat.id,
-      }));
-
-      this.eventHub.emit("chat.created", chat, { chatId: chat.id });
-      return chat;
+      return this.createExistingWorktreeChat(projectId, project, {
+        worktreeName: result.value.worktree,
+        worktreePath: result.value.path,
+      });
+    }
+    if (hasExistingWorktreeInput) {
+      return this.createExistingWorktreeChat(projectId, project, {
+        worktreeName: targetWorktreeName,
+        worktreePath: targetWorktreePath ?? "",
+      });
     }
 
     const explicitName = input.name?.trim();

--- a/packages/server/src/services.ts
+++ b/packages/server/src/services.ts
@@ -744,10 +744,30 @@ export class ServeServices {
       if (!result.ok) {
         throw result.error;
       }
-      return this.createExistingWorktreeChat(projectId, project, {
-        worktreeName: result.value.worktree,
-        worktreePath: result.value.path,
-      });
+      try {
+        return await this.createExistingWorktreeChat(projectId, project, {
+          worktreeName: result.value.worktree,
+          worktreePath: result.value.path,
+        });
+      } catch (error) {
+        if (!result.value.alreadyExists) {
+          try {
+            await rollbackCreatedWorktree(
+              project.rootPath,
+              result.value.path,
+              result.value.worktree,
+              {
+                deleteBranch: result.value.createdBranch === true,
+              },
+            );
+          } catch (rollbackError) {
+            throw new Error(
+              `Failed to start Codex thread: ${toErrorMessage(error)}. Rollback failed: ${toErrorMessage(rollbackError)}`,
+            );
+          }
+        }
+        throw error instanceof Error ? error : new Error(String(error));
+      }
     }
     if (hasExistingWorktreeInput) {
       return this.createExistingWorktreeChat(projectId, project, {
@@ -3577,7 +3597,9 @@ async function rollbackCreatedWorktree(
   gitRoot: string,
   worktreePath: string,
   branchName: string,
+  options: { deleteBranch?: boolean } = {},
 ): Promise<void> {
+  const { deleteBranch: shouldDeleteBranch = true } = options;
   const errors: string[] = [];
 
   try {
@@ -3586,9 +3608,11 @@ async function rollbackCreatedWorktree(
     errors.push(`worktree remove failed: ${toErrorMessage(error)}`);
   }
 
-  const branchResult = await deleteBranch(gitRoot, branchName);
-  if (!branchResult.ok) {
-    errors.push(`branch delete failed: ${branchResult.error.message}`);
+  if (shouldDeleteBranch) {
+    const branchResult = await deleteBranch(gitRoot, branchName);
+    if (!branchResult.ok) {
+      errors.push(`branch delete failed: ${branchResult.error.message}`);
+    }
   }
 
   if (errors.length > 0) {

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -22,6 +22,20 @@ export interface ProjectWorktreeRecord {
   chatTitle: string;
 }
 
+export interface GitHubCheckoutTargetRecord {
+  author: string | null;
+  htmlUrl: string;
+  kind: "issue" | "pullRequest";
+  number: number;
+  title: string;
+  updatedAt: string;
+}
+
+export interface GitHubCheckoutTargetsResult {
+  available: boolean;
+  targets: GitHubCheckoutTargetRecord[];
+}
+
 export interface CodexFileRecord {
   name: string;
   path: string;

--- a/packages/web/src/api/mutations.test.ts
+++ b/packages/web/src/api/mutations.test.ts
@@ -76,6 +76,35 @@ describe("createChatMutation", () => {
       }),
     );
   });
+
+  it("sends a GitHub checkout target when starting a chat from an issue or PR", async () => {
+    let requestBody: string | undefined;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        requestBody = init?.body?.toString();
+        return new Response('{"chat":{"id":"chat_1"}}', {
+          headers: {
+            "Content-Type": "application/json",
+          },
+          status: 201,
+        });
+      }),
+    );
+
+    await createChatMutation("proj_1", {
+      githubTargetNumber: 42,
+      initialMessage: "Start here",
+    });
+
+    strictEqual(
+      requestBody,
+      JSON.stringify({
+        githubTargetNumber: 42,
+        initialMessage: "Start here",
+      }),
+    );
+  });
 });
 
 describe("message control mutations", () => {

--- a/packages/web/src/api/mutations.ts
+++ b/packages/web/src/api/mutations.ts
@@ -23,6 +23,7 @@ export interface SendMessageInput {
 }
 
 export interface CreateChatInput {
+  githubTargetNumber?: number;
   initialMessage?: string;
   worktreeName?: string;
   worktreePath?: string;

--- a/packages/web/src/api/queries.ts
+++ b/packages/web/src/api/queries.ts
@@ -7,6 +7,7 @@ import type {
   CodexFileRecord,
   CodexModelRecord,
   CodexSkillRecord,
+  GitHubCheckoutTargetsResult,
   ProjectRecord,
   ProjectWorktreeRecord,
 } from "@phantompane/server";
@@ -52,6 +53,18 @@ export function projectChatsQueryOptions(projectId: string) {
     queryFn: async () =>
       readRpcJson<{ chats: ChatRecord[] }>(
         await api.projects[":projectId"].chats.$get({
+          param: { projectId: routeParam(projectId) },
+        }),
+      ),
+  });
+}
+
+export function projectGitHubCheckoutTargetsQueryOptions(projectId: string) {
+  return queryOptions({
+    queryKey: queryKeys.projectGitHubCheckoutTargets(projectId),
+    queryFn: async () =>
+      readRpcJson<{ github: GitHubCheckoutTargetsResult }>(
+        await api.projects[":projectId"].github["checkout-targets"].$get({
           param: { projectId: routeParam(projectId) },
         }),
       ),

--- a/packages/web/src/api/query-keys.ts
+++ b/packages/web/src/api/query-keys.ts
@@ -4,6 +4,8 @@ export const queryKeys = {
   projects: ["projects"] as const,
   projectChats: (projectId: string) =>
     ["projects", projectId, "chats"] as const,
+  projectGitHubCheckoutTargets: (projectId: string) =>
+    ["projects", projectId, "github", "checkout-targets"] as const,
   projectWorktrees: (projectId: string) =>
     ["projects", projectId, "worktrees"] as const,
   chat: (chatId: string) => ["chats", chatId] as const,

--- a/packages/web/src/routes/home.tsx
+++ b/packages/web/src/routes/home.tsx
@@ -3,10 +3,12 @@ import {
   Bot,
   Brain,
   ChevronRight,
+  CircleDot,
   Clock3,
   FileText,
   FolderGit2,
   GitBranch,
+  GitPullRequest,
   Inbox,
   MessageSquare,
   MessageSquarePlus,
@@ -54,6 +56,7 @@ import {
   messagesQueryOptions,
   modelsQueryOptions,
   projectChatsQueryOptions,
+  projectGitHubCheckoutTargetsQueryOptions,
   projectWorktreesQueryOptions,
   projectsQueryOptions,
 } from "../api/queries";
@@ -131,6 +134,8 @@ import type {
   CodexModelRecord,
   CodexSkillRecord,
   CodexTurnContextItem,
+  GitHubCheckoutTargetRecord,
+  GitHubCheckoutTargetsResult,
   PhantomEvent,
   ProjectWorktreeRecord,
   ProjectRecord,
@@ -449,6 +454,9 @@ export function HomeRoute() {
   const [worktreesByProject, setWorktreesByProject] = useState<
     Record<string, ProjectWorktreeRecord[]>
   >({});
+  const [githubTargetsByProject, setGithubTargetsByProject] = useState<
+    Record<string, GitHubCheckoutTargetsResult>
+  >({});
   const [expandedWorktreeKeys, setExpandedWorktreeKeys] = useState<Set<string>>(
     () => new Set(),
   );
@@ -495,6 +503,11 @@ export function HomeRoute() {
   const [isMessagesLoading, setIsMessagesLoading] = useState(false);
   const [isChatContextLoading, setIsChatContextLoading] = useState(false);
   const [isFileSearchLoading, setIsFileSearchLoading] = useState(false);
+  const [loadingGitHubTargetProjectIds, setLoadingGitHubTargetProjectIds] =
+    useState<Set<string>>(() => new Set());
+  const [selectedGitHubTargetNumber, setSelectedGitHubTargetNumber] = useState<
+    number | null
+  >(null);
   const [creatingProjectId, setCreatingProjectId] = useState<string | null>(
     null,
   );
@@ -516,6 +529,7 @@ export function HomeRoute() {
   const selectedChatVersionRef = useRef(0);
   const chatsByProjectRef = useRef(chatsByProject);
   const worktreesByProjectRef = useRef(worktreesByProject);
+  const githubTargetsByProjectRef = useRef(githubTargetsByProject);
   const messagesRefreshRequestIdRef = useRef(0);
   const sendMessageRequestIdRef = useRef(0);
   const composerTextareaRef = useRef<HTMLTextAreaElement | null>(null);
@@ -729,11 +743,29 @@ export function HomeRoute() {
   selectedProjectIdRef.current = selectedProjectId;
   chatsByProjectRef.current = chatsByProject;
   worktreesByProjectRef.current = worktreesByProject;
+  githubTargetsByProjectRef.current = githubTargetsByProject;
   fileSearchQueryRef.current = fileSearchQuery;
   const selectedProject = useMemo(
     () => projects.find((project) => project.id === selectedProjectId) ?? null,
     [projects, selectedProjectId],
   );
+  const selectedProjectGitHubTargets =
+    selectedProjectId && !selectedChatId
+      ? (githubTargetsByProject[selectedProjectId] ?? null)
+      : null;
+  const isSelectedProjectGitHubTargetsLoading = Boolean(
+    selectedProjectId && loadingGitHubTargetProjectIds.has(selectedProjectId),
+  );
+  const selectedGitHubTarget = useMemo(() => {
+    if (!selectedProjectGitHubTargets?.available) {
+      return null;
+    }
+    return (
+      selectedProjectGitHubTargets.targets.find(
+        (target) => target.number === selectedGitHubTargetNumber,
+      ) ?? null
+    );
+  }, [selectedGitHubTargetNumber, selectedProjectGitHubTargets]);
   const hasLoadedSelectedProjectData = Boolean(
     selectedProjectId &&
     chatsByProject[selectedProjectId] !== undefined &&
@@ -976,6 +1008,27 @@ export function HomeRoute() {
       updateSelection: isSelectedChatValidated,
     });
   }, [isSelectedChatValidated, selectedProjectId]);
+
+  useEffect(() => {
+    setSelectedGitHubTargetNumber(null);
+    if (!selectedProjectId || selectedChatId) {
+      return;
+    }
+    void refreshGitHubCheckoutTargets(selectedProjectId);
+  }, [selectedProjectId, selectedChatId]);
+
+  useEffect(() => {
+    if (
+      selectedGitHubTargetNumber === null ||
+      !selectedProjectGitHubTargets?.available ||
+      selectedProjectGitHubTargets.targets.some(
+        (target) => target.number === selectedGitHubTargetNumber,
+      )
+    ) {
+      return;
+    }
+    setSelectedGitHubTargetNumber(null);
+  }, [selectedGitHubTargetNumber, selectedProjectGitHubTargets]);
 
   useEffect(() => {
     selectedChatVersionRef.current += 1;
@@ -1279,6 +1332,21 @@ export function HomeRoute() {
     });
   }
 
+  function setGitHubTargetProjectLoading(
+    projectId: string,
+    isLoading: boolean,
+  ) {
+    setLoadingGitHubTargetProjectIds((current) => {
+      const next = new Set(current);
+      if (isLoading) {
+        next.add(projectId);
+      } else {
+        next.delete(projectId);
+      }
+      return next;
+    });
+  }
+
   async function refreshProjects(): Promise<boolean> {
     const requestWorkspaceSelectionKey = workspaceSelectionKeyRef.current;
     setIsProjectsLoading(true);
@@ -1294,10 +1362,17 @@ export function HomeRoute() {
         worktreesByProjectRef.current,
         projectIds,
       );
+      const nextGitHubTargetsByProject = Object.fromEntries(
+        Object.entries(githubTargetsByProjectRef.current).filter(
+          ([projectId]) => projectIds.has(projectId),
+        ),
+      );
       chatsByProjectRef.current = nextChatsByProject;
       worktreesByProjectRef.current = nextWorktreesByProject;
+      githubTargetsByProjectRef.current = nextGitHubTargetsByProject;
       setChatsByProject(nextChatsByProject);
       setWorktreesByProject(nextWorktreesByProject);
+      setGithubTargetsByProject(nextGitHubTargetsByProject);
       if (workspaceSelectionKeyRef.current !== requestWorkspaceSelectionKey) {
         return true;
       }
@@ -1511,6 +1586,33 @@ export function HomeRoute() {
     }
   }
 
+  async function refreshGitHubCheckoutTargets(projectId: string) {
+    setGitHubTargetProjectLoading(projectId, true);
+    try {
+      const data = await queryClient.fetchQuery(
+        projectGitHubCheckoutTargetsQueryOptions(projectId),
+      );
+      const nextGitHubTargetsByProject = {
+        ...githubTargetsByProjectRef.current,
+        [projectId]: data.github,
+      };
+      githubTargetsByProjectRef.current = nextGitHubTargetsByProject;
+      setGithubTargetsByProject(nextGitHubTargetsByProject);
+    } catch {
+      const nextGitHubTargetsByProject = {
+        ...githubTargetsByProjectRef.current,
+        [projectId]: {
+          available: false,
+          targets: [],
+        },
+      };
+      githubTargetsByProjectRef.current = nextGitHubTargetsByProject;
+      setGithubTargetsByProject(nextGitHubTargetsByProject);
+    } finally {
+      setGitHubTargetProjectLoading(projectId, false);
+    }
+  }
+
   function upsertChatRecord(chat: ChatRecord) {
     const projectChats = chatsByProjectRef.current[chat.projectId] ?? [];
     const hasExistingChat = projectChats.some(
@@ -1656,6 +1758,9 @@ export function HomeRoute() {
     });
     void queryClient.invalidateQueries({
       queryKey: queryKeys.projectChats(projectId),
+    });
+    void queryClient.invalidateQueries({
+      queryKey: queryKeys.projectGitHubCheckoutTargets(projectId),
     });
     setExpandedWorktreeKeys((current) =>
       new Set(current).add(
@@ -1869,6 +1974,7 @@ export function HomeRoute() {
     input: SendMessageInput,
     composerInput: string,
     requestWorkspaceSelectionKey: string,
+    githubTargetNumber: number | null,
   ) {
     let createdChatId: string | null = null;
     const isRequestWorkspaceSelected = () =>
@@ -1885,6 +1991,7 @@ export function HomeRoute() {
         projectId,
         requestWorkspaceSelectionKey,
         {
+          githubTargetNumber: githubTargetNumber ?? undefined,
           initialMessage: input.text,
         },
       );
@@ -1912,6 +2019,7 @@ export function HomeRoute() {
       if (isCreatedChatSelected()) {
         setSelectedFiles([]);
         setSelectedSkillPaths(new Set());
+        setSelectedGitHubTargetNumber(null);
         setFileSearchQuery("");
         await refreshMessages(chat.id);
       }
@@ -1984,6 +2092,7 @@ export function HomeRoute() {
         messageInput,
         composerInput,
         workspaceSelectionKeyRef.current,
+        selectedGitHubTarget?.number ?? null,
       );
       setIsSendingMessage(false);
       setPendingComposerMode(null);
@@ -2838,10 +2947,14 @@ export function HomeRoute() {
             <TimelineSkeleton />
           ) : visibleMessages.length === 0 ? (
             <EmptyTimeline
+              githubTargets={selectedProjectGitHubTargets}
               hasChat={Boolean(selectedChat)}
               hasWorktree={Boolean(selectedWorktree)}
+              isGitHubTargetsLoading={isSelectedProjectGitHubTargetsLoading}
               selectedProject={selectedProject}
+              selectedGitHubTargetNumber={selectedGitHubTargetNumber}
               onOpenProjectDialog={() => setIsAddProjectOpen(true)}
+              onSelectGitHubTarget={setSelectedGitHubTargetNumber}
             />
           ) : (
             <div className="mx-auto flex max-w-[var(--layout-max-content-width)] flex-col gap-2">
@@ -3282,19 +3395,30 @@ function SystemBanner({
 }
 
 function EmptyTimeline({
+  githubTargets,
   hasChat,
   hasWorktree,
+  isGitHubTargetsLoading,
   onOpenProjectDialog,
+  onSelectGitHubTarget,
+  selectedGitHubTargetNumber,
   selectedProject,
 }: {
+  githubTargets: GitHubCheckoutTargetsResult | null;
   hasChat: boolean;
   hasWorktree: boolean;
+  isGitHubTargetsLoading: boolean;
   onOpenProjectDialog: () => void;
+  onSelectGitHubTarget: (number: number | null) => void;
+  selectedGitHubTargetNumber: number | null;
   selectedProject: ProjectRecord | null;
 }) {
+  const showGitHubTargets =
+    Boolean(selectedProject) && !hasChat && githubTargets?.available;
+
   return (
     <div className="mx-auto flex h-full max-w-[var(--layout-max-content-width)] items-center justify-center py-8">
-      <section className="grid w-full max-w-xl gap-4 px-5 py-6 text-center">
+      <section className="grid w-full max-w-2xl gap-4 px-5 py-6 text-center">
         <div className="mx-auto flex size-10 items-center justify-center rounded-[var(--radius-md)] bg-[var(--surface-code)] text-[var(--icon-color-default)]">
           <Inbox className="size-5" />
         </div>
@@ -3326,8 +3450,107 @@ function EmptyTimeline({
             </Button>
           </div>
         )}
+        {showGitHubTargets && githubTargets && (
+          <GitHubTargetPicker
+            isLoading={isGitHubTargetsLoading}
+            selectedNumber={selectedGitHubTargetNumber}
+            targets={githubTargets.targets}
+            onSelectTarget={onSelectGitHubTarget}
+          />
+        )}
       </section>
     </div>
+  );
+}
+
+function GitHubTargetPicker({
+  isLoading,
+  onSelectTarget,
+  selectedNumber,
+  targets,
+}: {
+  isLoading: boolean;
+  onSelectTarget: (number: number | null) => void;
+  selectedNumber: number | null;
+  targets: GitHubCheckoutTargetRecord[];
+}) {
+  return (
+    <div className="mx-auto mt-2 grid w-full gap-2 text-left">
+      <div className="flex items-center justify-between gap-3 px-1">
+        <p className="text-[length:var(--font-size-sm)] font-medium text-[var(--text-secondary)]">
+          GitHub
+        </p>
+        {isLoading && <InlineLoading label="Refreshing" />}
+      </div>
+      {targets.length === 0 ? (
+        <p className="rounded-[var(--radius-sm)] border border-dashed border-[var(--border-divider)] bg-[var(--surface-code)] px-3 py-2 text-[length:var(--font-size-sm)] text-muted-foreground">
+          No open issues or pull requests.
+        </p>
+      ) : (
+        <ul className="max-h-72 overflow-y-auto rounded-[var(--radius-sm)] border border-[var(--border-divider)] bg-[var(--surface-code)]">
+          {targets.map((target) => (
+            <GitHubTargetOption
+              isSelected={selectedNumber === target.number}
+              key={`${target.kind}-${target.number}`}
+              target={target}
+              onSelectTarget={onSelectTarget}
+            />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function GitHubTargetOption({
+  isSelected,
+  onSelectTarget,
+  target,
+}: {
+  isSelected: boolean;
+  onSelectTarget: (number: number | null) => void;
+  target: GitHubCheckoutTargetRecord;
+}) {
+  const label = `${target.kind === "pullRequest" ? "PR" : "Issue"} #${target.number}: ${target.title}`;
+
+  return (
+    <li className="border-b border-[var(--border-divider)] last:border-b-0">
+      <label
+        className={cn(
+          "grid cursor-pointer grid-cols-[auto_1fr] gap-3 px-3 py-2.5 text-[length:var(--font-size-sm)] transition-colors hover:bg-[var(--state-hover-bg)]",
+          isSelected && "bg-[var(--state-selected-bg)]",
+        )}
+      >
+        <input
+          aria-label={label}
+          checked={isSelected}
+          className="mt-0.5 size-4 accent-[var(--button-primary-bg)]"
+          type="checkbox"
+          onChange={(event) =>
+            onSelectTarget(event.target.checked ? target.number : null)
+          }
+        />
+        <span className="grid min-w-0 gap-1">
+          <span className="flex min-w-0 items-center gap-2">
+            {target.kind === "pullRequest" ? (
+              <GitPullRequest className="size-3.5 shrink-0 text-[var(--semantic-info-fg)]" />
+            ) : (
+              <CircleDot className="size-3.5 shrink-0 text-[var(--semantic-success-fg)]" />
+            )}
+            <span className="shrink-0 font-mono text-[length:var(--font-size-xs)] text-[var(--text-tertiary)]">
+              #{target.number}
+            </span>
+            <span className="truncate font-medium text-[var(--text-primary)]">
+              {target.title}
+            </span>
+          </span>
+          <span className="truncate text-[length:var(--font-size-xs)] text-muted-foreground">
+            {target.kind === "pullRequest" ? "Pull request" : "Issue"}
+            {target.author ? ` by ${target.author}` : ""}
+          </span>
+        </span>
+      </label>
+    </li>
   );
 }
 


### PR DESCRIPTION
## Summary

- Add a GitHub Issue/PR picker to the new chat view when GitHub authentication and repository access are available.
- Route selected targets through the existing `phantom github checkout` core flow before starting the Codex chat.
- Add server RPC, core cwd support, GitHub API helpers, web API bindings, and focused tests for the flow.

## Impact

Users can start a new chat from a selected GitHub pull request or issue and Phantom will automatically check out or reuse the matching worktree before sending the initial message.

## Validation

- `pnpm ready`
- `pnpm --filter @phantompane/web build`

Note: the initial local commit hook failed because `.pre-commit-config.yaml` is absent in this worktree; the commit was created with the hook's suggested `PREK_ALLOW_NO_CONFIG=1` override after validation passed.