### PR TITLE
[codex] render chat markdown

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -20,10 +20,13 @@
     "@phantompane/git": "workspace:*",
     "@phantompane/state": "workspace:*",
     "hono": "^4.12.12",
+    "marked": "^18.0.2",
+    "sanitize-html": "^2.17.3",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",
+    "@types/sanitize-html": "^2.16.1",
     "tsdown": "^0.21.8",
     "typescript": "^5.9.3",
     "vitest": "^4.1.2"

--- a/packages/server/src/markdown.test.ts
+++ b/packages/server/src/markdown.test.ts
@@ -1,0 +1,43 @@
+import { ok, strictEqual } from "node:assert";
+import { describe, it } from "vitest";
+import { renderChatMessage, renderMarkdownToHtml } from "./markdown.ts";
+import type { ChatMessageRecord } from "@phantompane/state";
+
+describe("renderMarkdownToHtml", () => {
+  it("renders GitHub-flavored Markdown to HTML", () => {
+    const html = renderMarkdownToHtml(
+      "## Result\n\n- **Done**\n\n```ts\nconst ok = true;\n```",
+    );
+
+    ok(html.includes("<h2>Result</h2>"));
+    ok(html.includes("<strong>Done</strong>"));
+    ok(html.includes('<pre><code class="language-ts">'));
+  });
+
+  it("removes unsafe HTML and URL schemes", () => {
+    const html = renderMarkdownToHtml(
+      "[bad](javascript:alert(1))\n\n<script>alert(1)</script>",
+    );
+
+    ok(!html.includes("javascript:"));
+    ok(!html.includes("<script>"));
+  });
+});
+
+describe("renderChatMessage", () => {
+  it("adds rendered HTML without mutating the Markdown text", () => {
+    const message: ChatMessageRecord = {
+      chatId: "chat_1",
+      createdAt: "2026-05-05T00:00:00.000Z",
+      id: "msg_1",
+      role: "assistant",
+      text: "**hello**",
+    };
+
+    strictEqual(renderChatMessage(message).text, "**hello**");
+    strictEqual(
+      renderChatMessage(message).textHtml,
+      "<p><strong>hello</strong></p>\n",
+    );
+  });
+});

--- a/packages/server/src/markdown.test.ts
+++ b/packages/server/src/markdown.test.ts
@@ -22,6 +22,20 @@ describe("renderMarkdownToHtml", () => {
     ok(!html.includes("javascript:"));
     ok(!html.includes("<script>"));
   });
+
+  it("renders safe links with external navigation attributes", () => {
+    const html = renderMarkdownToHtml(
+      "[safe](https://example.com) [bad](javascript:alert(1))",
+    );
+
+    ok(
+      html.includes(
+        '<a href="https://example.com" rel="noopener noreferrer" target="_blank">safe</a>',
+      ),
+    );
+    ok(html.includes("bad"));
+    ok(!html.includes("javascript:"));
+  });
 });
 
 describe("renderChatMessage", () => {
@@ -39,5 +53,17 @@ describe("renderChatMessage", () => {
       renderChatMessage(message).textHtml,
       "<p><strong>hello</strong></p>\n",
     );
+  });
+
+  it("does not render HTML for non-assistant messages", () => {
+    const message: ChatMessageRecord = {
+      chatId: "chat_1",
+      createdAt: "2026-05-05T00:00:00.000Z",
+      id: "msg_1",
+      role: "event",
+      text: "**event output**",
+    };
+
+    strictEqual("textHtml" in renderChatMessage(message), false);
   });
 });

--- a/packages/server/src/markdown.test.ts
+++ b/packages/server/src/markdown.test.ts
@@ -14,13 +14,25 @@ describe("renderMarkdownToHtml", () => {
     ok(html.includes('<pre><code class="language-ts">'));
   });
 
-  it("removes unsafe HTML and URL schemes", () => {
+  it("escapes unsafe HTML and removes unsafe URL schemes", () => {
     const html = renderMarkdownToHtml(
       "[bad](javascript:alert(1))\n\n<script>alert(1)</script>",
     );
 
     ok(!html.includes("javascript:"));
     ok(!html.includes("<script>"));
+    ok(html.includes("&lt;script&gt;alert(1)&lt;/script&gt;"));
+  });
+
+  it("preserves raw HTML and JSX snippets as escaped text", () => {
+    const html = renderMarkdownToHtml(
+      'Use <Button disabled>Save</Button> or <div data-id="1">content</div>.',
+    );
+
+    ok(html.includes("&lt;Button disabled&gt;Save&lt;/Button&gt;"));
+    ok(html.includes('&lt;div data-id="1"&gt;content&lt;/div&gt;'));
+    ok(!html.includes("<Button"));
+    ok(!html.includes("<div"));
   });
 
   it("renders safe links with external navigation attributes", () => {

--- a/packages/server/src/markdown.ts
+++ b/packages/server/src/markdown.ts
@@ -31,11 +31,23 @@ const allowedTags = [
   "ul",
 ];
 
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+const markdownRenderer = new marked.Renderer();
+markdownRenderer.html = ({ text }) => escapeHtml(text);
+
 export function renderMarkdownToHtml(markdown: string): string {
   const html = marked.parse(markdown, {
     async: false,
     breaks: true,
     gfm: true,
+    renderer: markdownRenderer,
   }) as string;
   return sanitizeHtml(html, {
     allowedAttributes: {

--- a/packages/server/src/markdown.ts
+++ b/packages/server/src/markdown.ts
@@ -51,7 +51,7 @@ export function renderMarkdownToHtml(markdown: string): string {
       a: (_tagName, attribs) => ({
         attribs: {
           ...attribs,
-          rel: "noreferrer",
+          rel: "noopener noreferrer",
           target: "_blank",
         },
         tagName: "a",
@@ -63,6 +63,9 @@ export function renderMarkdownToHtml(markdown: string): string {
 export function renderChatMessage(
   message: ChatMessageRecord,
 ): RenderedChatMessageRecord {
+  if (message.role !== "assistant") {
+    return message;
+  }
   return {
     ...message,
     textHtml: renderMarkdownToHtml(message.text),

--- a/packages/server/src/markdown.ts
+++ b/packages/server/src/markdown.ts
@@ -1,0 +1,76 @@
+import { marked } from "marked";
+import sanitizeHtml from "sanitize-html";
+import type { ChatMessageRecord } from "@phantompane/state";
+import type { RenderedChatMessageRecord } from "./types.ts";
+
+const allowedTags = [
+  "a",
+  "blockquote",
+  "br",
+  "code",
+  "del",
+  "em",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "hr",
+  "li",
+  "ol",
+  "p",
+  "pre",
+  "strong",
+  "table",
+  "tbody",
+  "td",
+  "th",
+  "thead",
+  "tr",
+  "ul",
+];
+
+export function renderMarkdownToHtml(markdown: string): string {
+  const html = marked.parse(markdown, {
+    async: false,
+    breaks: true,
+    gfm: true,
+  }) as string;
+  return sanitizeHtml(html, {
+    allowedAttributes: {
+      a: ["href", "rel", "target", "title"],
+      code: ["class"],
+    },
+    allowedClasses: {
+      code: [/^language-[\w-]+$/],
+    },
+    allowedSchemes: ["http", "https", "mailto"],
+    allowedTags,
+    transformTags: {
+      a: (_tagName, attribs) => ({
+        attribs: {
+          ...attribs,
+          rel: "noreferrer",
+          target: "_blank",
+        },
+        tagName: "a",
+      }),
+    },
+  });
+}
+
+export function renderChatMessage(
+  message: ChatMessageRecord,
+): RenderedChatMessageRecord {
+  return {
+    ...message,
+    textHtml: renderMarkdownToHtml(message.text),
+  };
+}
+
+export function renderChatMessages(
+  messages: ChatMessageRecord[],
+): RenderedChatMessageRecord[] {
+  return messages.map(renderChatMessage);
+}

--- a/packages/server/src/rpc.test.ts
+++ b/packages/server/src/rpc.test.ts
@@ -58,6 +58,14 @@ describe("rpcRoutes", () => {
         role: "assistant",
         text: "**hello**",
       },
+      {
+        chatId: "chat_1",
+        createdAt: "2026-05-05T00:00:01.000Z",
+        eventType: "item/commandExecution/outputDelta",
+        id: "msg_2",
+        role: "event",
+        text: "**raw output**",
+      },
     ]);
 
     const response = await rpcRoutes.request("/chats/chat_1/messages");
@@ -73,6 +81,14 @@ describe("rpcRoutes", () => {
           role: "assistant",
           text: "**hello**",
           textHtml: "<p><strong>hello</strong></p>\n",
+        },
+        {
+          chatId: "chat_1",
+          createdAt: "2026-05-05T00:00:01.000Z",
+          eventType: "item/commandExecution/outputDelta",
+          id: "msg_2",
+          role: "event",
+          text: "**raw output**",
         },
       ],
     });

--- a/packages/server/src/rpc.test.ts
+++ b/packages/server/src/rpc.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, it, vi } from "vitest";
 const services = vi.hoisted(() => ({
   addProject: vi.fn(),
   createChat: vi.fn(),
+  getMessages: vi.fn(),
   listProjectGitHubCheckoutTargets: vi.fn(),
   listProjects: vi.fn(),
 }));
@@ -43,6 +44,35 @@ describe("rpcRoutes", () => {
           createdAt: "2026-01-01T00:00:00.000Z",
           updatedAt: "2026-01-01T00:00:00.000Z",
           lastOpenedAt: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+    });
+  });
+
+  it("renders message Markdown in chat message responses", async () => {
+    services.getMessages.mockResolvedValueOnce([
+      {
+        chatId: "chat_1",
+        createdAt: "2026-05-05T00:00:00.000Z",
+        id: "msg_1",
+        role: "assistant",
+        text: "**hello**",
+      },
+    ]);
+
+    const response = await rpcRoutes.request("/chats/chat_1/messages");
+
+    strictEqual(response.status, 200);
+    deepStrictEqual(services.getMessages.mock.calls[0], ["chat_1"]);
+    deepStrictEqual(await response.json(), {
+      messages: [
+        {
+          chatId: "chat_1",
+          createdAt: "2026-05-05T00:00:00.000Z",
+          id: "msg_1",
+          role: "assistant",
+          text: "**hello**",
+          textHtml: "<p><strong>hello</strong></p>\n",
         },
       ],
     });

--- a/packages/server/src/rpc.ts
+++ b/packages/server/src/rpc.ts
@@ -2,6 +2,7 @@ import { Hono, type Context } from "hono";
 import { validator } from "hono/validator";
 import { z } from "zod";
 import { createSseResponse, parseLastEventId } from "./event-hub.ts";
+import { renderChatMessages } from "./markdown.ts";
 import { getServeServices } from "./services.ts";
 import type { ApiErrorBody, CodexTurnContextItem } from "./types.ts";
 
@@ -366,7 +367,7 @@ export const rpcRoutes = new Hono()
       const messages = await getServeServices().getMessages(
         c.req.param("chatId"),
       );
-      return c.json({ messages }, 200);
+      return c.json({ messages: renderChatMessages(messages) }, 200);
     } catch (error) {
       return handleApiError(c, error);
     }

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -10,7 +10,7 @@ export type {
 } from "@phantompane/state";
 
 export type RenderedChatMessageRecord = ChatMessageRecord & {
-  textHtml: string;
+  textHtml?: string;
 };
 
 export interface ProjectWorktreeRecord {

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -1,4 +1,4 @@
-import type { ChatStatus } from "@phantompane/state";
+import type { ChatMessageRecord, ChatStatus } from "@phantompane/state";
 
 export type {
   ChatMessageRecord,
@@ -8,6 +8,10 @@ export type {
   QueuedMessageRecord,
   ServeState,
 } from "@phantompane/state";
+
+export type RenderedChatMessageRecord = ChatMessageRecord & {
+  textHtml: string;
+};
 
 export interface ProjectWorktreeRecord {
   name: string;

--- a/packages/web/src/api/queries.ts
+++ b/packages/web/src/api/queries.ts
@@ -2,7 +2,6 @@ import { queryOptions } from "@tanstack/react-query";
 import { api, readRpcJson, routeParam } from "./client";
 import { queryKeys } from "./query-keys";
 import type {
-  ChatMessageRecord,
   ChatRecord,
   CodexFileRecord,
   CodexModelRecord,
@@ -11,6 +10,7 @@ import type {
   PendingApprovalRecord,
   ProjectRecord,
   ProjectWorktreeRecord,
+  RenderedChatMessageRecord,
 } from "@phantompane/server";
 
 export function authQueryOptions() {
@@ -107,7 +107,7 @@ export function messagesQueryOptions(chatId: string) {
   return queryOptions({
     queryKey: queryKeys.messages(chatId),
     queryFn: async () =>
-      readRpcJson<{ messages: ChatMessageRecord[] }>(
+      readRpcJson<{ messages: RenderedChatMessageRecord[] }>(
         await api.chats[":chatId"].messages.$get({
           param: { chatId: routeParam(chatId) },
         }),

--- a/packages/web/src/routes/home.tsx
+++ b/packages/web/src/routes/home.tsx
@@ -4462,7 +4462,7 @@ function MessageCard({
       {message.role === "assistant" ? (
         <div
           className="markdown-message"
-          dangerouslySetInnerHTML={{ __html: message.textHtml }}
+          dangerouslySetInnerHTML={{ __html: message.textHtml ?? "" }}
         />
       ) : (
         <pre className="whitespace-pre-wrap break-words font-sans text-[length:var(--font-size-md)] leading-[var(--line-height-relaxed)]">

--- a/packages/web/src/routes/home.tsx
+++ b/packages/web/src/routes/home.tsx
@@ -149,7 +149,6 @@ import {
 } from "./rich-events";
 import { mergeStreamingMessagesForDisplay } from "./chat-message-stream-order";
 import type {
-  ChatMessageRecord,
   ChatRecord,
   ChatStatus,
   CodexFileRecord,
@@ -162,6 +161,7 @@ import type {
   PhantomEvent,
   ProjectWorktreeRecord,
   ProjectRecord,
+  RenderedChatMessageRecord,
 } from "@phantompane/server";
 
 const chatEventNames = [
@@ -276,7 +276,7 @@ interface RestoredPendingComposerContext {
   model: string | null;
 }
 
-type VisibleMessageRecord = ChatMessageRecord & {
+type VisibleMessageRecord = RenderedChatMessageRecord & {
   role: "assistant" | "error" | "event" | "user";
 };
 
@@ -533,7 +533,7 @@ export function HomeRoute() {
   const [expandedWorktreeKeys, setExpandedWorktreeKeys] = useState<Set<string>>(
     () => new Set(),
   );
-  const [messages, setMessages] = useState<ChatMessageRecord[]>([]);
+  const [messages, setMessages] = useState<RenderedChatMessageRecord[]>([]);
   const [messagesChatId, setMessagesChatId] = useState<string | null>(null);
   const messagesChatIdRef = useRef(messagesChatId);
   messagesChatIdRef.current = messagesChatId;
@@ -4459,9 +4459,16 @@ function MessageCard({
           "rounded-[var(--radius-lg)] border border-[var(--semantic-danger-border)] bg-[var(--semantic-danger-bg)] px-4 py-3 text-[var(--semantic-danger-fg)] shadow-[var(--shadow-xs)]",
       )}
     >
-      <pre className="whitespace-pre-wrap break-words font-sans text-[length:var(--font-size-md)] leading-[var(--line-height-relaxed)]">
-        {message.text}
-      </pre>
+      {message.role === "assistant" ? (
+        <div
+          className="markdown-message"
+          dangerouslySetInnerHTML={{ __html: message.textHtml }}
+        />
+      ) : (
+        <pre className="whitespace-pre-wrap break-words font-sans text-[length:var(--font-size-md)] leading-[var(--line-height-relaxed)]">
+          {message.text}
+        </pre>
+      )}
       {deliveryState && (
         <MessageDeliveryBadge
           isActionBusy={isPendingActionBusy}

--- a/packages/web/src/routes/home.tsx
+++ b/packages/web/src/routes/home.tsx
@@ -4459,10 +4459,10 @@ function MessageCard({
           "rounded-[var(--radius-lg)] border border-[var(--semantic-danger-border)] bg-[var(--semantic-danger-bg)] px-4 py-3 text-[var(--semantic-danger-fg)] shadow-[var(--shadow-xs)]",
       )}
     >
-      {message.role === "assistant" ? (
+      {message.role === "assistant" && message.textHtml !== undefined ? (
         <div
           className="markdown-message"
-          dangerouslySetInnerHTML={{ __html: message.textHtml ?? "" }}
+          dangerouslySetInnerHTML={{ __html: message.textHtml }}
         />
       ) : (
         <pre className="whitespace-pre-wrap break-words font-sans text-[length:var(--font-size-md)] leading-[var(--line-height-relaxed)]">

--- a/packages/web/src/styles.css
+++ b/packages/web/src/styles.css
@@ -474,6 +474,129 @@ body {
   padding-inline: var(--space-3);
 }
 
+.markdown-message {
+  overflow-wrap: anywhere;
+  color: var(--text-primary);
+  font-size: var(--font-size-md);
+  line-height: var(--line-height-relaxed);
+}
+
+.markdown-message > :first-child {
+  margin-block-start: 0;
+}
+
+.markdown-message > :last-child {
+  margin-block-end: 0;
+}
+
+.markdown-message p,
+.markdown-message blockquote,
+.markdown-message ul,
+.markdown-message ol,
+.markdown-message pre,
+.markdown-message table {
+  margin-block: 0 0.75em;
+}
+
+.markdown-message h1,
+.markdown-message h2,
+.markdown-message h3,
+.markdown-message h4,
+.markdown-message h5,
+.markdown-message h6 {
+  margin-block: 1em 0.45em;
+  color: var(--text-primary);
+  font-weight: var(--font-weight-semibold);
+  line-height: var(--line-height-tight);
+}
+
+.markdown-message h1 {
+  font-size: var(--font-size-2xl);
+}
+
+.markdown-message h2 {
+  font-size: var(--font-size-xl);
+}
+
+.markdown-message h3,
+.markdown-message h4,
+.markdown-message h5,
+.markdown-message h6 {
+  font-size: var(--font-size-lg);
+}
+
+.markdown-message a {
+  color: var(--text-link);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+}
+
+.markdown-message blockquote {
+  border-inline-start: 2px solid var(--border-strong);
+  color: var(--text-secondary);
+  padding-inline-start: var(--space-3);
+}
+
+.markdown-message ul,
+.markdown-message ol {
+  padding-inline-start: 1.35rem;
+}
+
+.markdown-message li + li {
+  margin-block-start: 0.25em;
+}
+
+.markdown-message code {
+  border-radius: var(--radius-xs);
+  background: var(--surface-code);
+  font-family: var(--font-mono);
+  font-size: 0.92em;
+  padding: 0.08em 0.28em;
+}
+
+.markdown-message pre {
+  overflow-x: auto;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--surface-code);
+  padding: var(--space-3);
+}
+
+.markdown-message pre code {
+  display: block;
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
+  white-space: pre;
+}
+
+.markdown-message table {
+  display: block;
+  max-width: 100%;
+  overflow-x: auto;
+  border-collapse: collapse;
+}
+
+.markdown-message th,
+.markdown-message td {
+  border: 1px solid var(--border-subtle);
+  padding: var(--space-1_5) var(--space-2);
+  text-align: start;
+  vertical-align: top;
+}
+
+.markdown-message th {
+  background: var(--surface-panel);
+  font-weight: var(--font-weight-semibold);
+}
+
+.markdown-message hr {
+  border: 0;
+  border-block-start: 1px solid var(--border-divider);
+  margin-block: var(--space-4);
+}
+
 @media (max-width: 767px) {
   aside[data-variant] {
     top: var(--safe-area-inset-top);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -181,6 +181,12 @@ importers:
       hono:
         specifier: ^4.12.12
         version: 4.12.12
+      marked:
+        specifier: ^18.0.2
+        version: 18.0.2
+      sanitize-html:
+        specifier: ^2.17.3
+        version: 2.17.3
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -188,6 +194,9 @@ importers:
       '@types/node':
         specifier: ^25.5.0
         version: 25.6.0
+      '@types/sanitize-html':
+        specifier: ^2.16.1
+        version: 2.16.1
       tsdown:
         specifier: ^0.21.8
         version: 0.21.8(@typescript/native-preview@7.0.0-dev.20260417.1)(typescript@5.9.3)
@@ -1667,6 +1676,9 @@ packages:
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
+  '@types/sanitize-html@2.16.1':
+    resolution: {integrity: sha512-n9wjs8bCOTyN/ynwD8s/nTcTreIHB1vf31vhLMGqUPNHaweKC4/fAl4Dj+hUlCTKYgm4P3k83fmiFfzkZ6sgMA==}
+
   '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260417.1':
     resolution: {integrity: sha512-TSV/P3OlMs3iua4dus60uphUwuB0DXnx+1nNazpcAhrpi1oAP6SyKcpYR0D+pqa55i+BDUHVAqpj/AP6pWli8Q==}
     cpu: [arm64]
@@ -1940,6 +1952,10 @@ packages:
       supports-color:
         optional: true
 
+  deepmerge@4.3.1:
+    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
+    engines: {node: '>=0.10.0'}
+
   default-browser-id@5.0.1:
     resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
     engines: {node: '>=18'}
@@ -1969,6 +1985,19 @@ packages:
   diff@4.0.4:
     resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
     engines: {node: '>=0.3.1'}
+
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
   dts-resolver@2.1.3:
     resolution: {integrity: sha512-bihc7jPC90VrosXNzK0LTE2cuLP6jr0Ro8jk+kMugHReJVLIpHz/xadeq3MhuwyO4TD4OA3L1Q8pBBFRc08Tsw==}
@@ -2001,6 +2030,14 @@ packages:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
 
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
     engines: {node: '>= 0.4'}
@@ -2027,6 +2064,10 @@ packages:
 
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -2162,6 +2203,9 @@ packages:
   hookable@6.1.1:
     resolution: {integrity: sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==}
 
+  htmlparser2@10.1.0:
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
+
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
@@ -2214,6 +2258,10 @@ packages:
     resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
     engines: {node: '>=14.16'}
     hasBin: true
+
+  is-plain-object@5.0.0:
+    resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
+    engines: {node: '>=0.10.0'}
 
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
@@ -2415,6 +2463,11 @@ packages:
   make-error@1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
 
+  marked@18.0.2:
+    resolution: {integrity: sha512-NsmlUYBS/Zg57rgDWMYdnre6OTj4e+qq/JS2ot3KrYLSoHLw+sDu0Nm1ZGpRgYAq6c+b1ekaY5NzVchMCQnzcg==}
+    engines: {node: '>= 20'}
+    hasBin: true
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -2506,6 +2559,9 @@ packages:
     peerDependenciesMeta:
       oxlint-tsgolint:
         optional: true
+
+  parse-srcset@1.0.2:
+    resolution: {integrity: sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==}
 
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
@@ -2710,6 +2766,9 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  sanitize-html@2.17.3:
+    resolution: {integrity: sha512-Kn4srCAo2+wZyvCNKCSyB2g8RQ8IkX/gQs2uqoSRNu5t9I2qvUyAVvRDiFUVAiX3N3PNuwStY0eNr+ooBHVWEg==}
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
@@ -4512,6 +4571,10 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/sanitize-html@2.16.1':
+    dependencies:
+      htmlparser2: 10.1.0
+
   '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260417.1':
     optional: true
 
@@ -4770,6 +4833,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  deepmerge@4.3.1: {}
+
   default-browser-id@5.0.1: {}
 
   default-browser@5.5.0:
@@ -4788,6 +4853,24 @@ snapshots:
   detect-node-es@1.1.0: {}
 
   diff@4.0.4: {}
+
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
 
   dts-resolver@2.1.3: {}
 
@@ -4809,6 +4892,10 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.2
+
+  entities@4.5.0: {}
+
+  entities@7.0.1: {}
 
   es-define-property@1.0.1: {}
 
@@ -4853,6 +4940,8 @@ snapshots:
   escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
+
+  escape-string-regexp@4.0.0: {}
 
   estree-walker@3.0.3:
     dependencies:
@@ -5004,6 +5093,13 @@ snapshots:
 
   hookable@6.1.1: {}
 
+  htmlparser2@10.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
+
   http-errors@2.0.1:
     dependencies:
       depd: 2.0.0
@@ -5044,6 +5140,8 @@ snapshots:
   is-inside-container@1.0.0:
     dependencies:
       is-docker: 3.0.0
+
+  is-plain-object@5.0.0: {}
 
   is-promise@4.0.0: {}
 
@@ -5185,6 +5283,8 @@ snapshots:
 
   make-error@1.3.6: {}
 
+  marked@18.0.2: {}
+
   math-intrinsics@1.1.0: {}
 
   media-typer@1.1.0: {}
@@ -5289,6 +5389,8 @@ snapshots:
       '@oxlint/binding-win32-arm64-msvc': 1.59.0
       '@oxlint/binding-win32-ia32-msvc': 1.59.0
       '@oxlint/binding-win32-x64-msvc': 1.59.0
+
+  parse-srcset@1.0.2: {}
 
   parseurl@1.3.3: {}
 
@@ -5525,6 +5627,15 @@ snapshots:
       tslib: 2.8.1
 
   safer-buffer@2.1.2: {}
+
+  sanitize-html@2.17.3:
+    dependencies:
+      deepmerge: 4.3.1
+      escape-string-regexp: 4.0.0
+      htmlparser2: 10.1.0
+      is-plain-object: 5.0.0
+      parse-srcset: 1.0.2
+      postcss: 8.5.9
 
   scheduler@0.23.2:
     dependencies:


### PR DESCRIPTION
## Summary

- Render chat message Markdown on the server and return sanitized `textHtml` from the messages API.
- Display assistant messages as rendered Markdown in the web chat while keeping user/error output as plain text.
- Add Markdown presentation styles and coverage for rendering, sanitization, and RPC response shape.

## Why

Chat output is usually Markdown, but the web UI was showing raw text. Server-side rendering keeps Markdown parsing and XSS sanitization centralized at the API boundary while preserving Markdown as the stored source of truth.

## Validation

- `pnpm ready`