### PR TITLE
[codex] Hide archived chats from sidebar

### DIFF
--- a/packages/web/src/routes/home-url-state.test.ts
+++ b/packages/web/src/routes/home-url-state.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  dedupeChatThreads,
   findValidatedSelectedProjectChat,
   findValidatedSelectedChat,
   getSelectableReasoningEfforts,
@@ -216,6 +217,91 @@ describe("mergeWorktreesWithChats", () => {
         chatId: "chat-current",
         chatStatus: "idle",
         chatTitle: "current",
+      },
+    ]);
+  });
+
+  it("clears worktree chat selection when only archived chats remain", () => {
+    const worktrees = [
+      {
+        name: "feature",
+        path: "/repo/feature",
+        chatId: "chat-stale",
+        chatStatus: "archived",
+        chatTitle: "archived",
+      },
+    ];
+    const chats = [
+      {
+        id: "chat-archived",
+        worktreePath: "/repo/feature",
+        title: "archived",
+        status: "archived",
+        updatedAt: "2026-04-25T00:01:00.000Z",
+      },
+    ];
+
+    expect(mergeWorktreesWithChats(worktrees, chats)).toEqual([
+      {
+        name: "feature",
+        path: "/repo/feature",
+        chatId: null,
+        chatStatus: null,
+        chatTitle: "feature",
+      },
+    ]);
+  });
+});
+
+describe("dedupeChatThreads", () => {
+  it("prefers a non-archived chat over a newer archived duplicate thread", () => {
+    expect(
+      dedupeChatThreads([
+        {
+          codexThreadId: "thread-1",
+          id: "chat-active",
+          status: "idle",
+          updatedAt: "2026-04-25T00:00:00.000Z",
+        },
+        {
+          codexThreadId: "thread-1",
+          id: "chat-archived",
+          status: "archived",
+          updatedAt: "2026-04-25T00:01:00.000Z",
+        },
+      ]),
+    ).toEqual([
+      {
+        codexThreadId: "thread-1",
+        id: "chat-active",
+        status: "idle",
+        updatedAt: "2026-04-25T00:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("keeps the latest archived chat when a thread has no active duplicate", () => {
+    expect(
+      dedupeChatThreads([
+        {
+          codexThreadId: "thread-1",
+          id: "chat-archived-old",
+          status: "archived",
+          updatedAt: "2026-04-25T00:00:00.000Z",
+        },
+        {
+          codexThreadId: "thread-1",
+          id: "chat-archived-new",
+          status: "archived",
+          updatedAt: "2026-04-25T00:01:00.000Z",
+        },
+      ]),
+    ).toEqual([
+      {
+        codexThreadId: "thread-1",
+        id: "chat-archived-new",
+        status: "archived",
+        updatedAt: "2026-04-25T00:01:00.000Z",
       },
     ]);
   });

--- a/packages/web/src/routes/home-url-state.ts
+++ b/packages/web/src/routes/home-url-state.ts
@@ -30,6 +30,13 @@ interface WorktreeChatMergeRecord<TStatus extends string> {
   worktreePath: string;
 }
 
+interface ChatThreadDedupeRecord<TStatus extends string> {
+  codexThreadId: string | null;
+  id: string;
+  status: TStatus;
+  updatedAt: string;
+}
+
 interface WorktreeMergeRecord<TStatus extends string> {
   chatId: string | null;
   chatStatus: TStatus | null;
@@ -130,16 +137,12 @@ export function mergeWorktreesWithChats<
 >(worktrees: TWorktree[], chats: TChat[]): TWorktree[] {
   const latestChatsByPath = new Map<string, TChat>();
   for (const chat of chats) {
+    if (chat.status === "archived") {
+      continue;
+    }
+
     const current = latestChatsByPath.get(chat.worktreePath);
-    if (
-      !current ||
-      (current.status === "archived" && chat.status !== "archived") ||
-      (current.status === chat.status &&
-        chat.updatedAt.localeCompare(current.updatedAt) > 0) ||
-      (current.status !== "archived" &&
-        chat.status !== "archived" &&
-        chat.updatedAt.localeCompare(current.updatedAt) > 0)
-    ) {
+    if (!current || chat.updatedAt.localeCompare(current.updatedAt) > 0) {
       latestChatsByPath.set(chat.worktreePath, chat);
     }
   }
@@ -160,6 +163,35 @@ export function mergeWorktreesWithChats<
       chatTitle: chat.title,
     };
   });
+}
+
+export function dedupeChatThreads<
+  TStatus extends string,
+  TChat extends ChatThreadDedupeRecord<TStatus>,
+>(chats: TChat[]): TChat[] {
+  const chatsWithThreads = chats.filter((chat) => chat.codexThreadId);
+  const source = chatsWithThreads.length > 0 ? chatsWithThreads : chats;
+  const chatsByThread = new Map<string, TChat>();
+
+  for (const chat of source) {
+    const key = chat.codexThreadId ?? chat.id;
+    const current = chatsByThread.get(key);
+    if (
+      !current ||
+      (current.status === "archived" && chat.status !== "archived") ||
+      (current.status === chat.status &&
+        chat.updatedAt.localeCompare(current.updatedAt) > 0) ||
+      (current.status !== "archived" &&
+        chat.status !== "archived" &&
+        chat.updatedAt.localeCompare(current.updatedAt) > 0)
+    ) {
+      chatsByThread.set(key, chat);
+    }
+  }
+
+  return [...chatsByThread.values()].sort((left, right) =>
+    right.updatedAt.localeCompare(left.updatedAt),
+  );
 }
 
 export function isKnownWorktreeChat<TWorktree extends WorktreeSelectionRecord>(

--- a/packages/web/src/routes/home.tsx
+++ b/packages/web/src/routes/home.tsx
@@ -126,6 +126,7 @@ import {
 } from "../lib/composer-keyboard";
 import { cn } from "../lib/utils";
 import {
+  dedupeChatThreads,
   findValidatedSelectedProjectChat,
   findValidatedSelectedChat,
   getSelectableReasoningEfforts,
@@ -406,24 +407,6 @@ function formatLeadingEllipsisPath(path: string, maxLength = 44): string {
   const suffix = path.slice(-suffixLength);
   const slashIndex = suffix.indexOf("/");
   return `...${slashIndex > 0 ? suffix.slice(slashIndex) : suffix}`;
-}
-
-function dedupeChatThreads(chats: ChatRecord[]): ChatRecord[] {
-  const chatsWithThreads = chats.filter((chat) => chat.codexThreadId);
-  const source = chatsWithThreads.length > 0 ? chatsWithThreads : chats;
-  const chatsByThread = new Map<string, ChatRecord>();
-
-  for (const chat of source) {
-    const key = chat.codexThreadId ?? chat.id;
-    const current = chatsByThread.get(key);
-    if (!current || chat.updatedAt.localeCompare(current.updatedAt) > 0) {
-      chatsByThread.set(key, chat);
-    }
-  }
-
-  return [...chatsByThread.values()].sort((left, right) =>
-    right.updatedAt.localeCompare(left.updatedAt),
-  );
 }
 
 function getChatScrollStorageKey(chatId: string): string {
@@ -3963,11 +3946,8 @@ function SidebarChatList({
   selectedChatId: string | null;
 }) {
   const activeChats = chats.filter((chat) => chat.status !== "archived");
-  const archivedChats = chats.filter((chat) => chat.status === "archived");
   const renderChat = (chat: ChatRecord) => {
     const isSelected = chat.id === selectedChatId;
-    const isArchived = chat.status === "archived";
-    const archiveLabel = isArchived ? "Restore chat" : "Archive chat";
 
     return (
       <li className="group/chat min-w-0" key={chat.id}>
@@ -4020,15 +4000,11 @@ function SidebarChatList({
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
               <DropdownMenuItem
-                disabled={!isArchived && !canArchiveChat(chat)}
-                onSelect={() => onSetChatArchived(chat, !isArchived)}
+                disabled={!canArchiveChat(chat)}
+                onSelect={() => onSetChatArchived(chat, true)}
               >
-                {isArchived ? (
-                  <ArchiveRestore className="size-4" />
-                ) : (
-                  <Archive className="size-4" />
-                )}
-                <span>{archiveLabel}</span>
+                <Archive className="size-4" />
+                <span>Archive chat</span>
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
@@ -4046,20 +4022,12 @@ function SidebarChatList({
         <li className="px-2 py-1.5">
           <InlineLoading label="Loading chats" />
         </li>
-      ) : chats.length === 0 ? (
+      ) : activeChats.length === 0 ? (
         <li className="px-2 py-1.5 text-[length:var(--font-size-xs)] text-[var(--text-tertiary)]">
           No chat history
         </li>
       ) : (
-        <>
-          {activeChats.map(renderChat)}
-          {archivedChats.length > 0 && (
-            <li className="px-2 pt-1 text-[length:var(--font-size-2xs)] font-medium uppercase text-[var(--text-tertiary)]">
-              Archived
-            </li>
-          )}
-          {archivedChats.map(renderChat)}
-        </>
+        activeChats.map(renderChat)
       )}
     </ul>
   );


### PR DESCRIPTION
## Summary

Hide archived chats from the sidebar chat history list so only active chat history remains visible under each worktree.

## Why

Archived chats were still rendered in a separate sidebar section after archive, keeping them visible in the primary chat list. The sidebar now treats archived chats as hidden history and shows the empty state when no non-archived chats remain.

## Validation

- `pnpm ready`

## Notes

- Consulted `DESIGN.md` for the sidebar UI change.