### PR TITLE
[codex] fix web chat stream events

### DIFF
--- a/packages/web/src/routes/chat-message-stream-order.test.ts
+++ b/packages/web/src/routes/chat-message-stream-order.test.ts
@@ -1,0 +1,134 @@
+import { deepStrictEqual } from "node:assert";
+import { describe, it } from "vitest";
+import { mergeStreamingMessagesForDisplay } from "./chat-message-stream-order";
+import type { ChatMessageRecord } from "@phantompane/server";
+
+function createMessage(
+  id: string,
+  role: ChatMessageRecord["role"],
+  text: string,
+  overrides: Partial<ChatMessageRecord> = {},
+): ChatMessageRecord {
+  return {
+    id,
+    chatId: "chat_1",
+    role,
+    text,
+    createdAt: "2026-05-05T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("mergeStreamingMessagesForDisplay", () => {
+  it("appends new stream messages instead of accepting a server-prepended event", () => {
+    const currentMessages = [
+      createMessage("msg_user", "user", "fix chat"),
+      createMessage("msg_assistant", "assistant", "working"),
+    ];
+    const incomingMessages = [
+      createMessage("msg_event", "event", "pnpm test", {
+        eventType: "item/commandExecution/outputDelta",
+        itemId: "cmd_1",
+      }),
+      currentMessages[0]!,
+      currentMessages[1]!,
+    ];
+
+    const mergedMessages = mergeStreamingMessagesForDisplay(
+      currentMessages,
+      incomingMessages,
+    );
+
+    deepStrictEqual(
+      mergedMessages.map((message) => message.id),
+      ["msg_user", "msg_assistant", "msg_event"],
+    );
+  });
+
+  it("moves updated stream events to the bottom while preserving other message order", () => {
+    const currentMessages = [
+      createMessage("msg_user", "user", "fix chat"),
+      createMessage("msg_event", "event", "first", {
+        eventData: { text: "first" },
+        eventType: "item/commandExecution/outputDelta",
+        itemId: "cmd_1",
+      }),
+      createMessage("msg_assistant", "assistant", "working"),
+    ];
+    const incomingMessages = [
+      currentMessages[0]!,
+      createMessage("msg_event", "event", "first second", {
+        eventData: { text: "first second" },
+        eventType: "item/commandExecution/outputDelta",
+        itemId: "cmd_1",
+      }),
+      currentMessages[2]!,
+    ];
+
+    const mergedMessages = mergeStreamingMessagesForDisplay(
+      currentMessages,
+      incomingMessages,
+    );
+
+    deepStrictEqual(
+      mergedMessages.map((message) => [message.id, message.text]),
+      [
+        ["msg_user", "fix chat"],
+        ["msg_assistant", "working"],
+        ["msg_event", "first second"],
+      ],
+    );
+  });
+
+  it("keeps updated stream events below new assistant messages from the same refresh", () => {
+    const currentMessages = [
+      createMessage("msg_user", "user", "fix chat"),
+      createMessage("msg_event", "event", "first", {
+        eventData: { text: "first" },
+        eventType: "item/commandExecution/outputDelta",
+        itemId: "cmd_1",
+      }),
+    ];
+    const incomingMessages = [
+      currentMessages[0]!,
+      createMessage("msg_event", "event", "first second", {
+        eventData: { text: "first second" },
+        eventType: "item/commandExecution/outputDelta",
+        itemId: "cmd_1",
+      }),
+      createMessage("msg_assistant", "assistant", "working"),
+    ];
+
+    const mergedMessages = mergeStreamingMessagesForDisplay(
+      currentMessages,
+      incomingMessages,
+    );
+
+    deepStrictEqual(
+      mergedMessages.map((message) => [message.id, message.text]),
+      [
+        ["msg_user", "fix chat"],
+        ["msg_assistant", "working"],
+        ["msg_event", "first second"],
+      ],
+    );
+  });
+
+  it("drops messages removed by the incoming refresh", () => {
+    const currentMessages = [
+      createMessage("msg_user", "user", "fix chat"),
+      createMessage("msg_deleted", "user", "queued"),
+    ];
+    const incomingMessages = [currentMessages[0]!];
+
+    const mergedMessages = mergeStreamingMessagesForDisplay(
+      currentMessages,
+      incomingMessages,
+    );
+
+    deepStrictEqual(
+      mergedMessages.map((message) => message.id),
+      ["msg_user"],
+    );
+  });
+});

--- a/packages/web/src/routes/chat-message-stream-order.ts
+++ b/packages/web/src/routes/chat-message-stream-order.ts
@@ -1,0 +1,95 @@
+import type { ChatMessageRecord } from "@phantompane/server";
+
+export function mergeStreamingMessagesForDisplay(
+  currentMessages: ChatMessageRecord[],
+  incomingMessages: ChatMessageRecord[],
+): ChatMessageRecord[] {
+  if (currentMessages.length === 0) {
+    return incomingMessages;
+  }
+
+  const currentIds = new Set(currentMessages.map((message) => message.id));
+  const incomingMessagesById = new Map(
+    incomingMessages.map((message) => [message.id, message]),
+  );
+  const updatedStreamEventIds = new Set<string>();
+  const retainedMessages: ChatMessageRecord[] = [];
+
+  for (const currentMessage of currentMessages) {
+    const incomingMessage = incomingMessagesById.get(currentMessage.id);
+    if (!incomingMessage) {
+      continue;
+    }
+
+    if (isUpdatedStreamEvent(currentMessage, incomingMessage)) {
+      updatedStreamEventIds.add(incomingMessage.id);
+      continue;
+    }
+
+    retainedMessages.push(incomingMessage);
+  }
+
+  const newMessages = incomingMessages.filter(
+    (message) => !currentIds.has(message.id),
+  );
+  const updatedStreamEvents = incomingMessages.filter(
+    (message) =>
+      currentIds.has(message.id) && updatedStreamEventIds.has(message.id),
+  );
+
+  return [...retainedMessages, ...newMessages, ...updatedStreamEvents];
+}
+
+function isUpdatedStreamEvent(
+  currentMessage: ChatMessageRecord,
+  incomingMessage: ChatMessageRecord,
+): boolean {
+  return (
+    incomingMessage.role === "event" &&
+    currentMessage.role === "event" &&
+    currentMessage.id === incomingMessage.id &&
+    hasStreamEventContentChanged(currentMessage, incomingMessage)
+  );
+}
+
+function hasStreamEventContentChanged(
+  currentMessage: ChatMessageRecord,
+  incomingMessage: ChatMessageRecord,
+): boolean {
+  return (
+    currentMessage.text !== incomingMessage.text ||
+    currentMessage.eventType !== incomingMessage.eventType ||
+    currentMessage.itemId !== incomingMessage.itemId ||
+    stableSerialize(currentMessage.eventData) !==
+      stableSerialize(incomingMessage.eventData)
+  );
+}
+
+function stableSerialize(value: unknown): string {
+  if (value === undefined) {
+    return "";
+  }
+  try {
+    return JSON.stringify(sortRecordKeys(value)) ?? "";
+  } catch {
+    return "";
+  }
+}
+
+function sortRecordKeys(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sortRecordKeys);
+  }
+  if (!isRecord(value)) {
+    return value;
+  }
+  return Object.fromEntries(
+    Object.entries(value)
+      .sort(([leftKey], [rightKey]) => leftKey.localeCompare(rightKey))
+      .map(([key, item]) => [key, sortRecordKeys(item)]),
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}

--- a/packages/web/src/routes/home.tsx
+++ b/packages/web/src/routes/home.tsx
@@ -147,6 +147,7 @@ import {
   getWarningEventText,
   isRichEventMessage,
 } from "./rich-events";
+import { mergeStreamingMessagesForDisplay } from "./chat-message-stream-order";
 import type {
   ChatMessageRecord,
   ChatRecord,
@@ -185,6 +186,15 @@ const chatEventNames = [
   "agent.event",
   "auth.updated",
 ];
+const streamOrderPreservingChatEventNames = new Set([
+  "agent.plan.updated",
+  "agent.diff.updated",
+  "agent.command.output",
+  "agent.file.updated",
+  "agent.reasoning.updated",
+  "agent.item.updated",
+  "agent.item.delta",
+]);
 
 const chatScrollStorageKeyPrefix = "phantom.chatScroll:v1:";
 const chatScrollBottomThreshold = 4;
@@ -525,6 +535,8 @@ export function HomeRoute() {
   );
   const [messages, setMessages] = useState<ChatMessageRecord[]>([]);
   const [messagesChatId, setMessagesChatId] = useState<string | null>(null);
+  const messagesChatIdRef = useRef(messagesChatId);
+  messagesChatIdRef.current = messagesChatId;
   const [isAddProjectOpen, setIsAddProjectOpen] = useState(false);
   const [projectPath, setProjectPath] = useState("");
   const [deleteProjectTarget, setDeleteProjectTarget] = useState<string | null>(
@@ -1321,7 +1333,11 @@ export function HomeRoute() {
       void queryClient.invalidateQueries({
         queryKey: queryKeys.chat(selectedChatId),
       });
-      void refreshMessages(selectedChatId);
+      void refreshMessages(selectedChatId, {
+        preserveStreamOrder: streamOrderPreservingChatEventNames.has(
+          phantomEvent.type,
+        ),
+      });
       void refreshSelectedChat(selectedChatId);
       if (selectedProjectId) {
         void queryClient.invalidateQueries({
@@ -1915,7 +1931,7 @@ export function HomeRoute() {
 
   async function refreshMessages(
     chatId: string,
-    options: { showLoading?: boolean } = {},
+    options: { preserveStreamOrder?: boolean; showLoading?: boolean } = {},
   ) {
     const requestId = messagesRefreshRequestIdRef.current + 1;
     messagesRefreshRequestIdRef.current = requestId;
@@ -1928,7 +1944,14 @@ export function HomeRoute() {
         selectedChatIdRef.current === chatId &&
         messagesRefreshRequestIdRef.current === requestId
       ) {
-        setMessages(data.messages);
+        const shouldPreserveStreamOrder =
+          options.preserveStreamOrder === true &&
+          messagesChatIdRef.current === chatId;
+        setMessages((currentMessages) =>
+          shouldPreserveStreamOrder
+            ? mergeStreamingMessagesForDisplay(currentMessages, data.messages)
+            : data.messages,
+        );
         setMessagesChatId(chatId);
         setTimelineError(null);
       }


### PR DESCRIPTION
## Summary

Fixes the web chat timeline ordering while a chat is streaming. Command output, file-change output, and other rich event messages now preserve the existing visible timeline and append newly created or updated stream events near the bottom instead of accepting a refreshed server order that can place them above the active chat content.

## Root cause

The web client refreshed the full message list for each chat SSE event and rendered the returned array directly. During active streams, server-side merged history can put local rich event records before the active assistant content, so command/file logs appeared above the chat being streamed.

## Changes

- Added a display-only stream-order merge helper for chat message refreshes.
- Applied that helper only to SSE-driven message refreshes, leaving initial loads and explicit mutation refreshes to use server order.
- Added coverage for server-prepended events, updated event messages, and removed messages.

## Validation

- `pnpm --filter @phantompane/web test -- chat-message-stream-order`
- `pnpm --filter @phantompane/web typecheck`
- `pnpm ready`