### PR TITLE
[codex] add sidebar project delete

### DIFF
--- a/packages/server/src/services.test.ts
+++ b/packages/server/src/services.test.ts
@@ -177,6 +177,15 @@ function markChatActiveInCurrentProcess(
   ).activeTurnChatIds.add(chatId);
 }
 
+function markChatDrainingQueuedMessages(
+  services: ServeServices,
+  chatId: string,
+): void {
+  (
+    services as unknown as { drainingQueuedMessageChatIds: Set<string> }
+  ).drainingQueuedMessageChatIds.add(chatId);
+}
+
 class ImportRaceStore extends ServeStateStore {
   private hasInjectedState = false;
 
@@ -315,6 +324,129 @@ describe("ServeServices", () => {
 
     strictEqual(worktrees[0]?.chatId, "chat_1");
     strictEqual(saveSpy.mock.calls.length, 0);
+  });
+
+  it("does not remove a project with an active chat", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [
+        createChat({
+          status: "running",
+          activeTurnId: "turn_1",
+        }),
+      ],
+      selectedProjectId: "proj_1",
+      selectedChatId: "chat_1",
+    };
+    const { services, store } = await createHarness(state);
+    markChatActiveInCurrentProcess(services, "chat_1");
+
+    await rejects(
+      services.removeProject("proj_1"),
+      /running, approval, or queued chats/,
+    );
+
+    const savedState = await store.load();
+    strictEqual(savedState.projects.length, 1);
+    strictEqual(savedState.chats.length, 1);
+    strictEqual(savedState.selectedProjectId, "proj_1");
+    strictEqual(savedState.selectedChatId, "chat_1");
+  });
+
+  it("does not remove a project with queued messages", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat()],
+      messages: [
+        {
+          id: "msg_queued",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "queued draft",
+          createdAt: timestamp,
+          eventType: "chat.message.queued" as const,
+        },
+      ],
+      queuedMessages: [
+        {
+          id: "queue_1",
+          chatId: "chat_1",
+          messageId: "msg_queued",
+          text: "queued draft",
+          createdAt: timestamp,
+        },
+      ],
+    };
+    const { services, store } = await createHarness(state);
+
+    await rejects(
+      services.removeProject("proj_1"),
+      /running, approval, or queued chats/,
+    );
+
+    const savedState = await store.load();
+    strictEqual(savedState.projects.length, 1);
+    strictEqual(savedState.chats.length, 1);
+    strictEqual(savedState.queuedMessages.length, 1);
+  });
+
+  it("does not remove a project while queued messages are draining", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat()],
+      selectedProjectId: "proj_1",
+      selectedChatId: "chat_1",
+    };
+    const { services, store } = await createHarness(state);
+    markChatDrainingQueuedMessages(services, "chat_1");
+
+    await rejects(
+      services.removeProject("proj_1"),
+      /running, approval, or queued chats/,
+    );
+
+    const savedState = await store.load();
+    strictEqual(savedState.projects.length, 1);
+    strictEqual(savedState.chats.length, 1);
+    strictEqual(savedState.selectedProjectId, "proj_1");
+    strictEqual(savedState.selectedChatId, "chat_1");
+  });
+
+  it("does not let stale transient chat state block project removal", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [
+        createChat({
+          status: "running",
+          activeTurnId: "turn_stale",
+        }),
+      ],
+      messages: [
+        {
+          id: "msg_stale",
+          chatId: "chat_1",
+          role: "event" as const,
+          text: "turn started",
+          createdAt: timestamp,
+        },
+      ],
+      selectedProjectId: "proj_1",
+      selectedChatId: "chat_1",
+    };
+    const { services, store } = await createHarness(state);
+
+    await services.removeProject("proj_1");
+
+    const savedState = await store.load();
+    deepStrictEqual(savedState.projects, []);
+    deepStrictEqual(savedState.chats, []);
+    deepStrictEqual(savedState.messages, []);
+    strictEqual(savedState.selectedProjectId, null);
+    strictEqual(savedState.selectedChatId, null);
   });
 
   it("removes persisted chats for worktrees missing from a live sync", async () => {
@@ -899,6 +1031,74 @@ describe("ServeServices", () => {
     const savedState = await store.load();
     strictEqual(savedState.chats[0]?.status, "idle");
     strictEqual(savedState.chats[0]?.activeTurnId, null);
+  });
+
+  it("annotates project chats with queued message state", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat()],
+      messages: [
+        {
+          id: "msg_queued",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "queued draft",
+          createdAt: timestamp,
+          eventType: "chat.message.queued" as const,
+        },
+      ],
+      queuedMessages: [
+        {
+          id: "queue_1",
+          chatId: "chat_1",
+          messageId: "msg_queued",
+          text: "queued draft",
+          createdAt: timestamp,
+        },
+      ],
+    };
+    const { services } = await createHarness(state);
+    markChatDrainingQueuedMessages(services, "chat_1");
+
+    const chats = await services.listChats("proj_1");
+
+    strictEqual(chats[0]?.hasQueuedMessages, true);
+    strictEqual(chats[0]?.isDrainingQueuedMessages, true);
+  });
+
+  it("annotates a selected chat with queued message state", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat()],
+      messages: [
+        {
+          id: "msg_queued",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "queued draft",
+          createdAt: timestamp,
+          eventType: "chat.message.queued" as const,
+        },
+      ],
+      queuedMessages: [
+        {
+          id: "queue_1",
+          chatId: "chat_1",
+          messageId: "msg_queued",
+          text: "queued draft",
+          createdAt: timestamp,
+        },
+      ],
+    };
+    const { services } = await createHarness(state);
+    markChatDrainingQueuedMessages(services, "chat_1");
+
+    const chat = await services.getChat("chat_1");
+
+    strictEqual(chat.hasQueuedMessages, true);
+    strictEqual(chat.isDrainingQueuedMessages, true);
   });
 
   it("syncs Codex thread metadata for project chats and reads messages lazily", async () => {

--- a/packages/server/src/services.ts
+++ b/packages/server/src/services.ts
@@ -338,12 +338,26 @@ export class ServeServices {
   }
 
   async removeProject(projectId: string): Promise<void> {
+    await this.resetStaleTransientChatState();
     await this.store.update((state) => {
-      const removedChatIds = new Set(
-        state.chats
-          .filter((chat) => chat.projectId === projectId)
-          .map((chat) => chat.id),
+      const queuedMessageChatIds = getQueuedMessageChatIds(state);
+      const projectChats = state.chats.filter(
+        (chat) => chat.projectId === projectId,
       );
+      const activeChat = projectChats.find(
+        (chat) =>
+          isChatActive(chat, this.pendingChatTurns) ||
+          queuedMessageChatIds.has(chat.id) ||
+          this.drainingQueuedMessageChatIds.has(chat.id) ||
+          this.pendingQueuedMessageDrainChatIds.has(chat.id),
+      );
+      if (activeChat) {
+        throw new Error(
+          "Cannot remove project while it has running, approval, or queued chats",
+        );
+      }
+
+      const removedChatIds = new Set(projectChats.map((chat) => chat.id));
 
       return {
         ...state,
@@ -373,8 +387,13 @@ export class ServeServices {
     const project = this.requireProject(state, projectId);
     const worktrees = await this.listProjectWorktreeSnapshot(projectId);
     if (!worktrees) {
-      return sortChatsByUpdatedAt(
-        state.chats.filter((chat) => chat.projectId === projectId),
+      return annotateTransientChatState(
+        sortChatsByUpdatedAt(
+          state.chats.filter((chat) => chat.projectId === projectId),
+        ),
+        state,
+        this.drainingQueuedMessageChatIds,
+        this.pendingQueuedMessageDrainChatIds,
       );
     }
 
@@ -382,8 +401,13 @@ export class ServeServices {
     try {
       codexThreads = await this.listCodexThreadsForWorktrees(worktrees);
     } catch {
-      return sortChatsByUpdatedAt(
-        state.chats.filter((chat) => chat.projectId === projectId),
+      return annotateTransientChatState(
+        sortChatsByUpdatedAt(
+          state.chats.filter((chat) => chat.projectId === projectId),
+        ),
+        state,
+        this.drainingQueuedMessageChatIds,
+        this.pendingQueuedMessageDrainChatIds,
       );
     }
 
@@ -480,8 +504,13 @@ export class ServeServices {
     });
 
     const syncedState = await this.store.load();
-    return sortChatsByUpdatedAt(
-      syncedState.chats.filter((chat) => chat.projectId === projectId),
+    return annotateTransientChatState(
+      sortChatsByUpdatedAt(
+        syncedState.chats.filter((chat) => chat.projectId === projectId),
+      ),
+      syncedState,
+      this.drainingQueuedMessageChatIds,
+      this.pendingQueuedMessageDrainChatIds,
     );
   }
 
@@ -995,7 +1024,12 @@ export class ServeServices {
   async getChat(chatId: string): Promise<ChatRecord> {
     await this.resetStaleTransientChatState();
     const state = await this.store.load();
-    return this.requireChat(state, chatId);
+    return annotateTransientChatState(
+      [this.requireChat(state, chatId)],
+      state,
+      this.drainingQueuedMessageChatIds,
+      this.pendingQueuedMessageDrainChatIds,
+    )[0]!;
   }
 
   async getMessages(chatId: string): Promise<ChatMessageRecord[]> {
@@ -3107,6 +3141,22 @@ function sortChatsByUpdatedAt(chats: ChatRecord[]): ChatRecord[] {
   return [...chats].sort((left, right) =>
     right.updatedAt.localeCompare(left.updatedAt),
   );
+}
+
+function annotateTransientChatState(
+  chats: ChatRecord[],
+  state: ServeState,
+  drainingQueuedMessageChatIds: ReadonlySet<string>,
+  pendingQueuedMessageDrainChatIds: ReadonlySet<string>,
+): ChatRecord[] {
+  const queuedMessageChatIds = getQueuedMessageChatIds(state);
+  return chats.map((chat) => ({
+    ...chat,
+    hasQueuedMessages: queuedMessageChatIds.has(chat.id),
+    isDrainingQueuedMessages:
+      drainingQueuedMessageChatIds.has(chat.id) ||
+      pendingQueuedMessageDrainChatIds.has(chat.id),
+  }));
 }
 
 function normalizeCodexThreadMessages(

--- a/packages/state/src/types.ts
+++ b/packages/state/src/types.ts
@@ -55,6 +55,8 @@ const chatRecordBaseSchema = z.object({
   title: z.string(),
   status: chatStatusSchema,
   activeTurnId: z.string().nullable().optional(),
+  hasQueuedMessages: z.boolean().optional(),
+  isDrainingQueuedMessages: z.boolean().optional(),
   createdAt: z.string(),
   updatedAt: z.string(),
 });

--- a/packages/web/src/api/mutations.test.ts
+++ b/packages/web/src/api/mutations.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, it, vi } from "vitest";
 import {
   answerApprovalMutation,
   createChatMutation,
+  deleteProjectMutation,
   deletePendingMessageMutation,
   queueMessageMutation,
   restorePendingMessageMutation,
@@ -104,6 +105,36 @@ describe("createChatMutation", () => {
         initialMessage: "Start here",
       }),
     );
+  });
+});
+
+describe("deleteProjectMutation", () => {
+  it("encodes project route params before calling Hono RPC", async () => {
+    let requestMethod: string | undefined;
+    let requestUrl: string | undefined;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        requestMethod = init?.method;
+        requestUrl =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+        return new Response("{}", {
+          headers: {
+            "Content-Type": "application/json",
+          },
+          status: 200,
+        });
+      }),
+    );
+
+    await deleteProjectMutation("proj/with#hash");
+
+    strictEqual(requestMethod, "DELETE");
+    strictEqual(requestUrl, "/api/projects/proj%2Fwith%23hash");
   });
 });
 

--- a/packages/web/src/api/mutations.ts
+++ b/packages/web/src/api/mutations.ts
@@ -47,6 +47,14 @@ export async function addProjectMutation(path: string) {
   );
 }
 
+export async function deleteProjectMutation(projectId: string) {
+  return readRpcJson<unknown>(
+    await api.projects[":projectId"].$delete({
+      param: { projectId: routeParam(projectId) },
+    }),
+  );
+}
+
 export async function createChatMutation(
   projectId: string,
   input: CreateChatInput = {},

--- a/packages/web/src/routes/home.tsx
+++ b/packages/web/src/routes/home.tsx
@@ -43,6 +43,7 @@ import {
   answerApprovalMutation,
   addProjectMutation,
   createChatMutation,
+  deleteProjectMutation,
   deletePendingMessageMutation,
   deleteWorktreeMutation,
   interruptChatMutation,
@@ -489,6 +490,9 @@ export function HomeRoute() {
   const [messagesChatId, setMessagesChatId] = useState<string | null>(null);
   const [isAddProjectOpen, setIsAddProjectOpen] = useState(false);
   const [projectPath, setProjectPath] = useState("");
+  const [deleteProjectTarget, setDeleteProjectTarget] = useState<string | null>(
+    null,
+  );
   const [deleteWorktreeTarget, setDeleteWorktreeTarget] =
     useState<DeleteWorktreeTarget | null>(null);
   const [deleteWorktreeBranchMode, setDeleteWorktreeBranchMode] =
@@ -570,6 +574,9 @@ export function HomeRoute() {
   const queryClient = useQueryClient();
   const addProjectRequest = useMutation({
     mutationFn: addProjectMutation,
+  });
+  const deleteProjectRequest = useMutation({
+    mutationFn: deleteProjectMutation,
   });
   const createChatRequest = useMutation({
     mutationFn: ({
@@ -921,6 +928,35 @@ export function HomeRoute() {
   );
 
   const pendingDeleteProject = useMemo(
+    () =>
+      deleteProjectTarget
+        ? (projects.find((project) => project.id === deleteProjectTarget) ??
+          null)
+        : null,
+    [deleteProjectTarget, projects],
+  );
+
+  const pendingDeleteProjectChats = useMemo(
+    () =>
+      deleteProjectTarget ? (chatsByProject[deleteProjectTarget] ?? []) : [],
+    [chatsByProject, deleteProjectTarget],
+  );
+
+  const pendingDeleteProjectBlockingChat = useMemo(
+    () =>
+      pendingDeleteProjectChats.find(
+        (chat) =>
+          chat.status === "running" ||
+          chat.status === "waitingForApproval" ||
+          Boolean(chat.activeTurnId) ||
+          Boolean(chat.hasQueuedMessages) ||
+          Boolean(chat.isDrainingQueuedMessages) ||
+          pendingSendChatIdsRef.current.has(chat.id),
+      ) ?? null,
+    [pendingDeleteProjectChats],
+  );
+
+  const pendingDeleteWorktreeProject = useMemo(
     () =>
       deleteWorktreeTarget
         ? (projects.find(
@@ -1776,6 +1812,72 @@ export function HomeRoute() {
     }
   }
 
+  function openDeleteProject(project: ProjectRecord) {
+    setError(null);
+    setDeleteProjectTarget(project.id);
+  }
+
+  function closeDeleteProjectDialog() {
+    setDeleteProjectTarget(null);
+  }
+
+  async function deleteSelectedProject(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!pendingDeleteProject || pendingDeleteProjectBlockingChat) {
+      return;
+    }
+
+    setError(null);
+    setIsBusy(true);
+    const projectId = pendingDeleteProject.id;
+    const deletedProjectChatIds = (
+      chatsByProjectRef.current[projectId] ?? []
+    ).map((chat) => chat.id);
+    const shouldClearComposerContext =
+      selectedProjectIdRef.current === projectId;
+    try {
+      await deleteProjectRequest.mutateAsync(projectId);
+      queryClient.removeQueries({
+        exact: true,
+        queryKey: queryKeys.projects,
+      });
+      queryClient.removeQueries({
+        queryKey: queryKeys.projectWorktrees(projectId),
+      });
+      queryClient.removeQueries({
+        queryKey: queryKeys.projectChats(projectId),
+      });
+      for (const chatId of deletedProjectChatIds) {
+        queryClient.removeQueries({ queryKey: queryKeys.chat(chatId) });
+      }
+      setExpandedWorktreeKeys((current) => {
+        const next = new Set<string>();
+        for (const key of current) {
+          if (!key.startsWith(`${projectId}:`)) {
+            next.add(key);
+          }
+        }
+        return next;
+      });
+      if (shouldClearComposerContext) {
+        setComposerText("");
+        setSelectedFiles([]);
+        setSelectedSkillPaths(new Set());
+        setTransientFileSearchQuery(null);
+        setFileSearchResults([]);
+        setSkills([]);
+        setPendingApproval(null);
+        restoredPendingComposerContextRef.current = null;
+      }
+      closeDeleteProjectDialog();
+      await refreshProjects();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setIsBusy(false);
+    }
+  }
+
   async function createProjectChat(
     projectId: string,
     requestWorkspaceSelectionKey: string,
@@ -2563,7 +2665,7 @@ export function HomeRoute() {
                           </SidebarMenuButton>
                           <Button
                             aria-label={`Create worktree in ${project.name}`}
-                            className="mr-1 size-7 text-[var(--icon-color-default)] group-data-[state=collapsed]/sidebar:hidden"
+                            className="size-7 text-[var(--icon-color-default)] group-data-[state=collapsed]/sidebar:hidden"
                             disabled={isBusy}
                             onClick={() => void createChat(project.id)}
                             size="icon"
@@ -2577,6 +2679,35 @@ export function HomeRoute() {
                               <MessageSquarePlus className="size-4" />
                             )}
                           </Button>
+                          <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                              <Button
+                                aria-label={`Open actions for ${project.name}`}
+                                className={cn(
+                                  "mr-1 size-7 text-[var(--icon-color-default)] opacity-100 data-[state=open]:opacity-100 group-data-[state=collapsed]/sidebar:hidden sm:opacity-0 sm:group-focus-within/project:opacity-100 sm:group-hover/project:opacity-100",
+                                  selectedProjectId === project.id &&
+                                    "sm:opacity-100",
+                                )}
+                                disabled={isBusy}
+                                size="icon"
+                                title="Project actions"
+                                type="button"
+                                variant="ghost"
+                              >
+                                <MoreHorizontal className="size-4" />
+                              </Button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent align="end">
+                              <DropdownMenuItem
+                                disabled={isBusy}
+                                onSelect={() => openDeleteProject(project)}
+                                variant="destructive"
+                              >
+                                <Trash2 className="size-4" />
+                                <span>Delete project</span>
+                              </DropdownMenuItem>
+                            </DropdownMenuContent>
+                          </DropdownMenu>
                         </div>
                         {isProjectExpanded && (
                           <SidebarMenuSub>
@@ -2846,6 +2977,69 @@ export function HomeRoute() {
       </Dialog>
 
       <Dialog
+        open={Boolean(deleteProjectTarget)}
+        onOpenChange={(open) => {
+          if (!open) {
+            closeDeleteProjectDialog();
+          }
+        }}
+      >
+        <DialogContent aria-labelledby="delete-project-title">
+          <DialogHeader>
+            <DialogTitle id="delete-project-title">Delete project</DialogTitle>
+            <DialogDescription>
+              Remove this project from the Phantom sidebar and delete its
+              Phantom chat history and messages. Local repository files and
+              worktrees are not deleted.
+            </DialogDescription>
+          </DialogHeader>
+          <form className="grid gap-4" onSubmit={deleteSelectedProject}>
+            <div className="grid gap-2 rounded-[var(--radius-sm)] bg-[var(--surface-code)] px-3 py-2">
+              <p className="truncate text-[length:var(--font-size-sm)] font-medium">
+                {pendingDeleteProject?.name ?? "Unknown project"}
+              </p>
+              {pendingDeleteProject && (
+                <p className="truncate font-mono text-[length:var(--font-size-xs)] text-muted-foreground">
+                  {pendingDeleteProject.rootPath}
+                </p>
+              )}
+            </div>
+            <p className="text-[length:var(--font-size-sm)] text-muted-foreground">
+              Projects with running, approval-blocked, or queued chats cannot be
+              deleted.
+            </p>
+            {pendingDeleteProjectBlockingChat && (
+              <div className="rounded-[var(--radius-sm)] border border-[var(--semantic-warning-border)] bg-[var(--semantic-warning-bg)] px-3 py-2 text-[length:var(--font-size-sm)] text-[var(--semantic-warning-fg)]">
+                Stop running, approval-blocked, or queued chats before deleting
+                this project.
+              </div>
+            )}
+            <DialogFooter>
+              <Button
+                onClick={closeDeleteProjectDialog}
+                type="button"
+                variant="outline"
+              >
+                Cancel
+              </Button>
+              <Button
+                disabled={
+                  isBusy ||
+                  !pendingDeleteProject ||
+                  Boolean(pendingDeleteProjectBlockingChat)
+                }
+                type="submit"
+                variant="destructive"
+              >
+                {isBusy && <LoadingSpinner />}
+                Delete project
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
         open={Boolean(deleteWorktreeTarget)}
         onOpenChange={(open) => {
           if (!open) {
@@ -2860,7 +3054,8 @@ export function HomeRoute() {
             </DialogTitle>
             <DialogDescription>
               This worktree has uncommitted changes. Force deletion is required
-              to remove it from {pendingDeleteProject?.name ?? "the project"}.
+              to remove it from{" "}
+              {pendingDeleteWorktreeProject?.name ?? "the project"}.
             </DialogDescription>
           </DialogHeader>
           <form className="grid gap-4" onSubmit={deleteSelectedWorktree}>


### PR DESCRIPTION
## Summary

Adds a project delete action to the Phantom sidebar project list.

## Details

- Adds a web API mutation for `DELETE /projects/:projectId`.
- Adds a project row actions menu with a destructive delete option.
- Adds a confirmation dialog that clarifies Phantom chat history is removed while local repository files and worktrees are not deleted.
- Blocks project deletion while the project has running, approval-blocked, queued, or queue-draining chats.
- Annotates chat records with queued/draining state so the sidebar delete flow can block unsafe removals before submitting.
- Clears stale project, chat, and context query state after removal.
- Covers encoded project IDs, server-side removal guards, stale transient state cleanup, and queued/draining chat annotations in tests.

## Validation

- `pnpm ready`
