### PR TITLE
[codex] add chat archiving

### DIFF
--- a/packages/codex/src/bridge.test.ts
+++ b/packages/codex/src/bridge.test.ts
@@ -183,6 +183,32 @@ describe("CodexBridge", () => {
     await expect(thread).resolves.toEqual({ thread: { id: "thread_1" } });
   });
 
+  it("archives and unarchives threads", async () => {
+    const { bridge, proc } = createBridge();
+    await initializeBridge(bridge, proc);
+
+    const archive = bridge.archiveThread("thread_1");
+    await vi.waitFor(() =>
+      expect(findWrite(proc, "thread/archive")).toBeDefined(),
+    );
+    const archiveRequest = findWrite(proc, "thread/archive");
+    expect(archiveRequest?.params).toEqual({ threadId: "thread_1" });
+    proc.send({ id: archiveRequest?.id, result: {} });
+    await expect(archive).resolves.toEqual({});
+
+    const unarchive = bridge.unarchiveThread("thread_1");
+    await vi.waitFor(() =>
+      expect(findWrite(proc, "thread/unarchive")).toBeDefined(),
+    );
+    const unarchiveRequest = findWrite(proc, "thread/unarchive");
+    expect(unarchiveRequest?.params).toEqual({ threadId: "thread_1" });
+    proc.send({
+      id: unarchiveRequest?.id,
+      result: { thread: { id: "thread_1" } },
+    });
+    await expect(unarchive).resolves.toEqual({ thread: { id: "thread_1" } });
+  });
+
   it("passes model, effort, file mentions, and skills to new turns", async () => {
     const { bridge, proc } = createBridge();
     await initializeBridge(bridge, proc);

--- a/packages/codex/src/bridge.ts
+++ b/packages/codex/src/bridge.ts
@@ -300,6 +300,18 @@ export class CodexBridge {
     });
   }
 
+  async archiveThread(threadId: string): Promise<unknown> {
+    return this.request("thread/archive", {
+      threadId,
+    });
+  }
+
+  async unarchiveThread(threadId: string): Promise<unknown> {
+    return this.request("thread/unarchive", {
+      threadId,
+    });
+  }
+
   async startThread(
     cwd: string,
     options: CodexTurnOptions = {},

--- a/packages/server/src/rpc.ts
+++ b/packages/server/src/rpc.ts
@@ -105,6 +105,10 @@ const approvalSchema = z.object({
   decision: z.enum(["accept", "acceptForSession", "decline", "cancel"]),
 });
 
+const archiveChatSchema = z.object({
+  archived: z.boolean(),
+});
+
 const chatQuerySchema = z.object({
   context: z.string().optional(),
   fileQuery: z.string().optional(),
@@ -331,6 +335,18 @@ export const rpcRoutes = new Hono()
         return c.json({ files }, 200);
       }
       const chat = await services.getChat(chatId);
+      return c.json({ chat }, 200);
+    } catch (error) {
+      return handleApiError(c, error);
+    }
+  })
+  .post("/chats/:chatId/archive", jsonBody(archiveChatSchema), async (c) => {
+    try {
+      const body = c.req.valid("json");
+      const chat = await getServeServices().setChatArchived(
+        c.req.param("chatId"),
+        body.archived,
+      );
       return c.json({ chat }, 200);
     } catch (error) {
       return handleApiError(c, error);

--- a/packages/server/src/services.test.ts
+++ b/packages/server/src/services.test.ts
@@ -45,6 +45,7 @@ class FakeCodexBridge {
   readonly notificationHandlers: Array<(message: CodexMessage) => void> = [];
   readonly processExitHandlers: Array<(error: Error) => void> = [];
   readonly serverRequestHandlers: Array<(message: CodexMessage) => void> = [];
+  readonly archiveThread = vi.fn();
   readonly exec = vi.fn();
   readonly interruptTurn = vi.fn();
   readonly listThreads = vi.fn();
@@ -58,6 +59,7 @@ class FakeCodexBridge {
   readonly startThread = vi.fn();
   readonly startTurn = vi.fn();
   readonly steerTurn = vi.fn();
+  readonly unarchiveThread = vi.fn();
 
   onNotification(handler: (message: CodexMessage) => void): () => void {
     this.notificationHandlers.push(handler);
@@ -1182,6 +1184,497 @@ describe("ServeServices", () => {
     const savedState = await store.load();
     strictEqual(savedState.chats.length, 1);
     deepStrictEqual(savedState.messages, []);
+  });
+
+  it("syncs Codex archived thread state when syncing metadata", async () => {
+    const threadId = "019dc000-0000-7000-8000-000000000001";
+    const worktreePath = "/repo/.git/phantom/worktrees/feature/list";
+    const { codex, services, store } = await createHarness({
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [
+        createChat({
+          codexThreadId: threadId,
+          status: "idle",
+          worktreeName: "feature/list",
+          worktreePath,
+        }),
+      ],
+    });
+    coreMocks.listWorktrees.mockResolvedValue({
+      ok: true,
+      value: {
+        worktrees: [
+          {
+            name: "feature/list",
+            path: worktreePath,
+            pathToDisplay: ".git/phantom/worktrees/feature/list",
+            branch: "feature/list",
+            isClean: true,
+          },
+        ],
+      },
+    });
+    codex.listThreads.mockResolvedValueOnce({ threads: [] });
+    codex.listThreads.mockResolvedValueOnce({
+      threads: [
+        {
+          id: threadId,
+          cwd: worktreePath,
+          title: "Existing work",
+          createdAt: "2026-04-25T00:00:00.000Z",
+          updatedAt: "2026-04-25T00:03:00.000Z",
+        },
+      ],
+    });
+
+    const chats = await services.listChats("proj_1");
+
+    strictEqual(chats[0]?.status, "archived");
+    strictEqual((await store.load()).chats[0]?.status, "archived");
+    strictEqual(codex.listThreads.mock.calls[0]?.[0]?.archived, false);
+    strictEqual(codex.listThreads.mock.calls[1]?.[0]?.archived, true);
+  });
+
+  it("rejects unsafe Codex archived metadata and restores Codex", async () => {
+    const threadId = "019dc000-0000-7000-8000-000000000001";
+    const worktreePath = "/repo/.git/phantom/worktrees/feature/list";
+    const { codex, services, store } = await createHarness({
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [
+        createChat({
+          activeTurnId: "turn_1",
+          codexThreadId: threadId,
+          status: "running",
+          worktreeName: "feature/list",
+          worktreePath,
+        }),
+      ],
+    });
+    markChatActiveInCurrentProcess(services, "chat_1");
+    coreMocks.listWorktrees.mockResolvedValue({
+      ok: true,
+      value: {
+        worktrees: [
+          {
+            name: "feature/list",
+            path: worktreePath,
+            pathToDisplay: ".git/phantom/worktrees/feature/list",
+            branch: "feature/list",
+            isClean: true,
+          },
+        ],
+      },
+    });
+    codex.listThreads.mockResolvedValueOnce({ threads: [] });
+    codex.listThreads.mockResolvedValueOnce({
+      threads: [
+        {
+          id: threadId,
+          cwd: worktreePath,
+          title: "Existing work",
+          createdAt: "2026-04-25T00:00:00.000Z",
+          updatedAt: "2026-04-25T00:03:00.000Z",
+        },
+      ],
+    });
+
+    const chats = await services.listChats("proj_1");
+    const savedChat = (await store.load()).chats[0];
+
+    strictEqual(chats[0]?.status, "running");
+    strictEqual(chats[0]?.activeTurnId, "turn_1");
+    strictEqual(savedChat?.status, "running");
+    strictEqual(savedChat?.activeTurnId, "turn_1");
+    deepStrictEqual(codex.unarchiveThread.mock.calls, [[threadId]]);
+  });
+
+  it("rejects Codex archived metadata while local messages are queued", async () => {
+    const threadId = "019dc000-0000-7000-8000-000000000001";
+    const worktreePath = "/repo/.git/phantom/worktrees/feature/list";
+    const { codex, services, store } = await createHarness({
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [
+        createChat({
+          codexThreadId: threadId,
+          worktreeName: "feature/list",
+          worktreePath,
+        }),
+      ],
+      queuedMessages: [
+        {
+          id: "queue_1",
+          chatId: "chat_1",
+          messageId: "msg_queued",
+          text: "queued draft",
+          createdAt: timestamp,
+        },
+      ],
+    });
+    coreMocks.listWorktrees.mockResolvedValue({
+      ok: true,
+      value: {
+        worktrees: [
+          {
+            name: "feature/list",
+            path: worktreePath,
+            pathToDisplay: ".git/phantom/worktrees/feature/list",
+            branch: "feature/list",
+            isClean: true,
+          },
+        ],
+      },
+    });
+    codex.listThreads.mockResolvedValueOnce({ threads: [] });
+    codex.listThreads.mockResolvedValueOnce({
+      threads: [
+        {
+          id: threadId,
+          cwd: worktreePath,
+          title: "Existing work",
+          createdAt: "2026-04-25T00:00:00.000Z",
+          updatedAt: "2026-04-25T00:03:00.000Z",
+        },
+      ],
+    });
+
+    const chats = await services.listChats("proj_1");
+    const savedState = await store.load();
+
+    strictEqual(chats[0]?.status, "idle");
+    strictEqual(savedState.chats[0]?.status, "idle");
+    strictEqual(savedState.queuedMessages.length, 1);
+    deepStrictEqual(codex.unarchiveThread.mock.calls, [[threadId]]);
+  });
+
+  it("syncs Codex unarchived thread state when syncing metadata", async () => {
+    const threadId = "019dc000-0000-7000-8000-000000000001";
+    const worktreePath = "/repo/.git/phantom/worktrees/feature/list";
+    const { codex, services, store } = await createHarness({
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [
+        createChat({
+          codexThreadId: threadId,
+          status: "archived",
+          worktreeName: "feature/list",
+          worktreePath,
+        }),
+      ],
+    });
+    coreMocks.listWorktrees.mockResolvedValue({
+      ok: true,
+      value: {
+        worktrees: [
+          {
+            name: "feature/list",
+            path: worktreePath,
+            pathToDisplay: ".git/phantom/worktrees/feature/list",
+            branch: "feature/list",
+            isClean: true,
+          },
+        ],
+      },
+    });
+    codex.listThreads.mockResolvedValueOnce({
+      threads: [
+        {
+          id: threadId,
+          cwd: worktreePath,
+          title: "Existing work",
+          createdAt: "2026-04-25T00:00:00.000Z",
+          updatedAt: "2026-04-25T00:03:00.000Z",
+        },
+      ],
+    });
+    codex.listThreads.mockResolvedValueOnce({ threads: [] });
+
+    const chats = await services.listChats("proj_1");
+
+    strictEqual(chats[0]?.status, "idle");
+    strictEqual((await store.load()).chats[0]?.status, "idle");
+  });
+
+  it("archives and restores idle chats", async () => {
+    const { codex, services, store } = await createHarness({
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat()],
+    });
+
+    const archivedChat = await services.setChatArchived("chat_1", true);
+    const restoredChat = await services.setChatArchived("chat_1", false);
+
+    strictEqual(archivedChat.status, "archived");
+    strictEqual(archivedChat.activeTurnId, null);
+    strictEqual(restoredChat.status, "idle");
+    strictEqual((await store.load()).chats[0]?.status, "idle");
+    deepStrictEqual(codex.archiveThread.mock.calls, [["thread_1"]]);
+    deepStrictEqual(codex.unarchiveThread.mock.calls, [["thread_1"]]);
+  });
+
+  it("archives local chats without Codex threads locally", async () => {
+    const { codex, services, store } = await createHarness({
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ codexThreadId: null })],
+    });
+
+    const archivedChat = await services.setChatArchived("chat_1", true);
+
+    strictEqual(archivedChat.status, "archived");
+    strictEqual((await store.load()).chats[0]?.status, "archived");
+    strictEqual(codex.archiveThread.mock.calls.length, 0);
+    strictEqual(codex.unarchiveThread.mock.calls.length, 0);
+  });
+
+  it("does not update local archive state when Codex archive fails", async () => {
+    const { codex, services, store } = await createHarness({
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat()],
+    });
+    codex.archiveThread.mockRejectedValueOnce(new Error("archive failed"));
+
+    await rejects(services.setChatArchived("chat_1", true), /archive failed/);
+
+    strictEqual((await store.load()).chats[0]?.status, "idle");
+  });
+
+  it("blocks messages while Codex archive is in progress", async () => {
+    const { codex, services, store } = await createHarness({
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat()],
+    });
+    let resolveArchive!: () => void;
+    const archivePromise = new Promise<void>((resolve) => {
+      resolveArchive = resolve;
+    });
+    codex.archiveThread.mockReturnValueOnce(archivePromise);
+
+    const archive = services.setChatArchived("chat_1", true);
+    await vi.waitFor(() => {
+      strictEqual(codex.archiveThread.mock.calls.length, 1);
+    });
+
+    await rejects(
+      services.sendMessage("chat_1", { text: "racing message" }),
+      /archive state is already changing/,
+    );
+
+    resolveArchive();
+    const archivedChat = await archive;
+    const savedState = await store.load();
+    strictEqual(archivedChat.status, "archived");
+    strictEqual(savedState.chats[0]?.status, "archived");
+    strictEqual(savedState.messages.length, 0);
+    strictEqual(savedState.queuedMessages.length, 0);
+  });
+
+  it("ignores turn state changes while Codex archive is in progress", async () => {
+    const { codex, services, store } = await createHarness({
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat()],
+    });
+    const emitSpy = vi.spyOn(services.eventHub, "emit");
+    let resolveArchive!: () => void;
+    const archivePromise = new Promise<void>((resolve) => {
+      resolveArchive = resolve;
+    });
+    codex.archiveThread.mockReturnValueOnce(archivePromise);
+
+    const archive = services.setChatArchived("chat_1", true);
+    await vi.waitFor(() => {
+      strictEqual(codex.archiveThread.mock.calls.length, 1);
+    });
+
+    codex.emitNotification({
+      method: "turn/started",
+      params: {
+        threadId: "thread_1",
+        turn: { id: "turn_1" },
+      },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    resolveArchive();
+    const archivedChat = await archive;
+    const savedState = await store.load();
+    strictEqual(archivedChat.status, "archived");
+    strictEqual(savedState.chats[0]?.status, "archived");
+    strictEqual(savedState.chats[0]?.activeTurnId, null);
+    strictEqual(
+      emitSpy.mock.calls.some((call) => call[0] === "agent.turn.started"),
+      false,
+    );
+  });
+
+  it("does not alter non-archived chats when restore is requested", async () => {
+    const { services, store } = await createHarness({
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [
+        createChat({
+          activeTurnId: "turn_1",
+          status: "running",
+        }),
+      ],
+    });
+    markChatActiveInCurrentProcess(services, "chat_1");
+
+    const restoredChat = await services.setChatArchived("chat_1", false);
+    const savedChat = (await store.load()).chats[0];
+
+    strictEqual(restoredChat.status, "running");
+    strictEqual(restoredChat.activeTurnId, "turn_1");
+    strictEqual(savedChat?.status, "running");
+    strictEqual(savedChat?.activeTurnId, "turn_1");
+  });
+
+  it("rejects archiving active chats and sending messages to archived chats", async () => {
+    const { services } = await createHarness({
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ activeTurnId: "turn_1", status: "running" })],
+    });
+    markChatActiveInCurrentProcess(services, "chat_1");
+
+    await rejects(
+      services.setChatArchived("chat_1", true),
+      /Cannot archive a chat/,
+    );
+
+    const { services: inProcessServices } = await createHarness({
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat()],
+    });
+    markChatActiveInCurrentProcess(inProcessServices, "chat_1");
+    await rejects(
+      inProcessServices.setChatArchived("chat_1", true),
+      /Cannot archive a chat/,
+    );
+
+    const { services: queuedServices } = await createHarness({
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat()],
+      queuedMessages: [
+        {
+          id: "queue_1",
+          chatId: "chat_1",
+          messageId: "msg_queued",
+          text: "queued draft",
+          createdAt: timestamp,
+        },
+      ],
+    });
+    await rejects(
+      queuedServices.setChatArchived("chat_1", true),
+      /Cannot archive a chat with pending messages/,
+    );
+
+    const { services: drainingServices } = await createHarness({
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat()],
+    });
+    markChatDrainingQueuedMessages(drainingServices, "chat_1");
+    await rejects(
+      drainingServices.setChatArchived("chat_1", true),
+      /Cannot archive a chat while queued messages are sending/,
+    );
+
+    const { services: archivedServices } = await createHarness({
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "archived" })],
+    });
+    await rejects(
+      archivedServices.sendMessage("chat_1", { text: "continue" }),
+      /Archived chats must be restored/,
+    );
+  });
+
+  it("ignores live Codex state changes for archived chats", async () => {
+    const { codex, services, store } = await createHarness({
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "archived" })],
+    });
+    const emitSpy = vi.spyOn(services.eventHub, "emit");
+
+    codex.emitNotification({
+      method: "turn/started",
+      params: {
+        threadId: "thread_1",
+        turn: { id: "turn_1" },
+      },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const savedState = await store.load();
+    strictEqual(savedState.chats[0]?.status, "archived");
+    strictEqual(savedState.chats[0]?.activeTurnId, null);
+    strictEqual(
+      emitSpy.mock.calls.some((call) => call[0] === "agent.turn.started"),
+      false,
+    );
+  });
+
+  it("syncs live Codex archive notifications", async () => {
+    const { codex, store } = await createHarness({
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat()],
+    });
+
+    codex.emitNotification({
+      method: "thread/archived",
+      params: { threadId: "thread_1" },
+    });
+    await vi.waitFor(async () => {
+      strictEqual((await store.load()).chats[0]?.status, "archived");
+    });
+
+    codex.emitNotification({
+      method: "thread/unarchived",
+      params: { threadId: "thread_1" },
+    });
+    await vi.waitFor(async () => {
+      strictEqual((await store.load()).chats[0]?.status, "idle");
+    });
+  });
+
+  it("rejects unsafe live Codex archive notifications and restores Codex", async () => {
+    const { codex, services, store } = await createHarness({
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ activeTurnId: "turn_1", status: "running" })],
+    });
+    markChatActiveInCurrentProcess(services, "chat_1");
+    const emitSpy = vi.spyOn(services.eventHub, "emit");
+
+    codex.emitNotification({
+      method: "thread/archived",
+      params: { threadId: "thread_1" },
+    });
+
+    await vi.waitFor(() => {
+      strictEqual(codex.unarchiveThread.mock.calls.length, 1);
+    });
+    const savedChat = (await store.load()).chats[0];
+    strictEqual(savedChat?.status, "running");
+    strictEqual(savedChat?.activeTurnId, "turn_1");
+    deepStrictEqual(codex.unarchiveThread.mock.calls, [["thread_1"]]);
+    strictEqual(
+      emitSpy.mock.calls.some((call) => call[0] === "agent.event"),
+      false,
+    );
   });
 
   it("keeps duplicate local messages that have not appeared in thread history yet", async () => {
@@ -5872,6 +6365,45 @@ describe("ServeServices", () => {
       emitSpy.mock.calls.some((call) => call[0] === "chat.message.created"),
       true,
     );
+  });
+
+  it("rejects restoring deleted pending messages into archived chats", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "archived" })],
+      messages: [],
+      queuedMessages: [],
+    };
+    const { codex, services, store } = await createHarness(state);
+
+    await rejects(
+      services.restorePendingMessage("chat_1", {
+        message: {
+          id: "msg_queued",
+          chatId: "chat_1",
+          role: "user",
+          text: "queued draft",
+          eventType: "chat.message.queued",
+          createdAt: timestamp,
+        },
+        messageIndex: 0,
+        queuedMessage: {
+          id: "queue_1",
+          chatId: "chat_1",
+          messageId: "msg_queued",
+          text: "queued draft",
+          createdAt: timestamp,
+        },
+        queuedMessageIndex: 0,
+      }),
+      /Archived chats must be restored/,
+    );
+
+    const savedState = await store.load();
+    strictEqual(savedState.messages.length, 0);
+    strictEqual(savedState.queuedMessages.length, 0);
+    strictEqual(codex.startTurn.mock.calls.length, 0);
   });
 
   it("restarts queued drain after restoring a pending message into an idle chat", async () => {

--- a/packages/server/src/services.ts
+++ b/packages/server/src/services.ts
@@ -260,6 +260,7 @@ export class ServeServices {
   private readonly drainingQueuedMessageChatIds = new Set<string>();
   private readonly pendingQueuedMessageDrainChatIds = new Set<string>();
   private readonly activeTurnChatIds = new Set<string>();
+  private readonly archiveOperationChatIds = new Set<string>();
   private readonly activeWorktreeOperationLocks = new Map<string, number>();
   private readonly reportedAgentErrors = new WeakSet<object>();
 
@@ -429,6 +430,10 @@ export class ServeServices {
       )
       .filter((chat): chat is ChatRecord => Boolean(chat));
 
+    const rejectedArchivedThreadChats: Array<{
+      chat: ChatRecord;
+      reason: string;
+    }> = [];
     await this.store.update((nextState) => {
       const existingProjectChats = nextState.chats.filter(
         (chat) => chat.projectId === projectId,
@@ -444,15 +449,39 @@ export class ServeServices {
         if (!existingChat) {
           return chat;
         }
+        const archiveBlockMessage =
+          chat.status === "archived"
+            ? this.getChatArchiveBlockMessage(nextState, existingChat, true)
+            : null;
+        if (archiveBlockMessage) {
+          rejectedArchivedThreadChats.push({
+            chat: existingChat,
+            reason: archiveBlockMessage,
+          });
+          return {
+            ...chat,
+            id: existingChat.id,
+            status: existingChat.status,
+            activeTurnId: existingChat.activeTurnId,
+            createdAt: existingChat.createdAt,
+          };
+        }
+        const shouldPreserveActiveChatState =
+          chat.status !== "archived" &&
+          (isChatActive(existingChat, this.pendingChatTurns) ||
+            this.isChatActiveInCurrentProcess(existingChat));
         return {
           ...chat,
           id: existingChat.id,
-          status: isChatActive(existingChat, this.pendingChatTurns)
+          status: shouldPreserveActiveChatState
             ? existingChat.status
             : chat.status,
-          activeTurnId: isChatActive(existingChat, this.pendingChatTurns)
-            ? existingChat.activeTurnId
-            : null,
+          activeTurnId:
+            chat.status === "archived"
+              ? null
+              : shouldPreserveActiveChatState
+                ? existingChat.activeTurnId
+                : null,
           createdAt: existingChat.createdAt,
         };
       });
@@ -505,6 +534,11 @@ export class ServeServices {
         selectedChatId,
       };
     });
+    await Promise.all(
+      rejectedArchivedThreadChats.map(({ chat, reason }) =>
+        this.restoreRejectedCodexArchive(chat, reason),
+      ),
+    );
 
     const syncedState = await this.store.load();
     return annotateTransientChatState(
@@ -597,24 +631,33 @@ export class ServeServices {
       return [];
     }
 
-    const threads: CodexThreadRecord[] = [];
-    let cursor: string | null = null;
-    do {
-      const result = await this.codex.listThreads({
-        archived: false,
-        cursor,
-        cwd,
-        limit: 100,
-        sourceKinds: ["cli", "vscode", "appServer"],
-        sortDirection: "desc",
-        sortKey: "updated_at",
-        useStateDbOnly: true,
-      });
-      threads.push(...normalizeCodexThreadList(result));
-      cursor = normalizeCodexCursor(result, "nextCursor");
-    } while (cursor);
+    const threadsById = new Map<string, CodexThreadRecord>();
+    for (const archived of [false, true]) {
+      let cursor: string | null = null;
+      do {
+        const result = await this.codex.listThreads({
+          archived,
+          cursor,
+          cwd,
+          limit: 100,
+          sourceKinds: ["cli", "vscode", "appServer"],
+          sortDirection: "desc",
+          sortKey: "updated_at",
+          useStateDbOnly: true,
+        });
+        for (const thread of normalizeCodexThreadList(result)) {
+          const nextThread: CodexThreadRecord = archived
+            ? { ...thread, status: "archived" }
+            : thread;
+          if (!archived || !threadsById.has(thread.id)) {
+            threadsById.set(thread.id, nextThread);
+          }
+        }
+        cursor = normalizeCodexCursor(result, "nextCursor");
+      } while (cursor);
+    }
 
-    return threads;
+    return Array.from(threadsById.values());
   }
 
   async listProjectGitHubCheckoutTargets(
@@ -1053,6 +1096,70 @@ export class ServeServices {
     return null;
   }
 
+  async setChatArchived(
+    chatId: string,
+    archived: boolean,
+  ): Promise<ChatRecord> {
+    await this.resetStaleTransientChatState();
+    const initialState = await this.store.load();
+    const initialChat = this.requireChat(initialState, chatId);
+    if (this.archiveOperationChatIds.has(chatId)) {
+      throw new Error("Chat archive state is already changing");
+    }
+    if (!archived && initialChat.status !== "archived") {
+      return initialChat;
+    }
+    this.assertCanSetChatArchived(initialState, initialChat, archived);
+    this.archiveOperationChatIds.add(chatId);
+    try {
+      if (initialChat.codexThreadId) {
+        if (archived) {
+          await this.codex.archiveThread(initialChat.codexThreadId);
+        } else {
+          await this.codex.unarchiveThread(initialChat.codexThreadId);
+        }
+      }
+
+      let updatedChat: ChatRecord | null = null;
+      let didUpdate = false;
+      await this.store.update((state) => {
+        const chat = this.requireChat(state, chatId);
+        if (!archived && chat.status !== "archived") {
+          updatedChat = chat;
+          return state;
+        }
+        this.assertCanSetChatArchived(state, chat, archived);
+
+        const nextChat: ChatRecord = {
+          ...chat,
+          status: archived ? "archived" : "idle",
+          activeTurnId: null,
+          updatedAt: createTimestamp(),
+        };
+        updatedChat = nextChat;
+        didUpdate = true;
+
+        return {
+          ...state,
+          chats: state.chats.map((candidate) =>
+            candidate.id === chatId ? nextChat : candidate,
+          ),
+        };
+      });
+
+      if (!updatedChat) {
+        throw new Error(`Chat '${chatId}' not found`);
+      }
+      if (!didUpdate) {
+        return updatedChat;
+      }
+      this.eventHub.emit("chat.updated", updatedChat, { chatId });
+      return updatedChat;
+    } finally {
+      this.archiveOperationChatIds.delete(chatId);
+    }
+  }
+
   async getMessages(chatId: string): Promise<ChatMessageRecord[]> {
     await this.resetStaleTransientChatState();
     const state = await this.store.load();
@@ -1121,6 +1228,7 @@ export class ServeServices {
     let queuedUserMessage: ChatMessageRecord | null = null;
     await this.store.update((nextState) => {
       const chat = this.requireChat(nextState, chatId);
+      this.assertChatCanReceiveMessage(chat);
       this.assertChatWorktreeIsAvailable(chat);
       const isDrainingQueuedMessage =
         this.drainingQueuedMessageChatIds.has(chatId);
@@ -1264,6 +1372,7 @@ export class ServeServices {
 
     await this.store.update((nextState) => {
       const chat = this.requireChat(nextState, chatId);
+      this.assertChatCanReceiveMessage(chat);
       this.assertChatWorktreeIsAvailable(chat);
       const isDrainingQueuedMessage =
         this.drainingQueuedMessageChatIds.has(chatId);
@@ -1321,6 +1430,7 @@ export class ServeServices {
 
     const state = await this.store.load();
     const chat = this.requireChat(state, chatId);
+    this.assertChatCanReceiveMessage(chat);
     if (chat.status === "waitingForApproval") {
       throw new Error("Chat is waiting for approval");
     }
@@ -1899,6 +2009,9 @@ export class ServeServices {
   private async drainQueuedMessages(chatId: string): Promise<void> {
     const state = await this.store.load();
     const chat = this.requireChat(state, chatId);
+    if (chat.status === "archived") {
+      return;
+    }
     if (isChatInActiveTurn(chat) || this.pendingChatTurns.has(chatId)) {
       return;
     }
@@ -2044,6 +2157,17 @@ export class ServeServices {
     if (this.isWorktreeOperationActive(chat.worktreePath)) {
       throw new Error(
         `Worktree '${chat.worktreeName}' is busy. Wait for the current worktree operation to finish before sending messages.`,
+      );
+    }
+  }
+
+  private assertChatCanReceiveMessage(chat: ChatRecord): void {
+    if (this.archiveOperationChatIds.has(chat.id)) {
+      throw new Error("Chat archive state is already changing");
+    }
+    if (chat.status === "archived") {
+      throw new Error(
+        "Archived chats must be restored before sending messages",
       );
     }
   }
@@ -2280,6 +2404,21 @@ export class ServeServices {
     method: string,
     params: unknown,
   ): Promise<boolean> {
+    const state = await this.store.load();
+    const chat = this.requireChat(state, chatId);
+    if (method === "thread/archived" || method === "thread/unarchived") {
+      return await this.updateChatArchiveStatusFromCodex(
+        chatId,
+        method === "thread/archived",
+      );
+    }
+    if (this.archiveOperationChatIds.has(chatId)) {
+      return false;
+    }
+    if (chat.status === "archived") {
+      return false;
+    }
+
     if (method === "turn/started") {
       this.activeTurnChatIds.add(chatId);
       await this.updateChatStatus(
@@ -2316,6 +2455,52 @@ export class ServeServices {
       await this.updateChatStatus(chatId, "running", undefined);
     }
     return true;
+  }
+
+  private async updateChatArchiveStatusFromCodex(
+    chatId: string,
+    archived: boolean,
+  ): Promise<boolean> {
+    let blockedChat: ChatRecord | null = null;
+    let blockMessage: string | null = null;
+    let didUpdate = false;
+    await this.store.update((state) => {
+      const chat = this.requireChat(state, chatId);
+      if (archived) {
+        const nextBlockMessage = this.getChatArchiveBlockMessage(
+          state,
+          chat,
+          true,
+        );
+        if (nextBlockMessage) {
+          blockedChat = chat;
+          blockMessage = nextBlockMessage;
+          return state;
+        }
+      } else if (chat.status !== "archived") {
+        return state;
+      }
+
+      const nextChat: ChatRecord = {
+        ...chat,
+        status: archived ? "archived" : "idle",
+        activeTurnId: null,
+        updatedAt: createTimestamp(),
+      };
+      didUpdate = true;
+      return {
+        ...state,
+        chats: state.chats.map((candidate) =>
+          candidate.id === chatId ? nextChat : candidate,
+        ),
+      };
+    });
+
+    if (blockedChat && blockMessage) {
+      await this.restoreRejectedCodexArchive(blockedChat, blockMessage);
+      return false;
+    }
+    return didUpdate;
   }
 
   private async resetStaleTransientChatState(): Promise<void> {
@@ -2357,6 +2542,62 @@ export class ServeServices {
     );
   }
 
+  private assertCanSetChatArchived(
+    state: ServeState,
+    chat: ChatRecord,
+    archived: boolean,
+  ): void {
+    const blockMessage = this.getChatArchiveBlockMessage(state, chat, archived);
+    if (blockMessage) {
+      throw new Error(blockMessage);
+    }
+  }
+
+  private getChatArchiveBlockMessage(
+    state: ServeState,
+    chat: ChatRecord,
+    archived: boolean,
+  ): string | null {
+    if (!archived) {
+      return null;
+    }
+    if (
+      isChatActive(chat, this.pendingChatTurns) ||
+      this.isChatActiveInCurrentProcess(chat)
+    ) {
+      return "Cannot archive a chat with an active Codex turn";
+    }
+    if (this.drainingQueuedMessageChatIds.has(chat.id)) {
+      return "Cannot archive a chat while queued messages are sending";
+    }
+    if (state.queuedMessages.some((message) => message.chatId === chat.id)) {
+      return "Cannot archive a chat with pending messages";
+    }
+    return null;
+  }
+
+  private async restoreRejectedCodexArchive(
+    chat: ChatRecord,
+    reason: string,
+  ): Promise<void> {
+    if (!chat.codexThreadId) {
+      return;
+    }
+    try {
+      await this.codex.unarchiveThread(chat.codexThreadId);
+    } catch (error) {
+      this.eventHub.emit(
+        "agent.error",
+        {
+          message: "Codex archived a chat that Phantom could not archive",
+          reason,
+          error: toErrorMessage(error),
+        },
+        { chatId: chat.id },
+      );
+    }
+  }
+
   private hasApprovalRequestForChat(chatId: string): boolean {
     for (const approvalRequest of this.approvalRequests.values()) {
       if (approvalRequest.chatId === chatId) {
@@ -2392,13 +2633,18 @@ export class ServeServices {
       ...state,
       chats: state.chats.map((chat) =>
         chat.id === chatId
-          ? {
-              ...chat,
-              status,
-              activeTurnId:
-                activeTurnId === undefined ? chat.activeTurnId : activeTurnId,
-              updatedAt: createTimestamp(),
-            }
+          ? chat.status === "archived"
+            ? {
+                ...chat,
+                activeTurnId: null,
+              }
+            : {
+                ...chat,
+                status,
+                activeTurnId:
+                  activeTurnId === undefined ? chat.activeTurnId : activeTurnId,
+                updatedAt: createTimestamp(),
+              }
           : chat,
       ),
     }));
@@ -2888,8 +3134,13 @@ function latestChatForWorktree(chats: ChatRecord[]): ChatRecord | null {
   const sortedChats = [...chats].sort((left, right) =>
     right.updatedAt.localeCompare(left.updatedAt),
   );
+  const selectableChats = sortedChats.some((chat) => chat.status !== "archived")
+    ? sortedChats.filter((chat) => chat.status !== "archived")
+    : sortedChats;
   return (
-    sortedChats.find((chat) => chat.codexThreadId) ?? sortedChats[0] ?? null
+    selectableChats.find((chat) => chat.codexThreadId) ??
+    selectableChats[0] ??
+    null
   );
 }
 

--- a/packages/web/src/api/mutations.test.ts
+++ b/packages/web/src/api/mutations.test.ts
@@ -2,6 +2,7 @@ import { strictEqual } from "node:assert";
 import { afterEach, describe, it, vi } from "vitest";
 import {
   answerApprovalMutation,
+  archiveChatMutation,
   createChatMutation,
   deleteProjectMutation,
   deletePendingMessageMutation,
@@ -135,6 +136,36 @@ describe("deleteProjectMutation", () => {
 
     strictEqual(requestMethod, "DELETE");
     strictEqual(requestUrl, "/api/projects/proj%2Fwith%23hash");
+  });
+});
+
+describe("archiveChatMutation", () => {
+  it("encodes chat route params and sends archive state", async () => {
+    let requestBody: string | undefined;
+    let requestUrl: string | undefined;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        requestBody = init?.body?.toString();
+        requestUrl =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+        return new Response('{"chat":{"id":"chat_1"}}', {
+          headers: {
+            "Content-Type": "application/json",
+          },
+          status: 200,
+        });
+      }),
+    );
+
+    await archiveChatMutation("chat/with#hash", true);
+
+    strictEqual(requestUrl, "/api/chats/chat%2Fwith%23hash/archive");
+    strictEqual(requestBody, JSON.stringify({ archived: true }));
   });
 });
 

--- a/packages/web/src/api/mutations.ts
+++ b/packages/web/src/api/mutations.ts
@@ -67,6 +67,15 @@ export async function createChatMutation(
   );
 }
 
+export async function archiveChatMutation(chatId: string, archived: boolean) {
+  return readRpcJson<{ chat: ChatRecord }>(
+    await api.chats[":chatId"].archive.$post({
+      param: { chatId: routeParam(chatId) },
+      json: { archived },
+    }),
+  );
+}
+
 export async function deleteWorktreeMutation(
   projectId: string,
   input: DeleteWorktreeInput,

--- a/packages/web/src/routes/home-url-state.test.ts
+++ b/packages/web/src/routes/home-url-state.test.ts
@@ -181,6 +181,44 @@ describe("mergeWorktreesWithChats", () => {
       },
     ]);
   });
+
+  it("prefers a non-archived chat over a newer archived chat", () => {
+    const worktrees = [
+      {
+        name: "feature",
+        path: "/repo/feature",
+        chatId: null,
+        chatStatus: null,
+        chatTitle: "feature",
+      },
+    ];
+    const chats = [
+      {
+        id: "chat-current",
+        worktreePath: "/repo/feature",
+        title: "current",
+        status: "idle",
+        updatedAt: "2026-04-25T00:00:00.000Z",
+      },
+      {
+        id: "chat-archived",
+        worktreePath: "/repo/feature",
+        title: "archived",
+        status: "archived",
+        updatedAt: "2026-04-25T00:01:00.000Z",
+      },
+    ];
+
+    expect(mergeWorktreesWithChats(worktrees, chats)).toEqual([
+      {
+        name: "feature",
+        path: "/repo/feature",
+        chatId: "chat-current",
+        chatStatus: "idle",
+        chatTitle: "current",
+      },
+    ]);
+  });
 });
 
 describe("isKnownWorktreeChat", () => {

--- a/packages/web/src/routes/home-url-state.ts
+++ b/packages/web/src/routes/home-url-state.ts
@@ -22,7 +22,7 @@ interface SkillSelectionRecord {
   path: string;
 }
 
-interface WorktreeChatMergeRecord<TStatus> {
+interface WorktreeChatMergeRecord<TStatus extends string> {
   id: string;
   status: TStatus;
   title: string;
@@ -30,7 +30,7 @@ interface WorktreeChatMergeRecord<TStatus> {
   worktreePath: string;
 }
 
-interface WorktreeMergeRecord<TStatus> {
+interface WorktreeMergeRecord<TStatus extends string> {
   chatId: string | null;
   chatStatus: TStatus | null;
   chatTitle: string;
@@ -124,14 +124,22 @@ export function retainRecordsForProjects<TRecord>(
 }
 
 export function mergeWorktreesWithChats<
-  TStatus,
+  TStatus extends string,
   TWorktree extends WorktreeMergeRecord<TStatus>,
   TChat extends WorktreeChatMergeRecord<TStatus>,
 >(worktrees: TWorktree[], chats: TChat[]): TWorktree[] {
   const latestChatsByPath = new Map<string, TChat>();
   for (const chat of chats) {
     const current = latestChatsByPath.get(chat.worktreePath);
-    if (!current || chat.updatedAt.localeCompare(current.updatedAt) > 0) {
+    if (
+      !current ||
+      (current.status === "archived" && chat.status !== "archived") ||
+      (current.status === chat.status &&
+        chat.updatedAt.localeCompare(current.updatedAt) > 0) ||
+      (current.status !== "archived" &&
+        chat.status !== "archived" &&
+        chat.updatedAt.localeCompare(current.updatedAt) > 0)
+    ) {
       latestChatsByPath.set(chat.worktreePath, chat);
     }
   }

--- a/packages/web/src/routes/home.tsx
+++ b/packages/web/src/routes/home.tsx
@@ -1,5 +1,7 @@
 import {
   AlertTriangle,
+  Archive,
+  ArchiveRestore,
   Bot,
   Brain,
   CheckCircle2,
@@ -42,6 +44,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   answerApprovalMutation,
   addProjectMutation,
+  archiveChatMutation,
   createChatMutation,
   deleteProjectMutation,
   deletePendingMessageMutation,
@@ -231,6 +234,15 @@ const statusMeta: Record<
 
 type PendingApproval = PendingApprovalRecord & { chatId: string };
 type PendingApprovalEventData = PendingApprovalRecord;
+
+function canArchiveChat(chat: ChatRecord): boolean {
+  return (
+    chat.status !== "archived" &&
+    chat.status !== "running" &&
+    chat.status !== "waitingForApproval" &&
+    !chat.activeTurnId
+  );
+}
 
 interface DeleteWorktreeTarget {
   forceRequired: boolean;
@@ -586,6 +598,9 @@ export function HomeRoute() {
   const [pendingComposerMode, setPendingComposerMode] =
     useState<ComposerSubmitMode | null>(null);
   const [isInterrupting, setIsInterrupting] = useState(false);
+  const [archiveTransitionChatId, setArchiveTransitionChatId] = useState<
+    string | null
+  >(null);
   const createChatInFlightRef = useRef(false);
   const chatTimelineRef = useRef<HTMLElement | null>(null);
   const isChatTimelinePinnedToBottomRef = useRef(true);
@@ -712,6 +727,10 @@ export function HomeRoute() {
       decision: "accept" | "acceptForSession" | "decline" | "cancel";
       requestId: string;
     }) => answerApprovalMutation(chatId, requestId, decision),
+  });
+  const archiveChatRequest = useMutation({
+    mutationFn: ({ archived, chatId }: { archived: boolean; chatId: string }) =>
+      archiveChatMutation(chatId, archived),
   });
 
   function clearToastTimer(id: number) {
@@ -920,6 +939,7 @@ export function HomeRoute() {
     ),
   );
   const hasActiveTurn = Boolean(selectedChat?.activeTurnId);
+  const isSelectedChatArchived = selectedChat?.status === "archived";
   const isChatRunning = selectedChat?.status === "running" && hasActiveTurn;
 
   const selectedModel = useMemo(
@@ -949,7 +969,9 @@ export function HomeRoute() {
   const canStartNewProjectChat =
     Boolean(selectedProject) && !selectedChatId && Boolean(composerText.trim());
   const canSendMessage =
-    (hasSelectedChat && Boolean(composerText.trim() || hasSelectedContext)) ||
+    (hasSelectedChat &&
+      !isSelectedChatArchived &&
+      Boolean(composerText.trim() || hasSelectedContext)) ||
     canStartNewProjectChat;
   const primaryComposerMode: ComposerSubmitMode = hasActiveTurn
     ? isChatRunning
@@ -958,6 +980,8 @@ export function HomeRoute() {
     : "send";
   const isComposerBlocked =
     isSendingMessage ||
+    isSelectedChatArchived ||
+    Boolean(selectedChatId && archiveTransitionChatId === selectedChatId) ||
     deletePendingMessageRequest.isPending ||
     restorePendingMessageRequest.isPending ||
     Boolean(
@@ -968,7 +992,10 @@ export function HomeRoute() {
     !isComposerBlocked &&
     (primaryComposerMode !== "steer" || isChatRunning);
   const canQueueComposerMessage =
-    hasSelectedChat && canSendMessage && !isComposerBlocked;
+    hasSelectedChat &&
+    !isSelectedChatArchived &&
+    canSendMessage &&
+    !isComposerBlocked;
   const canInterruptActiveTurn =
     hasActiveTurn && !isInterrupting && Boolean(selectedChat?.activeTurnId);
   const areComposerOptionsDisabled = !hasSelectedChat || isComposerBlocked;
@@ -2303,6 +2330,70 @@ export function HomeRoute() {
     }
   }
 
+  async function setChatArchived(chat: ChatRecord, archived: boolean) {
+    if (isBusy || archiveChatRequest.isPending) {
+      return;
+    }
+    if (archived && !canArchiveChat(chat)) {
+      return;
+    }
+    const hasRestoredPendingDraftForChat =
+      selectedChatIdRef.current === chat.id &&
+      restoredPendingComposerContextRef.current?.chatId === chat.id &&
+      Boolean(composerTextRef.current.trim() || hasSelectedContextRef.current);
+    const hasSelectedComposerDraftForChat =
+      selectedChatIdRef.current === chat.id &&
+      Boolean(composerTextRef.current.trim() || hasSelectedContextRef.current);
+    if (
+      archived &&
+      (hasSelectedComposerDraftForChat || hasRestoredPendingDraftForChat)
+    ) {
+      setComposerError(
+        "Clear or send the current message before archiving this chat",
+      );
+      composerTextareaRef.current?.focus();
+      return;
+    }
+
+    setComposerError(null);
+    setIsBusy(true);
+    setArchiveTransitionChatId(chat.id);
+    try {
+      const data = await archiveChatRequest.mutateAsync({
+        chatId: chat.id,
+        archived,
+      });
+      upsertChatRecord(data.chat);
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.chat(chat.id),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.projectChats(chat.projectId),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.projectWorktrees(chat.projectId),
+      });
+      if (selectedChatIdRef.current === chat.id && archived) {
+        restoredPendingComposerContextRef.current = null;
+        setComposerText("");
+        setSelectedFiles([]);
+        setSelectedSkillPaths(new Set());
+      }
+      await refreshChats(chat.projectId, { updateSelection: false });
+      await refreshWorktrees(chat.projectId, { updateSelection: false });
+    } catch (err) {
+      setComposerError(
+        formatErrorMessage(
+          archived ? "Could not archive chat" : "Could not restore chat",
+          err,
+        ),
+      );
+    } finally {
+      setArchiveTransitionChatId(null);
+      setIsBusy(false);
+    }
+  }
+
   async function sendMessage(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     await submitComposer("send");
@@ -2720,6 +2811,7 @@ export function HomeRoute() {
   }
 
   function selectProject(projectId: string) {
+    restoredPendingComposerContextRef.current = null;
     setComposerText("");
     setSelectedFiles([]);
     setSelectedSkillPaths(new Set());
@@ -3143,6 +3235,9 @@ export function HomeRoute() {
                                             chatId,
                                           )
                                         }
+                                        onSetChatArchived={(chat, archived) =>
+                                          void setChatArchived(chat, archived)
+                                        }
                                       />
                                     )}
                                   </SidebarMenuSubItem>
@@ -3400,6 +3495,44 @@ export function HomeRoute() {
               )}
             </p>
           </div>
+          {selectedChat && (
+            <Button
+              aria-label={
+                selectedChat.status === "archived"
+                  ? "Restore chat"
+                  : "Archive chat"
+              }
+              className="size-8 text-[var(--icon-color-default)]"
+              disabled={
+                isBusy ||
+                archiveChatRequest.isPending ||
+                (selectedChat.status !== "archived" &&
+                  !canArchiveChat(selectedChat))
+              }
+              onClick={() =>
+                void setChatArchived(
+                  selectedChat,
+                  selectedChat.status !== "archived",
+                )
+              }
+              size="icon"
+              title={
+                selectedChat.status === "archived"
+                  ? "Restore chat"
+                  : "Archive chat"
+              }
+              type="button"
+              variant="ghost"
+            >
+              {archiveChatRequest.isPending ? (
+                <LoadingSpinner />
+              ) : selectedChat.status === "archived" ? (
+                <ArchiveRestore />
+              ) : (
+                <Archive />
+              )}
+            </Button>
+          )}
         </header>
 
         {visiblePendingApproval && (
@@ -3567,11 +3700,13 @@ export function HomeRoute() {
                   enterKeyHint="enter"
                   id="composer"
                   placeholder={
-                    hasSelectedChat
-                      ? "Ask Codex to work in this worktree"
-                      : selectedProject
-                        ? "Ask Codex to create a worktree and start"
-                        : "Select a project to start"
+                    isSelectedChatArchived
+                      ? "Restore this chat to continue"
+                      : hasSelectedChat
+                        ? "Ask Codex to work in this worktree"
+                        : selectedProject
+                          ? "Ask Codex to create a worktree and start"
+                          : "Select a project to start"
                   }
                   rows={2}
                   ref={composerTextareaRef}
@@ -3736,14 +3871,91 @@ export function HomeRoute() {
 function SidebarChatList({
   chats,
   isLoading,
+  onSetChatArchived,
   onSelectChat,
   selectedChatId,
 }: {
   chats: ChatRecord[];
   isLoading: boolean;
+  onSetChatArchived: (chat: ChatRecord, archived: boolean) => void;
   onSelectChat: (chatId: string) => void;
   selectedChatId: string | null;
 }) {
+  const activeChats = chats.filter((chat) => chat.status !== "archived");
+  const archivedChats = chats.filter((chat) => chat.status === "archived");
+  const renderChat = (chat: ChatRecord) => {
+    const isSelected = chat.id === selectedChatId;
+    const isArchived = chat.status === "archived";
+    const archiveLabel = isArchived ? "Restore chat" : "Archive chat";
+
+    return (
+      <li className="group/chat min-w-0" key={chat.id}>
+        <div
+          className={cn(
+            "flex min-h-7 min-w-0 items-center gap-0.5 rounded-[var(--radius-sm)] transition-colors duration-[var(--motion-duration-fast)] hover:bg-sidebar-accent",
+            isSelected && "bg-sidebar-accent text-sidebar-accent-foreground",
+          )}
+        >
+          <button
+            aria-current={isSelected ? "page" : undefined}
+            className={cn(
+              "flex min-w-0 flex-1 items-center gap-2 rounded-[var(--radius-sm)] px-2 py-1 text-left text-[length:var(--font-size-xs)] outline-none focus-visible:shadow-[var(--state-focus-ring)]",
+              isSelected
+                ? "text-sidebar-accent-foreground"
+                : "text-[var(--text-secondary)]",
+            )}
+            onClick={() => onSelectChat(chat.id)}
+            title={chat.title}
+            type="button"
+          >
+            <MessageSquare className="size-3.5 shrink-0 text-[var(--icon-color-default)]" />
+            <span className="min-w-0 flex-1 truncate">{chat.title}</span>
+            <span
+              aria-hidden="true"
+              className={cn(
+                "size-1.5 shrink-0 rounded-full",
+                statusMeta[chat.status].dot,
+              )}
+            />
+            <span className="sr-only">
+              Status: {statusMeta[chat.status].label}
+            </span>
+          </button>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                aria-label={`Open actions for ${chat.title}`}
+                className={cn(
+                  "mr-0.5 size-6 text-[var(--icon-color-default)] opacity-100 data-[state=open]:opacity-100 sm:opacity-0 sm:group-focus-within/chat:opacity-100 sm:group-hover/chat:opacity-100",
+                  isSelected && "sm:opacity-100",
+                )}
+                size="icon"
+                title="Chat actions"
+                type="button"
+                variant="ghost"
+              >
+                <MoreHorizontal className="size-3.5" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem
+                disabled={!isArchived && !canArchiveChat(chat)}
+                onSelect={() => onSetChatArchived(chat, !isArchived)}
+              >
+                {isArchived ? (
+                  <ArchiveRestore className="size-4" />
+                ) : (
+                  <Archive className="size-4" />
+                )}
+                <span>{archiveLabel}</span>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </li>
+    );
+  };
+
   return (
     <ul
       aria-label="Chat history"
@@ -3758,38 +3970,15 @@ function SidebarChatList({
           No chat history
         </li>
       ) : (
-        chats.map((chat) => {
-          const isSelected = chat.id === selectedChatId;
-          return (
-            <li className="min-w-0" key={chat.id}>
-              <button
-                aria-current={isSelected ? "page" : undefined}
-                className={cn(
-                  "flex min-h-7 w-full min-w-0 items-center gap-2 rounded-[var(--radius-sm)] px-2 py-1 text-left text-[length:var(--font-size-xs)] outline-none transition-colors duration-[var(--motion-duration-fast)] hover:bg-sidebar-accent focus-visible:shadow-[var(--state-focus-ring)]",
-                  isSelected
-                    ? "bg-sidebar-accent text-sidebar-accent-foreground"
-                    : "text-[var(--text-secondary)]",
-                )}
-                onClick={() => onSelectChat(chat.id)}
-                title={chat.title}
-                type="button"
-              >
-                <MessageSquare className="size-3.5 shrink-0 text-[var(--icon-color-default)]" />
-                <span className="min-w-0 flex-1 truncate">{chat.title}</span>
-                <span
-                  aria-hidden="true"
-                  className={cn(
-                    "size-1.5 shrink-0 rounded-full",
-                    statusMeta[chat.status].dot,
-                  )}
-                />
-                <span className="sr-only">
-                  Status: {statusMeta[chat.status].label}
-                </span>
-              </button>
+        <>
+          {activeChats.map(renderChat)}
+          {archivedChats.length > 0 && (
+            <li className="px-2 pt-1 text-[length:var(--font-size-2xs)] font-medium uppercase text-[var(--text-tertiary)]">
+              Archived
             </li>
-          );
-        })
+          )}
+          {archivedChats.map(renderChat)}
+        </>
       )}
     </ul>
   );


### PR DESCRIPTION
## Summary

Adds chat archiving support to Phantom Serve.

- Adds a server RPC endpoint for archiving and restoring chats by updating chat status instead of deleting history.
- Prevents active chats from being archived and prevents archived chats from accepting new messages until restored.
- Adds web UI actions in the chat header and sidebar row menu, with archived chats grouped separately in the sidebar.
- Keeps archived chats from becoming the default worktree chat when an active/non-archived chat exists.

## Impact

Users can hide completed chats from the active chat flow without losing history, then restore them later when they need to continue the conversation.

## Validation

- `pnpm ready`