### PR TITLE
[codex] enable Codex auto approval review

### DIFF
--- a/packages/codex/src/bridge.test.ts
+++ b/packages/codex/src/bridge.test.ts
@@ -85,7 +85,13 @@ describe("CodexBridge", () => {
 
     expect(spawnCodexProcess).toHaveBeenCalledWith(
       "fake-codex",
-      ["app-server"],
+      [
+        "app-server",
+        "-c",
+        'sandbox_mode="workspace-write"',
+        "-c",
+        'approvals_reviewer="auto_review"',
+      ],
       {
         stdio: ["pipe", "pipe", "pipe"],
       },
@@ -295,6 +301,38 @@ describe("CodexBridge", () => {
       id: "99",
       result: { decision: "decline" },
     });
+  });
+
+  it("runs codex exec with read-only sandbox", async () => {
+    const { bridge, proc, spawnCodexProcess } = createBridge();
+
+    const execPromise = bridge.exec("name this branch", {
+      cwd: "/repo",
+      model: "gpt-5.4-mini",
+    });
+    await vi.waitFor(() => expect(spawnCodexProcess).toHaveBeenCalledOnce());
+
+    const args = spawnCodexProcess.mock.calls[0]?.[1];
+    expect(args).toEqual([
+      "exec",
+      "--model",
+      "gpt-5.4-mini",
+      "--sandbox",
+      "read-only",
+      "--ephemeral",
+      "--skip-git-repo-check",
+      "--output-last-message",
+      expect.stringMatching(/last-message\.txt$/),
+      "name this branch",
+    ]);
+    expect(spawnCodexProcess.mock.calls[0]?.[2]).toEqual({
+      cwd: "/repo",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    proc.stdout.write("branch-name\n");
+    proc.emit("close", 0, null);
+    await expect(execPromise).resolves.toBe("branch-name\n");
   });
 
   it("waits for codex exec processes to close after timeout before rejecting", async () => {

--- a/packages/codex/src/bridge.ts
+++ b/packages/codex/src/bridge.ts
@@ -69,6 +69,16 @@ interface PendingRequest {
 
 type SpawnCodexProcess = typeof spawn;
 
+const CODEX_APPROVAL_REVIEWER_CONFIG_ARGS = [
+  "-c",
+  'approvals_reviewer="auto_review"',
+] as const;
+const CODEX_APP_SERVER_CONFIG_ARGS = [
+  "-c",
+  'sandbox_mode="workspace-write"',
+  ...CODEX_APPROVAL_REVIEWER_CONFIG_ARGS,
+] as const;
+
 export function getCodexBin(): string {
   return process.env.PHANTOM_SERVE_CODEX_BIN ?? "codex";
 }
@@ -373,9 +383,13 @@ export class CodexBridge {
 
   private async start(): Promise<void> {
     this.stderr = "";
-    this.proc = this.spawnCodexProcess(this.codexBin, ["app-server"], {
-      stdio: ["pipe", "pipe", "pipe"],
-    }) as ChildProcessWithoutNullStreams;
+    this.proc = this.spawnCodexProcess(
+      this.codexBin,
+      ["app-server", ...CODEX_APP_SERVER_CONFIG_ARGS],
+      {
+        stdio: ["pipe", "pipe", "pipe"],
+      },
+    ) as ChildProcessWithoutNullStreams;
     const proc = this.proc;
 
     proc.stderr.on("data", (chunk: Buffer) => {


### PR DESCRIPTION
## Summary

- Starts the Codex app server with explicit `workspace-write` sandboxing and `approvals_reviewer="auto_review"`.
- Leaves approval policy and short-lived `codex exec` approval behavior to the existing Codex configuration while keeping exec read-only.
- Updates bridge tests to cover both app-server and exec launch arguments.

## Why

`packages/codex` previously inherited the user’s local Codex approval reviewer configuration for the embedded app-server, so Phantom Serve was not guaranteed to run in auto review mode. This makes the app-server sandbox and approval reviewer explicit while avoiding approval-policy overrides that managed environments may disallow.

## Validation

- `pnpm --filter @phantompane/codex lint`
- `pnpm --filter @phantompane/codex typecheck`
- `pnpm --filter @phantompane/codex test`

`pnpm ready` was attempted before the final review fixes and stopped in `@phantompane/web#fix` because `@tailwindcss/vite` could not be resolved and package `node_modules` were missing in this worktree.