### PR TITLE
[codex] Keep Codex events below chat messages

### DIFF
--- a/packages/server/src/services.test.ts
+++ b/packages/server/src/services.test.ts
@@ -1762,6 +1762,231 @@ describe("ServeServices", () => {
     );
   });
 
+  it("keeps a repeated pending message when only fallback-timestamp Codex history matches", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "running", activeTurnId: "turn_current" })],
+      messages: [
+        {
+          id: "msg_pending_retry",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "retry",
+          createdAt: "2026-04-25T00:01:00.000Z",
+        },
+        {
+          id: "msg_command_event",
+          chatId: "chat_1",
+          role: "event" as const,
+          text: "pnpm test",
+          eventType: "item/commandExecution/outputDelta",
+          itemId: "cmd_1",
+          createdAt: "2026-04-25T00:02:00.000Z",
+        },
+      ],
+    };
+    const { codex, services } = await createHarness(state);
+    codex.readThread.mockResolvedValueOnce({
+      thread: {
+        turns: [
+          {
+            id: "turn_old",
+            items: [{ type: "userMessage", text: "retry" }],
+          },
+        ],
+      },
+    });
+
+    const messages = await services.getMessages("chat_1");
+
+    deepStrictEqual(
+      messages.map((message) => [
+        message.id,
+        message.role,
+        message.text,
+        message.eventType,
+      ]),
+      [
+        ["chat_1_codex_turn_old_0", "user", "retry", undefined],
+        ["msg_pending_retry", "user", "retry", undefined],
+        [
+          "msg_command_event",
+          "event",
+          "pnpm test",
+          "item/commandExecution/outputDelta",
+        ],
+      ],
+    );
+  });
+
+  it("does not trust fallback-timestamp Codex history after stale active turn reset", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "running", activeTurnId: "turn_1" })],
+      messages: [
+        {
+          id: "msg_pending_retry",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "retry",
+          createdAt: "2026-04-25T00:01:00.000Z",
+        },
+      ],
+    };
+    const { codex, services } = await createHarness(state);
+    codex.readThread.mockResolvedValueOnce({
+      thread: {
+        turns: [
+          {
+            id: "turn_1",
+            items: [{ type: "userMessage", text: "retry" }],
+          },
+        ],
+      },
+    });
+
+    const messages = await services.getMessages("chat_1");
+
+    deepStrictEqual(
+      messages.map((message) => [message.id, message.role, message.text]),
+      [
+        ["chat_1_codex_turn_1_0", "user", "retry"],
+        ["msg_pending_retry", "user", "retry"],
+      ],
+    );
+  });
+
+  it("keeps live assistant deltas after fallback-timestamp Codex history when the later user is retained", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat()],
+      messages: [
+        {
+          id: "msg_live_assistant",
+          chatId: "chat_1",
+          role: "assistant" as const,
+          text: "still working",
+          eventType: "item/agentMessage/delta",
+          itemId: "assistant_1",
+          createdAt: "2026-04-25T00:00:01.000Z",
+        },
+        {
+          id: "msg_command_event",
+          chatId: "chat_1",
+          role: "event" as const,
+          text: "pnpm test",
+          eventType: "item/commandExecution/outputDelta",
+          itemId: "cmd_1",
+          createdAt: "2026-04-25T00:00:02.000Z",
+        },
+        {
+          id: "msg_pending_retry",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "retry",
+          createdAt: "2026-04-25T00:00:03.000Z",
+        },
+      ],
+    };
+    const { codex, services } = await createHarness(state);
+    codex.readThread.mockResolvedValueOnce({
+      thread: {
+        turns: [
+          {
+            id: "turn_old",
+            items: [{ type: "userMessage", text: "retry" }],
+          },
+        ],
+      },
+    });
+
+    const messages = await services.getMessages("chat_1");
+
+    deepStrictEqual(
+      messages.map((message) => [
+        message.role,
+        message.text,
+        message.eventType,
+      ]),
+      [
+        ["user", "retry", undefined],
+        ["assistant", "still working", "item/agentMessage/delta"],
+        ["event", "pnpm test", "item/commandExecution/outputDelta"],
+        ["user", "retry", undefined],
+      ],
+    );
+  });
+
+  it("keeps live assistant deltas before a repeated user boundary after fallback-timestamp history", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat()],
+      messages: [
+        {
+          id: "msg_live_assistant",
+          chatId: "chat_1",
+          role: "assistant" as const,
+          text: "still working",
+          eventType: "item/agentMessage/delta",
+          itemId: "assistant_1",
+          createdAt: "2026-04-25T00:00:01.000Z",
+        },
+        {
+          id: "msg_command_event",
+          chatId: "chat_1",
+          role: "event" as const,
+          text: "pnpm test",
+          eventType: "item/commandExecution/outputDelta",
+          itemId: "cmd_1",
+          createdAt: "2026-04-25T00:00:02.000Z",
+        },
+        {
+          id: "msg_pending_retry",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "retry",
+          createdAt: "2026-04-25T00:00:03.000Z",
+        },
+      ],
+    };
+    const { codex, services } = await createHarness(state);
+    codex.readThread.mockResolvedValueOnce({
+      thread: {
+        turns: [
+          {
+            id: "turn_old",
+            items: [{ type: "userMessage", text: "retry" }],
+          },
+          {
+            id: "turn_new",
+            createdAt: "2026-04-25T00:00:03.000Z",
+            items: [{ type: "userMessage", text: "retry" }],
+          },
+        ],
+      },
+    });
+
+    const messages = await services.getMessages("chat_1");
+
+    deepStrictEqual(
+      messages.map((message) => [
+        message.role,
+        message.text,
+        message.eventType,
+      ]),
+      [
+        ["user", "retry", undefined],
+        ["assistant", "still working", "item/agentMessage/delta"],
+        ["event", "pnpm test", "item/commandExecution/outputDelta"],
+        ["user", "retry", undefined],
+      ],
+    );
+  });
+
   it("keeps local Codex events after thread messages with fallback timestamps", async () => {
     const state = {
       ...createTestState(),
@@ -1804,6 +2029,759 @@ describe("ServeServices", () => {
         ["user", "fix the UI", undefined],
         ["assistant", "working", undefined],
         ["event", "pnpm test", "item/commandExecution/outputDelta"],
+      ],
+    );
+  });
+
+  it("keeps local Codex events before later live assistant deltas", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "running", activeTurnId: "turn_1" })],
+      messages: [
+        {
+          id: "msg_command_event",
+          chatId: "chat_1",
+          role: "event" as const,
+          text: "pnpm test",
+          eventType: "item/commandExecution/outputDelta",
+          itemId: "cmd_1",
+          createdAt: "2026-04-25T00:00:01.000Z",
+        },
+        {
+          id: "msg_live_assistant",
+          chatId: "chat_1",
+          role: "assistant" as const,
+          text: "still working",
+          eventType: "item/agentMessage/delta",
+          itemId: "assistant_1",
+          createdAt: "2026-04-25T00:00:02.000Z",
+        },
+        {
+          id: "msg_next_user",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "next request",
+          createdAt: "2026-04-25T00:00:03.000Z",
+        },
+      ],
+    };
+    const { codex, services } = await createHarness(state);
+    codex.readThread.mockResolvedValueOnce({
+      thread: {
+        turns: [
+          {
+            id: "turn_1",
+            createdAt: "2026-04-25T00:00:03.000Z",
+            input: [{ text: "fix the UI" }],
+            items: [
+              { type: "agentMessage", text: "done" },
+              { type: "userMessage", text: "next request" },
+            ],
+          },
+        ],
+      },
+    });
+
+    const messages = await services.getMessages("chat_1");
+
+    deepStrictEqual(
+      messages.map((message) => [
+        message.role,
+        message.text,
+        message.eventType,
+      ]),
+      [
+        ["user", "fix the UI", undefined],
+        ["assistant", "done", undefined],
+        ["event", "pnpm test", "item/commandExecution/outputDelta"],
+        ["assistant", "still working", "item/agentMessage/delta"],
+        ["user", "next request", undefined],
+      ],
+    );
+  });
+
+  it("keeps local Codex events before live assistant deltas merged into Codex history", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "running", activeTurnId: "turn_1" })],
+      messages: [
+        {
+          id: "msg_user",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "fix the UI",
+          createdAt: "2026-04-25T00:00:01.000Z",
+        },
+        {
+          id: "msg_command_event",
+          chatId: "chat_1",
+          role: "event" as const,
+          text: "pnpm test",
+          eventType: "item/commandExecution/outputDelta",
+          itemId: "cmd_1",
+          createdAt: "2026-04-25T00:00:02.000Z",
+        },
+        {
+          id: "msg_live_assistant",
+          chatId: "chat_1",
+          role: "assistant" as const,
+          text: "still working",
+          eventType: "item/agentMessage/delta",
+          itemId: "assistant_1",
+          createdAt: "2026-04-25T00:00:03.000Z",
+        },
+      ],
+    };
+    const { codex, services } = await createHarness(state);
+    codex.readThread.mockResolvedValueOnce({
+      thread: {
+        turns: [
+          {
+            id: "turn_1",
+            createdAt: "2026-04-25T00:00:01.000Z",
+            input: [{ text: "fix the UI" }],
+            items: [
+              {
+                id: "assistant_1",
+                type: "agentMessage",
+                text: "still",
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const messages = await services.getMessages("chat_1");
+
+    deepStrictEqual(
+      messages.map((message) => [
+        message.role,
+        message.text,
+        message.eventType,
+      ]),
+      [
+        ["user", "fix the UI", undefined],
+        ["event", "pnpm test", "item/commandExecution/outputDelta"],
+        ["assistant", "still working", "item/agentMessage/delta"],
+      ],
+    );
+  });
+
+  it("keeps local Codex events before live assistant deltas deduplicated by text", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "running", activeTurnId: "turn_1" })],
+      messages: [
+        {
+          id: "msg_user",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "fix the UI",
+          createdAt: "2026-04-25T00:00:01.000Z",
+        },
+        {
+          id: "msg_command_event",
+          chatId: "chat_1",
+          role: "event" as const,
+          text: "pnpm test",
+          eventType: "item/commandExecution/outputDelta",
+          itemId: "cmd_1",
+          createdAt: "2026-04-25T00:00:02.000Z",
+        },
+        {
+          id: "msg_live_assistant",
+          chatId: "chat_1",
+          role: "assistant" as const,
+          text: "done",
+          eventType: "item/agentMessage/delta",
+          itemId: "local_assistant",
+          createdAt: "2026-04-25T00:00:03.000Z",
+        },
+      ],
+    };
+    const { codex, services } = await createHarness(state);
+    codex.readThread.mockResolvedValueOnce({
+      thread: {
+        turns: [
+          {
+            id: "turn_1",
+            createdAt: "2026-04-25T00:00:01.000Z",
+            input: [{ text: "fix the UI" }],
+            items: [
+              {
+                id: "codex_assistant",
+                type: "agentMessage",
+                text: "done",
+                createdAt: "2026-04-25T00:00:04.000Z",
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const messages = await services.getMessages("chat_1");
+
+    deepStrictEqual(
+      messages.map((message) => [
+        message.role,
+        message.text,
+        message.eventType,
+      ]),
+      [
+        ["user", "fix the UI", undefined],
+        ["event", "pnpm test", "item/commandExecution/outputDelta"],
+        ["assistant", "done", undefined],
+      ],
+    );
+  });
+
+  it("keeps local Codex events between live assistant deltas and later user messages", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "running", activeTurnId: "turn_1" })],
+      messages: [
+        {
+          id: "msg_live_assistant",
+          chatId: "chat_1",
+          role: "assistant" as const,
+          text: "still working",
+          eventType: "item/agentMessage/delta",
+          itemId: "assistant_1",
+          createdAt: "2026-04-25T00:00:01.000Z",
+        },
+        {
+          id: "msg_command_event",
+          chatId: "chat_1",
+          role: "event" as const,
+          text: "pnpm test",
+          eventType: "item/commandExecution/outputDelta",
+          itemId: "cmd_1",
+          createdAt: "2026-04-25T00:00:02.000Z",
+        },
+        {
+          id: "msg_next_user",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "next request",
+          createdAt: "2026-04-25T00:00:03.000Z",
+        },
+      ],
+    };
+    const { codex, services } = await createHarness(state);
+    codex.readThread.mockResolvedValueOnce({
+      thread: {
+        turns: [
+          {
+            id: "turn_1",
+            createdAt: "2026-04-25T00:00:03.000Z",
+            input: [{ text: "fix the UI" }],
+            items: [
+              { type: "agentMessage", text: "done" },
+              { type: "userMessage", text: "next request" },
+            ],
+          },
+        ],
+      },
+    });
+
+    const messages = await services.getMessages("chat_1");
+
+    deepStrictEqual(
+      messages.map((message) => [
+        message.role,
+        message.text,
+        message.eventType,
+      ]),
+      [
+        ["user", "fix the UI", undefined],
+        ["assistant", "done", undefined],
+        ["assistant", "still working", "item/agentMessage/delta"],
+        ["event", "pnpm test", "item/commandExecution/outputDelta"],
+        ["user", "next request", undefined],
+      ],
+    );
+  });
+
+  it("keeps local Codex events after deduplicated local user messages", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "running", activeTurnId: "turn_1" })],
+      messages: [
+        {
+          id: "msg_user",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "fix the UI",
+          createdAt: "2026-04-25T00:00:01.000Z",
+        },
+        {
+          id: "msg_command_event",
+          chatId: "chat_1",
+          role: "event" as const,
+          text: "pnpm test",
+          eventType: "item/commandExecution/outputDelta",
+          itemId: "cmd_1",
+          createdAt: "2026-04-25T00:00:02.000Z",
+        },
+      ],
+    };
+    const { codex, services } = await createHarness(state);
+    codex.readThread.mockResolvedValueOnce({
+      thread: {
+        turns: [
+          {
+            id: "turn_1",
+            createdAt: "2026-04-25T00:00:01.000Z",
+            input: [{ text: "fix the UI" }],
+            items: [{ type: "agentMessage", text: "done" }],
+          },
+        ],
+      },
+    });
+
+    const messages = await services.getMessages("chat_1");
+
+    deepStrictEqual(
+      messages.map((message) => [
+        message.role,
+        message.text,
+        message.eventType,
+      ]),
+      [
+        ["user", "fix the UI", undefined],
+        ["event", "pnpm test", "item/commandExecution/outputDelta"],
+        ["assistant", "done", undefined],
+      ],
+    );
+  });
+
+  it("keeps local Codex events after retained local user messages", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "running", activeTurnId: "turn_1" })],
+      messages: [
+        {
+          id: "msg_user",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "new request",
+          createdAt: "2026-04-25T00:01:00.000Z",
+        },
+        {
+          id: "msg_command_event",
+          chatId: "chat_1",
+          role: "event" as const,
+          text: "pnpm test",
+          eventType: "item/commandExecution/outputDelta",
+          itemId: "cmd_1",
+          createdAt: "2026-04-25T00:02:00.000Z",
+        },
+        {
+          id: "msg_live_assistant",
+          chatId: "chat_1",
+          role: "assistant" as const,
+          text: "still working",
+          eventType: "item/agentMessage/delta",
+          itemId: "assistant_1",
+          createdAt: "2026-04-25T00:03:00.000Z",
+        },
+      ],
+    };
+    const { codex, services } = await createHarness(state);
+    codex.readThread.mockResolvedValueOnce({
+      thread: {
+        turns: [
+          {
+            id: "turn_1",
+            createdAt: "not-a-date",
+            input: [{ text: "previous request" }],
+            items: [{ type: "agentMessage", text: "previous response" }],
+          },
+        ],
+      },
+    });
+
+    const messages = await services.getMessages("chat_1");
+
+    deepStrictEqual(
+      messages.map((message) => [
+        message.role,
+        message.text,
+        message.eventType,
+      ]),
+      [
+        ["user", "previous request", undefined],
+        ["assistant", "previous response", undefined],
+        ["user", "new request", undefined],
+        ["event", "pnpm test", "item/commandExecution/outputDelta"],
+        ["assistant", "still working", "item/agentMessage/delta"],
+      ],
+    );
+  });
+
+  it("keeps retained local messages before later trusted Codex history after fallback timestamps", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat()],
+      messages: [
+        {
+          id: "msg_user",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "middle request",
+          createdAt: "2026-04-25T00:05:00.000Z",
+        },
+        {
+          id: "msg_command_event",
+          chatId: "chat_1",
+          role: "event" as const,
+          text: "pnpm test",
+          eventType: "item/commandExecution/outputDelta",
+          itemId: "cmd_1",
+          createdAt: "2026-04-25T00:06:00.000Z",
+        },
+      ],
+    };
+    const { codex, services } = await createHarness(state);
+    codex.readThread.mockResolvedValueOnce({
+      thread: {
+        turns: [
+          {
+            id: "turn_old",
+            items: [{ type: "userMessage", text: "previous request" }],
+          },
+          {
+            id: "turn_new",
+            createdAt: "2026-04-25T00:10:00.000Z",
+            items: [{ type: "agentMessage", text: "later response" }],
+          },
+        ],
+      },
+    });
+
+    const messages = await services.getMessages("chat_1");
+
+    deepStrictEqual(
+      messages.map((message) => [
+        message.role,
+        message.text,
+        message.eventType,
+      ]),
+      [
+        ["user", "previous request", undefined],
+        ["user", "middle request", undefined],
+        ["event", "pnpm test", "item/commandExecution/outputDelta"],
+        ["assistant", "later response", undefined],
+      ],
+    );
+  });
+
+  it("keeps local Codex events after repeated deduplicated local user messages", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "running", activeTurnId: "turn_1" })],
+      messages: [
+        {
+          id: "msg_user_1",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "repeat",
+          createdAt: "2026-04-25T00:00:01.000Z",
+        },
+        {
+          id: "msg_user_2",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "repeat",
+          createdAt: "2026-04-25T00:00:02.000Z",
+        },
+        {
+          id: "msg_command_event",
+          chatId: "chat_1",
+          role: "event" as const,
+          text: "pnpm test",
+          eventType: "item/commandExecution/outputDelta",
+          itemId: "cmd_1",
+          createdAt: "2026-04-25T00:00:03.000Z",
+        },
+      ],
+    };
+    const { codex, services } = await createHarness(state);
+    codex.readThread.mockResolvedValueOnce({
+      thread: {
+        turns: [
+          {
+            id: "turn_1",
+            items: [
+              {
+                type: "userMessage",
+                text: "repeat",
+                createdAt: "2026-04-25T00:00:01.000Z",
+              },
+              {
+                type: "userMessage",
+                text: "repeat",
+                createdAt: "2026-04-25T00:00:02.000Z",
+              },
+              {
+                type: "agentMessage",
+                text: "done",
+                createdAt: "2026-04-25T00:00:04.000Z",
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const messages = await services.getMessages("chat_1");
+
+    deepStrictEqual(
+      messages.map((message) => [
+        message.role,
+        message.text,
+        message.eventType,
+      ]),
+      [
+        ["user", "repeat", undefined],
+        ["user", "repeat", undefined],
+        ["event", "pnpm test", "item/commandExecution/outputDelta"],
+        ["assistant", "done", undefined],
+      ],
+    );
+  });
+
+  it("keeps local Codex events between a deduplicated and retained repeated user message", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "running", activeTurnId: "turn_1" })],
+      messages: [
+        {
+          id: "msg_user_1",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "repeat",
+          createdAt: "2026-04-25T00:00:01.000Z",
+        },
+        {
+          id: "msg_command_event",
+          chatId: "chat_1",
+          role: "event" as const,
+          text: "pnpm test",
+          eventType: "item/commandExecution/outputDelta",
+          itemId: "cmd_1",
+          createdAt: "2026-04-25T00:00:02.000Z",
+        },
+        {
+          id: "msg_live_assistant",
+          chatId: "chat_1",
+          role: "assistant" as const,
+          text: "still working",
+          eventType: "item/agentMessage/delta",
+          itemId: "assistant_1",
+          createdAt: "2026-04-25T00:00:03.000Z",
+        },
+        {
+          id: "msg_user_2",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "repeat",
+          createdAt: "2026-04-25T00:00:04.000Z",
+        },
+      ],
+    };
+    const { codex, services } = await createHarness(state);
+    codex.readThread.mockResolvedValueOnce({
+      thread: {
+        turns: [
+          {
+            id: "turn_1",
+            items: [
+              {
+                type: "userMessage",
+                text: "repeat",
+                createdAt: "2026-04-25T00:00:01.000Z",
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const messages = await services.getMessages("chat_1");
+
+    deepStrictEqual(
+      messages.map((message) => [
+        message.role,
+        message.text,
+        message.eventType,
+      ]),
+      [
+        ["user", "repeat", undefined],
+        ["event", "pnpm test", "item/commandExecution/outputDelta"],
+        ["assistant", "still working", "item/agentMessage/delta"],
+        ["user", "repeat", undefined],
+      ],
+    );
+  });
+
+  it("keeps retained repeated user messages after earlier deduplicated matches", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat()],
+      messages: [
+        {
+          id: "msg_user_1",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "retry",
+          createdAt: "2026-04-25T00:00:01.000Z",
+        },
+        {
+          id: "msg_live_assistant",
+          chatId: "chat_1",
+          role: "assistant" as const,
+          text: "still working",
+          eventType: "item/agentMessage/delta",
+          itemId: "assistant_1",
+          createdAt: "2026-04-25T00:00:02.000Z",
+        },
+        {
+          id: "msg_command_event",
+          chatId: "chat_1",
+          role: "event" as const,
+          text: "pnpm test",
+          eventType: "item/commandExecution/outputDelta",
+          itemId: "cmd_1",
+          createdAt: "2026-04-25T00:00:03.000Z",
+        },
+        {
+          id: "msg_user_2",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "retry",
+          createdAt: "2026-04-25T00:00:04.000Z",
+        },
+      ],
+    };
+    const { codex, services } = await createHarness(state);
+    codex.readThread.mockResolvedValueOnce({
+      thread: {
+        turns: [
+          {
+            id: "turn_1",
+            createdAt: "2026-04-25T00:00:05.000Z",
+            items: [{ type: "userMessage", text: "retry" }],
+          },
+        ],
+      },
+    });
+
+    const messages = await services.getMessages("chat_1");
+
+    deepStrictEqual(
+      messages.map((message) => [
+        message.role,
+        message.text,
+        message.eventType,
+      ]),
+      [
+        ["user", "retry", undefined],
+        ["assistant", "still working", "item/agentMessage/delta"],
+        ["event", "pnpm test", "item/commandExecution/outputDelta"],
+        ["user", "retry", undefined],
+      ],
+    );
+  });
+
+  it("keeps local Codex events before a later repeated user boundary", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "running", activeTurnId: "turn_1" })],
+      messages: [
+        {
+          id: "msg_user_1",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "repeat",
+          createdAt: "2026-04-25T00:00:01.000Z",
+        },
+        {
+          id: "msg_live_assistant",
+          chatId: "chat_1",
+          role: "assistant" as const,
+          text: "still working",
+          eventType: "item/agentMessage/delta",
+          itemId: "assistant_1",
+          createdAt: "2026-04-25T00:00:02.000Z",
+        },
+        {
+          id: "msg_command_event",
+          chatId: "chat_1",
+          role: "event" as const,
+          text: "pnpm test",
+          eventType: "item/commandExecution/outputDelta",
+          itemId: "cmd_1",
+          createdAt: "2026-04-25T00:00:03.000Z",
+        },
+        {
+          id: "msg_user_2",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "repeat",
+          createdAt: "2026-04-25T00:00:04.000Z",
+        },
+      ],
+    };
+    const { codex, services } = await createHarness(state);
+    codex.readThread.mockResolvedValueOnce({
+      thread: {
+        turns: [
+          {
+            id: "turn_1",
+            items: [
+              {
+                type: "userMessage",
+                text: "repeat",
+                createdAt: "2026-04-25T00:00:01.000Z",
+              },
+              {
+                type: "userMessage",
+                text: "repeat",
+                createdAt: "2026-04-25T00:00:04.000Z",
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const messages = await services.getMessages("chat_1");
+
+    deepStrictEqual(
+      messages.map((message) => [
+        message.role,
+        message.text,
+        message.eventType,
+      ]),
+      [
+        ["user", "repeat", undefined],
+        ["assistant", "still working", "item/agentMessage/delta"],
+        ["event", "pnpm test", "item/commandExecution/outputDelta"],
+        ["user", "repeat", undefined],
       ],
     );
   });

--- a/packages/server/src/services.test.ts
+++ b/packages/server/src/services.test.ts
@@ -1762,6 +1762,52 @@ describe("ServeServices", () => {
     );
   });
 
+  it("keeps local Codex events after thread messages with fallback timestamps", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "running", activeTurnId: "turn_1" })],
+      messages: [
+        {
+          id: "msg_command_event",
+          chatId: "chat_1",
+          role: "event" as const,
+          text: "pnpm test",
+          eventType: "item/commandExecution/outputDelta",
+          itemId: "cmd_1",
+          createdAt: "2026-04-25T00:00:01.000Z",
+        },
+      ],
+    };
+    const { codex, services } = await createHarness(state);
+    codex.readThread.mockResolvedValueOnce({
+      thread: {
+        turns: [
+          {
+            id: "turn_1",
+            input: [{ text: "fix the UI" }],
+            items: [{ type: "agentMessage", text: "working" }],
+          },
+        ],
+      },
+    });
+
+    const messages = await services.getMessages("chat_1");
+
+    deepStrictEqual(
+      messages.map((message) => [
+        message.role,
+        message.text,
+        message.eventType,
+      ]),
+      [
+        ["user", "fix the UI", undefined],
+        ["assistant", "working", undefined],
+        ["event", "pnpm test", "item/commandExecution/outputDelta"],
+      ],
+    );
+  });
+
   it("deduplicates a local message once a matching newer Codex message exists", async () => {
     const state = {
       ...createTestState(),

--- a/packages/server/src/services.test.ts
+++ b/packages/server/src/services.test.ts
@@ -1903,7 +1903,18 @@ describe("ServeServices", () => {
         ["msg_stale_steered", "user", "retry", undefined],
       ],
     );
-    deepStrictEqual(repeatedMessages, messages);
+    deepStrictEqual(
+      repeatedMessages.map((message) => [
+        message.id,
+        message.role,
+        message.text,
+        message.eventType,
+      ]),
+      [
+        ["chat_1_codex_turn_1_0", "user", "retry", undefined],
+        ["msg_stale_steered", "user", "retry", undefined],
+      ],
+    );
     strictEqual(savedState.messages[0]?.eventType, undefined);
   });
 

--- a/packages/server/src/services.test.ts
+++ b/packages/server/src/services.test.ts
@@ -1858,6 +1858,55 @@ describe("ServeServices", () => {
     );
   });
 
+  it("does not restore stale active turns from local steered messages", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "running", activeTurnId: "turn_1" })],
+      messages: [
+        {
+          id: "msg_stale_steered",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "retry",
+          eventType: "chat.message.steered",
+          itemId: "turn_1",
+          createdAt: "2026-04-25T00:01:00.000Z",
+        },
+      ],
+    };
+    const { codex, services, store } = await createHarness(state);
+    codex.readThread.mockResolvedValue({
+      thread: {
+        turns: [
+          {
+            id: "turn_1",
+            input: [{ text: "retry" }],
+          },
+        ],
+      },
+    });
+
+    const messages = await services.getMessages("chat_1");
+    const repeatedMessages = await services.getMessages("chat_1");
+    const savedState = await store.load();
+
+    deepStrictEqual(
+      messages.map((message) => [
+        message.id,
+        message.role,
+        message.text,
+        message.eventType,
+      ]),
+      [
+        ["chat_1_codex_turn_1_0", "user", "retry", undefined],
+        ["msg_stale_steered", "user", "retry", undefined],
+      ],
+    );
+    deepStrictEqual(repeatedMessages, messages);
+    strictEqual(savedState.messages[0]?.eventType, undefined);
+  });
+
   it("keeps live assistant deltas after fallback-timestamp Codex history when the later user is retained", async () => {
     const state = {
       ...createTestState(),

--- a/packages/server/src/services.ts
+++ b/packages/server/src/services.ts
@@ -217,6 +217,8 @@ type CodexTurnItemSource = "input" | "item";
 type InternalChatMessageRecord = ChatMessageRecord & {
   codexOrder?: number;
   codexItemSource?: CodexTurnItemSource;
+  codexTurnId?: string;
+  hasFallbackTimestamp?: boolean;
   mergeSortBucket?: number;
   mergeSortIndex?: number;
 };
@@ -1167,6 +1169,8 @@ export class ServeServices {
     const localMessages = state.messages.filter(
       (message) => message.chatId === chatId,
     );
+    const activeTurnId =
+      chat.activeTurnId ?? findLocalSteeredTurnId(localMessages);
     if (!chat.codexThreadId) {
       return localMessagesWithoutStaleSteeredState(chat, localMessages);
     }
@@ -1179,7 +1183,11 @@ export class ServeServices {
       if (codexMessages.length === 0) {
         return localMessagesWithoutStaleSteeredState(chat, localMessages);
       }
-      return mergeCodexAndLocalMessages(codexMessages, localMessages);
+      return mergeCodexAndLocalMessages(
+        codexMessages,
+        localMessages,
+        activeTurnId,
+      );
     } catch {
       return localMessagesWithoutStaleSteeredState(chat, localMessages);
     }
@@ -3412,6 +3420,13 @@ function normalizeCodexTimestamp(value: unknown, fallback: string): string {
   return fallback;
 }
 
+function isValidCodexTimestamp(value: unknown): boolean {
+  if (typeof value === "number") {
+    return Number.isFinite(value);
+  }
+  return typeof value === "string" && Number.isFinite(Date.parse(value));
+}
+
 function sortChatsByUpdatedAt(chats: ChatRecord[]): ChatRecord[] {
   return [...chats].sort((left, right) =>
     right.updatedAt.localeCompare(left.updatedAt),
@@ -3452,8 +3467,11 @@ function normalizeCodexThreadMessages(
       getRecordString(turn, "id") ??
       getRecordString(turn, "turnId") ??
       String(turnIndex);
+    const turnTimestampValue =
+      turn.createdAt ?? turn.created_at ?? turn.updatedAt ?? turn.updated_at;
+    const hasFallbackTurnTimestamp = !isValidCodexTimestamp(turnTimestampValue);
     const turnTimestamp = normalizeCodexTimestamp(
-      turn.createdAt ?? turn.created_at ?? turn.updatedAt ?? turn.updated_at,
+      turnTimestampValue,
       createTimestamp(),
     );
     const items = getCodexTurnItems(turn);
@@ -3466,6 +3484,8 @@ function normalizeCodexThreadMessages(
       if (!text) {
         continue;
       }
+      const itemTimestampValue =
+        item.createdAt ?? item.created_at ?? item.timestamp;
       messages.push({
         id: `${chatId}_codex_${turnId}_${itemIndex}`,
         chatId,
@@ -3473,11 +3493,12 @@ function normalizeCodexThreadMessages(
         text,
         codexOrder: codexOrder++,
         codexItemSource: item.codexItemSource,
+        codexTurnId: turnId,
+        hasFallbackTimestamp:
+          !isValidCodexTimestamp(itemTimestampValue) &&
+          hasFallbackTurnTimestamp,
         itemId: getRecordString(item, "id") ?? undefined,
-        createdAt: normalizeCodexTimestamp(
-          item.createdAt ?? item.created_at ?? item.timestamp,
-          turnTimestamp,
-        ),
+        createdAt: normalizeCodexTimestamp(itemTimestampValue, turnTimestamp),
       });
     }
   }
@@ -3560,18 +3581,21 @@ function extractCodexText(value: unknown): string {
 function mergeCodexAndLocalMessages(
   codexMessages: InternalChatMessageRecord[],
   localMessages: ChatMessageRecord[],
+  activeTurnId: string | null,
 ): ChatMessageRecord[] {
   if (codexMessages.length === 0) {
     return localMessages;
   }
   const mergedCodexMessages = [...codexMessages];
   const unmatchedCodexMessageIndexes = codexMessages.map((_, index) => index);
+  const localMessageCodexOrderMatches = new Map<string, number>();
   const steeredLocalMessageCounts = countSteeredLocalMessages(localMessages);
   const liveAssistantDeltaCodexOrderLimits =
     findLiveAssistantDeltaCodexOrderLimits(
       localMessages,
       mergedCodexMessages,
       steeredLocalMessageCounts,
+      activeTurnId,
     );
   const retainedLocalMessages = localMessages.filter((message) => {
     if (message.role === "event" || message.role === "error") {
@@ -3590,6 +3614,10 @@ function mergeCodexAndLocalMessages(
       const staleCodexMessage =
         mergedCodexMessages[staleLiveAssistantDeltaIndex];
       if (staleCodexMessage) {
+        localMessageCodexOrderMatches.set(
+          message.id,
+          staleCodexMessage.codexOrder ?? staleLiveAssistantDeltaIndex,
+        );
         mergedCodexMessages[staleLiveAssistantDeltaIndex] = {
           ...message,
           codexOrder: staleCodexMessage.codexOrder,
@@ -3608,11 +3636,18 @@ function mergeCodexAndLocalMessages(
       message,
       steeredLocalMessageCounts,
       liveAssistantDeltaCodexOrderLimits,
+      activeTurnId,
     );
     if (matchedCodexIndex === undefined) {
       return true;
     }
     const matchedCodexMessage = mergedCodexMessages[matchedCodexIndex];
+    if (matchedCodexMessage) {
+      localMessageCodexOrderMatches.set(
+        message.id,
+        matchedCodexMessage.codexOrder ?? matchedCodexIndex,
+      );
+    }
     if (message.eventType === "chat.message.steered" && matchedCodexMessage) {
       mergedCodexMessages[matchedCodexIndex] = {
         ...matchedCodexMessage,
@@ -3628,8 +3663,11 @@ function mergeCodexAndLocalMessages(
   return assignMergedMessageSortKeys(
     mergedCodexMessages,
     retainedLocalMessages,
+    localMessages,
+    localMessageCodexOrderMatches,
     liveAssistantDeltaCodexOrderLimits,
     steeredLocalMessageCounts,
+    activeTurnId,
   )
     .sort(compareMergedMessages)
     .map(stripInternalCodexMessageMetadata);
@@ -3663,11 +3701,17 @@ function insertRecordAtIndex<TRecord>(
 function assignMergedMessageSortKeys(
   codexMessages: InternalChatMessageRecord[],
   localMessages: ChatMessageRecord[],
+  allLocalMessages: ChatMessageRecord[],
+  localMessageCodexOrderMatches: ReadonlyMap<string, number>,
   liveAssistantDeltaCodexOrderLimits: ReadonlyMap<string, number>,
   steeredLocalMessageCounts: ReadonlyMap<string, number>,
+  activeTurnId: string | null,
 ): InternalChatMessageRecord[] {
   const orderedCodexMessages = [...codexMessages].sort(
     (left, right) => (left.codexOrder ?? 0) - (right.codexOrder ?? 0),
+  );
+  const allLocalMessageIndexes = new Map(
+    allLocalMessages.map((message, index) => [message.id, index]),
   );
   return [
     ...orderedCodexMessages.map((message, index) => ({
@@ -3676,13 +3720,16 @@ function assignMergedMessageSortKeys(
       mergeSortIndex: 0,
     })),
     ...localMessages.map((message, index) => {
+      const allLocalMessageIndex = allLocalMessageIndexes.get(message.id);
       const mergeSortBucket = getLocalMessageMergeSortBucket(
         message,
-        index,
-        localMessages,
+        allLocalMessageIndex ?? index,
+        allLocalMessages,
         orderedCodexMessages,
+        localMessageCodexOrderMatches,
         liveAssistantDeltaCodexOrderLimits,
         steeredLocalMessageCounts,
+        activeTurnId,
       );
       return {
         ...message,
@@ -3698,8 +3745,10 @@ function getLocalMessageMergeSortBucket(
   index: number,
   localMessages: ChatMessageRecord[],
   orderedCodexMessages: InternalChatMessageRecord[],
+  localMessageCodexOrderMatches: ReadonlyMap<string, number>,
   liveAssistantDeltaCodexOrderLimits: ReadonlyMap<string, number>,
   steeredLocalMessageCounts: ReadonlyMap<string, number>,
+  activeTurnId: string | null,
 ): number {
   if (isPendingSteeredMessage(message)) {
     return orderedCodexMessages.length * 2 + 2;
@@ -3708,27 +3757,317 @@ function getLocalMessageMergeSortBucket(
     return orderedCodexMessages.length * 2 + 3;
   }
   if (isLocalTimelineEvent(message)) {
-    return orderedCodexMessages.length * 2 + 1;
+    return getLocalTimelineEventMergeSortBucket(
+      index,
+      localMessages,
+      orderedCodexMessages,
+      localMessageCodexOrderMatches,
+      liveAssistantDeltaCodexOrderLimits,
+      steeredLocalMessageCounts,
+      activeTurnId,
+    );
   }
   if (isLiveAssistantDeltaMessage(message)) {
-    const boundaryInsertionIndex = findLiveAssistantDeltaBoundaryInsertionIndex(
+    return getLiveAssistantDeltaMergeSortBucket(
       message,
       index,
       localMessages,
       orderedCodexMessages,
+      localMessageCodexOrderMatches,
       liveAssistantDeltaCodexOrderLimits,
       steeredLocalMessageCounts,
+      activeTurnId,
     );
-    return boundaryInsertionIndex === null
-      ? orderedCodexMessages.length * 2 + 1
-      : boundaryInsertionIndex * 2 - 1;
   }
+  return getStandardLocalMessageMergeSortBucket(
+    message,
+    orderedCodexMessages,
+    index,
+    localMessages,
+    localMessageCodexOrderMatches,
+  );
+}
+
+function getLocalTimelineEventMergeSortBucket(
+  index: number,
+  localMessages: ChatMessageRecord[],
+  orderedCodexMessages: InternalChatMessageRecord[],
+  localMessageCodexOrderMatches: ReadonlyMap<string, number>,
+  liveAssistantDeltaCodexOrderLimits: ReadonlyMap<string, number>,
+  steeredLocalMessageCounts: ReadonlyMap<string, number>,
+  activeTurnId: string | null,
+): number {
+  const earlierLocalBoundaryBucket = localMessages
+    .slice(0, index)
+    .map((message, index) => ({ index, message }))
+    .reverse()
+    .map(({ index, message }) =>
+      getLocalTimelineEventBoundaryMergeSortBucket(
+        message,
+        index,
+        localMessages,
+        orderedCodexMessages,
+        localMessageCodexOrderMatches,
+        liveAssistantDeltaCodexOrderLimits,
+        steeredLocalMessageCounts,
+        activeTurnId,
+      ),
+    )
+    .find((bucket): bucket is number => bucket !== null);
+  const laterLocalBoundaryBucket = localMessages
+    .slice(index + 1)
+    .map((message, offset) => ({ index: index + offset + 1, message }))
+    .map(({ index, message }) =>
+      getLocalTimelineEventBoundaryMergeSortBucket(
+        message,
+        index,
+        localMessages,
+        orderedCodexMessages,
+        localMessageCodexOrderMatches,
+        liveAssistantDeltaCodexOrderLimits,
+        steeredLocalMessageCounts,
+        activeTurnId,
+      ),
+    )
+    .find((bucket): bucket is number => bucket !== null);
+
+  if (
+    earlierLocalBoundaryBucket !== undefined &&
+    laterLocalBoundaryBucket !== undefined
+  ) {
+    if (earlierLocalBoundaryBucket === laterLocalBoundaryBucket) {
+      return earlierLocalBoundaryBucket;
+    }
+    if (earlierLocalBoundaryBucket < laterLocalBoundaryBucket) {
+      return (
+        earlierLocalBoundaryBucket +
+        (laterLocalBoundaryBucket - earlierLocalBoundaryBucket) / 2
+      );
+    }
+    return earlierLocalBoundaryBucket + 0.5;
+  }
+  if (earlierLocalBoundaryBucket !== undefined) {
+    return earlierLocalBoundaryBucket + 0.5;
+  }
+  if (laterLocalBoundaryBucket === undefined) {
+    return orderedCodexMessages.length * 2 + 1;
+  }
+  return laterLocalBoundaryBucket - 0.5;
+}
+
+function getLocalTimelineEventBoundaryMergeSortBucket(
+  message: ChatMessageRecord,
+  index: number,
+  localMessages: ChatMessageRecord[],
+  orderedCodexMessages: InternalChatMessageRecord[],
+  localMessageCodexOrderMatches: ReadonlyMap<string, number>,
+  liveAssistantDeltaCodexOrderLimits: ReadonlyMap<string, number>,
+  steeredLocalMessageCounts: ReadonlyMap<string, number>,
+  activeTurnId: string | null,
+): number | null {
+  if (!isLocalTimelineEventBoundary(message)) {
+    return null;
+  }
+  if (isLiveAssistantDeltaBoundaryUserMessage(message)) {
+    const boundaryBucket = getLocalUserBoundaryMergeSortBucket(
+      message,
+      index,
+      localMessages,
+      orderedCodexMessages,
+      localMessageCodexOrderMatches,
+    );
+    if (boundaryBucket !== null) {
+      return boundaryBucket;
+    }
+  }
+  if (isPendingSteeredMessage(message)) {
+    return orderedCodexMessages.length * 2 + 2;
+  }
+  if (isQueuedMessage(message)) {
+    return orderedCodexMessages.length * 2 + 3;
+  }
+  if (!isLiveAssistantDeltaMessage(message)) {
+    return null;
+  }
+  return (
+    getMergedLiveAssistantDeltaMergeSortBucket(
+      message,
+      orderedCodexMessages,
+      localMessageCodexOrderMatches,
+    ) ??
+    getLiveAssistantDeltaMergeSortBucket(
+      message,
+      index,
+      localMessages,
+      orderedCodexMessages,
+      localMessageCodexOrderMatches,
+      liveAssistantDeltaCodexOrderLimits,
+      steeredLocalMessageCounts,
+      activeTurnId,
+    )
+  );
+}
+
+function getStandardLocalMessageMergeSortBucket(
+  message: ChatMessageRecord,
+  orderedCodexMessages: InternalChatMessageRecord[],
+  index?: number,
+  localMessages?: ChatMessageRecord[],
+  localMessageCodexOrderMatches?: ReadonlyMap<string, number>,
+): number {
   const insertionIndex = orderedCodexMessages.findIndex(
     (codexMessage) => codexMessage.createdAt > message.createdAt,
   );
-  return insertionIndex === -1
-    ? orderedCodexMessages.length * 2 + 1
-    : insertionIndex * 2 - 1;
+  if (
+    insertionIndex !== -1 &&
+    orderedCodexMessages[insertionIndex]?.hasFallbackTimestamp
+  ) {
+    const nextTrustedInsertionIndex = orderedCodexMessages.findIndex(
+      (codexMessage, index) =>
+        index > insertionIndex &&
+        !codexMessage.hasFallbackTimestamp &&
+        codexMessage.createdAt > message.createdAt,
+    );
+    return applyEarlierLocalCodexBoundary(
+      nextTrustedInsertionIndex === -1
+        ? orderedCodexMessages.length * 2 + 1
+        : nextTrustedInsertionIndex * 2 - 1,
+      index,
+      localMessages,
+      localMessageCodexOrderMatches,
+    );
+  }
+  const bucket =
+    insertionIndex === -1
+      ? orderedCodexMessages.length * 2 + 1
+      : insertionIndex * 2 - 1;
+  return applyEarlierLocalCodexBoundary(
+    bucket,
+    index,
+    localMessages,
+    localMessageCodexOrderMatches,
+  );
+}
+
+function applyEarlierLocalCodexBoundary(
+  bucket: number,
+  index: number | undefined,
+  localMessages: ChatMessageRecord[] | undefined,
+  localMessageCodexOrderMatches: ReadonlyMap<string, number> | undefined,
+): number {
+  if (index === undefined || !localMessages || !localMessageCodexOrderMatches) {
+    return bucket;
+  }
+  const earlierMatchedCodexOrder = localMessages
+    ? getEarlierLocalCodexOrder(
+        index,
+        localMessages,
+        localMessageCodexOrderMatches,
+      )
+    : undefined;
+  if (earlierMatchedCodexOrder === undefined) {
+    return bucket;
+  }
+  return Math.max(bucket, earlierMatchedCodexOrder * 2 + 0.5);
+}
+
+function getEarlierLocalCodexOrder(
+  index: number,
+  localMessages: ChatMessageRecord[],
+  localMessageCodexOrderMatches: ReadonlyMap<string, number>,
+): number | undefined {
+  return localMessages
+    .slice(0, index)
+    .reverse()
+    .map((message) => localMessageCodexOrderMatches.get(message.id))
+    .find((codexOrder): codexOrder is number => codexOrder !== undefined);
+}
+
+function getMergedLiveAssistantDeltaMergeSortBucket(
+  message: ChatMessageRecord,
+  orderedCodexMessages: InternalChatMessageRecord[],
+  localMessageCodexOrderMatches: ReadonlyMap<string, number>,
+): number | null {
+  const matchedCodexOrder = localMessageCodexOrderMatches.get(message.id);
+  if (matchedCodexOrder !== undefined) {
+    return matchedCodexOrder * 2;
+  }
+  const matchedCodexMessage = orderedCodexMessages.find(
+    (codexMessage) =>
+      codexMessage.role === "assistant" &&
+      (codexMessage.id === message.id ||
+        (Boolean(message.itemId) && codexMessage.itemId === message.itemId)),
+  );
+  if (!matchedCodexMessage) {
+    return null;
+  }
+  const codexOrder = matchedCodexMessage.codexOrder;
+  if (codexOrder !== undefined) {
+    return codexOrder * 2;
+  }
+  const index = orderedCodexMessages.indexOf(matchedCodexMessage);
+  return index === -1 ? null : index * 2;
+}
+
+function getLocalUserBoundaryMergeSortBucket(
+  message: ChatMessageRecord,
+  index: number,
+  localMessages: ChatMessageRecord[],
+  orderedCodexMessages: InternalChatMessageRecord[],
+  localMessageCodexOrderMatches: ReadonlyMap<string, number>,
+): number | null {
+  const matchedCodexOrder = localMessageCodexOrderMatches.get(message.id);
+  if (matchedCodexOrder !== undefined) {
+    return matchedCodexOrder * 2;
+  }
+  if (!message.eventType) {
+    return getStandardLocalMessageMergeSortBucket(
+      message,
+      orderedCodexMessages,
+      index,
+      localMessages,
+      localMessageCodexOrderMatches,
+    );
+  }
+  return null;
+}
+
+function getLiveAssistantDeltaMergeSortBucket(
+  message: ChatMessageRecord,
+  index: number,
+  localMessages: ChatMessageRecord[],
+  orderedCodexMessages: InternalChatMessageRecord[],
+  localMessageCodexOrderMatches: ReadonlyMap<string, number>,
+  liveAssistantDeltaCodexOrderLimits: ReadonlyMap<string, number>,
+  steeredLocalMessageCounts: ReadonlyMap<string, number>,
+  activeTurnId: string | null,
+): number {
+  const boundaryInsertionIndex = findLiveAssistantDeltaBoundaryInsertionIndex(
+    message,
+    index,
+    localMessages,
+    orderedCodexMessages,
+    liveAssistantDeltaCodexOrderLimits,
+    steeredLocalMessageCounts,
+    activeTurnId,
+  );
+  if (boundaryInsertionIndex === null) {
+    const earlierMatchedCodexOrder = getEarlierLocalCodexOrder(
+      index,
+      localMessages,
+      localMessageCodexOrderMatches,
+    );
+    return earlierMatchedCodexOrder === undefined
+      ? orderedCodexMessages.length * 2 + 1
+      : earlierMatchedCodexOrder * 2 + 0.5;
+  }
+  const bucket = boundaryInsertionIndex * 2 - 1;
+  return applyEarlierLocalCodexBoundary(
+    bucket,
+    index,
+    localMessages,
+    localMessageCodexOrderMatches,
+  );
 }
 
 function findLiveAssistantDeltaBoundaryInsertionIndex(
@@ -3738,6 +4077,7 @@ function findLiveAssistantDeltaBoundaryInsertionIndex(
   orderedCodexMessages: InternalChatMessageRecord[],
   liveAssistantDeltaCodexOrderLimits: ReadonlyMap<string, number>,
   steeredLocalMessageCounts: ReadonlyMap<string, number>,
+  activeTurnId: string | null,
 ): number | null {
   if (!isLiveAssistantDeltaMessage(message)) {
     return null;
@@ -3764,6 +4104,7 @@ function findLiveAssistantDeltaBoundaryInsertionIndex(
     localMessages,
     laterUserMessageEntry.index,
     steeredLocalMessageCounts,
+    activeTurnId,
   );
   if (boundaryCodexMessage?.codexOrder === undefined) {
     return null;
@@ -3795,6 +4136,7 @@ function findDeduplicatedCodexMessageIndex(
   localMessage: ChatMessageRecord,
   steeredLocalMessageCounts: ReadonlyMap<string, number>,
   liveAssistantDeltaCodexOrderLimits: ReadonlyMap<string, number>,
+  activeTurnId: string | null,
 ): number | undefined {
   const matchedIndexes = unmatchedCodexMessageIndexes.filter((index) => {
     const codexMessage = codexMessages[index];
@@ -3803,6 +4145,7 @@ function findDeduplicatedCodexMessageIndex(
           codexMessage,
           localMessage,
           liveAssistantDeltaCodexOrderLimits,
+          activeTurnId,
         )
       : false;
   });
@@ -3889,10 +4232,18 @@ function getSteeredMessageGroupKey(message: ChatMessageRecord): string | null {
   return `${message.itemId}\0${message.text}`;
 }
 
+function findLocalSteeredTurnId(messages: ChatMessageRecord[]): string | null {
+  return (
+    messages.find((message) => message.eventType === "chat.message.steered")
+      ?.itemId ?? null
+  );
+}
+
 function shouldDeduplicateLocalMessage(
   codexMessage: InternalChatMessageRecord,
   localMessage: ChatMessageRecord,
   liveAssistantDeltaCodexOrderLimits: ReadonlyMap<string, number>,
+  activeTurnId: string | null,
 ): boolean {
   if (codexMessage.role !== localMessage.role) {
     return false;
@@ -3930,10 +4281,23 @@ function shouldDeduplicateLocalMessage(
   if (messageFingerprint(codexMessage) !== messageFingerprint(localMessage)) {
     return false;
   }
-  if (isCodexMessageAtOrAfterLocalMessage(codexMessage, localMessage)) {
+  if (
+    isCodexTimestampTrustedForDeduplication(codexMessage, activeTurnId) &&
+    isCodexMessageAtOrAfterLocalMessage(codexMessage, localMessage)
+  ) {
     return true;
   }
   return isRelaxedSteeredCodexMatch(codexMessage, localMessage);
+}
+
+function isCodexTimestampTrustedForDeduplication(
+  codexMessage: InternalChatMessageRecord,
+  activeTurnId: string | null,
+): boolean {
+  return (
+    !codexMessage.hasFallbackTimestamp ||
+    (activeTurnId !== null && codexMessage.codexTurnId === activeTurnId)
+  );
 }
 
 function isLiveAssistantDeltaMessage(message: ChatMessageRecord): boolean {
@@ -3957,6 +4321,15 @@ function isLocalTimelineEvent(message: ChatMessageRecord): boolean {
   return message.role === "event" || message.role === "error";
 }
 
+function isLocalTimelineEventBoundary(message: ChatMessageRecord): boolean {
+  return (
+    isLiveAssistantDeltaMessage(message) ||
+    isLiveAssistantDeltaBoundaryUserMessage(message) ||
+    isPendingSteeredMessage(message) ||
+    isQueuedMessage(message)
+  );
+}
+
 function isCodexLiveAssistantMessageFresh(
   codexMessage: ChatMessageRecord,
   localMessage: ChatMessageRecord,
@@ -3971,6 +4344,7 @@ function findLiveAssistantDeltaCodexOrderLimits(
   messages: ChatMessageRecord[],
   codexMessages: InternalChatMessageRecord[],
   steeredLocalMessageCounts: ReadonlyMap<string, number>,
+  activeTurnId: string | null,
 ): ReadonlyMap<string, number> {
   const codexOrderLimits = new Map<string, number>();
   for (const [index, message] of messages.entries()) {
@@ -3989,6 +4363,7 @@ function findLiveAssistantDeltaCodexOrderLimits(
       messages,
       laterUserMessageEntry.index,
       steeredLocalMessageCounts,
+      activeTurnId,
     );
     if (boundaryCodexMessage?.codexOrder !== undefined) {
       codexOrderLimits.set(message.id, boundaryCodexMessage.codexOrder);
@@ -4002,6 +4377,7 @@ function findLiveAssistantDeltaBoundaryCodexMessage(
   localMessages: ChatMessageRecord[],
   laterUserMessageIndex: number,
   steeredLocalMessageCounts: ReadonlyMap<string, number>,
+  activeTurnId: string | null,
 ): InternalChatMessageRecord | undefined {
   const laterUserMessage = localMessages[laterUserMessageIndex];
   if (!laterUserMessage) {
@@ -4015,16 +4391,46 @@ function findLiveAssistantDeltaBoundaryCodexMessage(
       laterUserMessageIndex,
       laterUserMessage,
       steeredLocalMessageCounts,
+      activeTurnId,
     );
   }
-  const matchedIndex = findDeduplicatedCodexMessageIndex(
-    codexMessages.map((_, index) => index),
+  return findBoundaryCodexMessageForLocalOccurrence(
     codexMessages,
+    localMessages,
+    laterUserMessageIndex,
     laterUserMessage,
-    steeredLocalMessageCounts,
-    new Map(),
+    activeTurnId,
   );
-  return matchedIndex === undefined ? undefined : codexMessages[matchedIndex];
+}
+
+function findBoundaryCodexMessageForLocalOccurrence(
+  codexMessages: InternalChatMessageRecord[],
+  localMessages: ChatMessageRecord[],
+  localMessageIndex: number,
+  localMessage: ChatMessageRecord,
+  activeTurnId: string | null,
+): InternalChatMessageRecord | undefined {
+  const fingerprint = messageFingerprint(localMessage);
+  const localOccurrenceIndex =
+    localMessages
+      .slice(0, localMessageIndex + 1)
+      .filter(
+        (message) =>
+          !getSteeredMessageGroupKey(message) &&
+          isLiveAssistantDeltaBoundaryUserMessage(message) &&
+          messageFingerprint(message) === fingerprint,
+      ).length - 1;
+  if (localOccurrenceIndex < 0) {
+    return undefined;
+  }
+  const candidates = codexMessages
+    .filter((codexMessage) => messageFingerprint(codexMessage) === fingerprint)
+    .sort((left, right) => (left.codexOrder ?? 0) - (right.codexOrder ?? 0));
+  return candidates
+    .slice(localOccurrenceIndex)
+    .find((codexMessage) =>
+      isCodexBoundaryUserMessage(codexMessage, localMessage, activeTurnId),
+    );
 }
 
 function findSteeredBoundaryCodexMessageForLocalOccurrence(
@@ -4033,6 +4439,7 @@ function findSteeredBoundaryCodexMessageForLocalOccurrence(
   localMessageIndex: number,
   localMessage: ChatMessageRecord,
   steeredLocalMessageCounts: ReadonlyMap<string, number>,
+  activeTurnId: string | null,
 ): InternalChatMessageRecord | undefined {
   const localGroupKey = getSteeredMessageGroupKey(localMessage);
   if (!localGroupKey) {
@@ -4071,7 +4478,8 @@ function findSteeredBoundaryCodexMessageForLocalOccurrence(
     ];
   const candidate =
     candidateIndex === undefined ? undefined : codexMessages[candidateIndex];
-  return candidate && isCodexBoundaryUserMessage(candidate, localMessage)
+  return candidate &&
+    isCodexBoundaryUserMessage(candidate, localMessage, activeTurnId)
     ? candidate
     : undefined;
 }
@@ -4088,17 +4496,22 @@ function isLiveAssistantDeltaBoundaryUserMessage(
 function isCodexBoundaryUserMessage(
   codexMessage: InternalChatMessageRecord,
   localMessage: ChatMessageRecord,
+  activeTurnId: string | null,
 ): boolean {
   if (messageFingerprint(codexMessage) !== messageFingerprint(localMessage)) {
     return false;
   }
   if (localMessage.eventType === "chat.message.steered") {
     return (
-      isCodexMessageAtOrAfterLocalMessage(codexMessage, localMessage) ||
+      (isCodexTimestampTrustedForDeduplication(codexMessage, activeTurnId) &&
+        isCodexMessageAtOrAfterLocalMessage(codexMessage, localMessage)) ||
       isRelaxedSteeredCodexMatch(codexMessage, localMessage)
     );
   }
-  return isCodexMessageAtOrAfterLocalMessage(codexMessage, localMessage);
+  return (
+    isCodexTimestampTrustedForDeduplication(codexMessage, activeTurnId) &&
+    isCodexMessageAtOrAfterLocalMessage(codexMessage, localMessage)
+  );
 }
 
 function isRelaxedSteeredCodexMatch(
@@ -4125,6 +4538,8 @@ function stripInternalCodexMessageMetadata(
   const publicMessage: InternalChatMessageRecord = { ...message };
   delete publicMessage.codexOrder;
   delete publicMessage.codexItemSource;
+  delete publicMessage.codexTurnId;
+  delete publicMessage.hasFallbackTimestamp;
   delete publicMessage.mergeSortBucket;
   delete publicMessage.mergeSortIndex;
   return publicMessage;

--- a/packages/server/src/services.ts
+++ b/packages/server/src/services.ts
@@ -1163,14 +1163,15 @@ export class ServeServices {
   }
 
   async getMessages(chatId: string): Promise<ChatMessageRecord[]> {
-    await this.resetStaleTransientChatState();
+    const resetChatIds = await this.resetStaleTransientChatState();
     const state = await this.store.load();
     const chat = this.requireChat(state, chatId);
     const localMessages = state.messages.filter(
       (message) => message.chatId === chatId,
     );
     const activeTurnId =
-      chat.activeTurnId ?? findLocalSteeredTurnId(localMessages);
+      chat.activeTurnId ??
+      (resetChatIds.has(chatId) ? null : findLocalSteeredTurnId(localMessages));
     if (!chat.codexThreadId) {
       return localMessagesWithoutStaleSteeredState(chat, localMessages);
     }
@@ -2511,26 +2512,43 @@ export class ServeServices {
     return didUpdate;
   }
 
-  private async resetStaleTransientChatState(): Promise<void> {
+  private async resetStaleTransientChatState(): Promise<ReadonlySet<string>> {
     const state = await this.store.load();
     if (!state.chats.some((chat) => this.isStaleTransientChat(chat))) {
-      return;
+      return new Set();
     }
 
+    const resetChatIds = new Set<string>();
     const timestamp = createTimestamp();
-    await this.store.update((nextState) => ({
-      ...nextState,
-      chats: nextState.chats.map((chat) =>
-        this.isStaleTransientChat(chat)
-          ? {
-              ...chat,
-              status: "idle",
-              activeTurnId: null,
-              updatedAt: timestamp,
-            }
-          : chat,
-      ),
-    }));
+    await this.store.update((nextState) => {
+      resetChatIds.clear();
+      const chats = nextState.chats.map((chat) => {
+        if (!this.isStaleTransientChat(chat)) {
+          return chat;
+        }
+        resetChatIds.add(chat.id);
+        return {
+          ...chat,
+          status: "idle" as const,
+          activeTurnId: null,
+          updatedAt: timestamp,
+        };
+      });
+      if (resetChatIds.size === 0) {
+        return nextState;
+      }
+      return {
+        ...nextState,
+        chats,
+        messages: nextState.messages.map((message) =>
+          resetChatIds.has(message.chatId) &&
+          message.eventType === "chat.message.steered"
+            ? { ...message, eventType: undefined }
+            : message,
+        ),
+      };
+    });
+    return resetChatIds;
   }
 
   private isStaleTransientChat(chat: ChatRecord): boolean {

--- a/packages/server/src/services.ts
+++ b/packages/server/src/services.ts
@@ -3707,6 +3707,9 @@ function getLocalMessageMergeSortBucket(
   if (isQueuedMessage(message)) {
     return orderedCodexMessages.length * 2 + 3;
   }
+  if (isLocalTimelineEvent(message)) {
+    return orderedCodexMessages.length * 2 + 1;
+  }
   if (isLiveAssistantDeltaMessage(message)) {
     const boundaryInsertionIndex = findLiveAssistantDeltaBoundaryInsertionIndex(
       message,
@@ -3948,6 +3951,10 @@ function isPendingSteeredMessage(message: ChatMessageRecord): boolean {
 
 function isQueuedMessage(message: ChatMessageRecord): boolean {
   return message.role === "user" && message.eventType === "chat.message.queued";
+}
+
+function isLocalTimelineEvent(message: ChatMessageRecord): boolean {
+  return message.role === "event" || message.role === "error";
 }
 
 function isCodexLiveAssistantMessageFresh(


### PR DESCRIPTION
## Summary

Fixes chat timeline ordering for Codex event/error messages such as command execution output. Local Codex events now anchor to the surrounding streamed chat messages instead of jumping above the conversation when merged with Codex thread history.

## Root Cause

Codex thread items can arrive without stable timestamps, so Phantom falls back to the read time. The merge sorter could then treat local timeline events as older than refreshed Codex history, especially around live assistant deltas, repeated user messages, fallback timestamps, and stale active turns.

## Changes

- Track Codex turn IDs, fallback timestamp state, and internal merge buckets while normalizing thread history.
- Place local `event` and `error` messages using nearby local/Codex boundaries instead of blanket timestamp ordering.
- Preserve live assistant deltas and retained local messages below earlier local messages that were deduped into Codex history.
- Avoid trusting fallback-timestamp Codex history for stale active turns.
- Add regression coverage for fallback timestamps, repeated users, live deltas, retained local messages, and stale active-turn reset behavior.

## Verification

- `pnpm --filter @phantompane/server test`
- `pnpm ready`
- Browser verification with local Phantom API and Vite UI using headless Chromium; confirmed the rendered order was user message, streaming assistant response, then command event.