### PR TITLE
[codex] compact chat event display

### DIFF
--- a/packages/web/src/routes/home.tsx
+++ b/packages/web/src/routes/home.tsx
@@ -147,6 +147,7 @@ import {
   getWarningEventText,
   isRichEventMessage,
 } from "./rich-events";
+import type { RichFileChange } from "./rich-events";
 import { mergeStreamingMessagesForDisplay } from "./chat-message-stream-order";
 import type {
   ChatRecord,
@@ -4560,29 +4561,24 @@ function PlanEventCard({ message }: { message: VisibleMessageRecord }) {
 
 function DiffEventCard({ message }: { message: VisibleMessageRecord }) {
   const { diff, files } = getDiffEventData(message);
+  const lineDelta = getDiffLineDelta(diff || message.text);
   return (
     <RichEventShell
+      defaultOpen={false}
       icon={<FileDiff className="size-4" />}
-      meta={`${files.length} file${files.length === 1 ? "" : "s"}`}
-      title="Diff updated"
+      meta={formatEventMeta([
+        formatCount(files.length, "file"),
+        formatLineDelta(lineDelta),
+      ])}
+      summary={
+        files.length > 0 ? (
+          <CompactPathList paths={files} />
+        ) : (
+          <span className="truncate text-muted-foreground">No files</span>
+        )
+      }
+      title="Diff"
     >
-      {files.length > 0 && (
-        <div className="mb-2 flex flex-wrap gap-1.5">
-          {files.slice(0, 6).map((file) => (
-            <span
-              className="max-w-full truncate rounded-[var(--radius-sm)] border border-[var(--border-subtle)] bg-[var(--surface-panel)] px-1.5 py-0.5 font-mono text-[length:var(--font-size-xs)] text-muted-foreground"
-              key={file}
-            >
-              {file}
-            </span>
-          ))}
-          {files.length > 6 && (
-            <span className="text-[length:var(--font-size-xs)] text-muted-foreground">
-              +{files.length - 6}
-            </span>
-          )}
-        </div>
-      )}
       <CollapsibleCode title="Unified diff" value={diff || message.text} />
     </RichEventShell>
   );
@@ -4591,20 +4587,28 @@ function DiffEventCard({ message }: { message: VisibleMessageRecord }) {
 function CommandEventCard({ message }: { message: VisibleMessageRecord }) {
   const output = getRichEventText(message);
   const meta = getCommandEventMeta(message);
+  const outputLineCount = getTextLineCount(output);
   return (
     <RichEventShell
+      defaultOpen={false}
       icon={<Terminal className="size-4" />}
-      meta={meta.status ?? meta.stream ?? "output"}
-      title={meta.command ? "Command execution" : "Command output"}
-    >
-      {meta.command && (
-        <p
-          className="mb-2 min-w-0 break-words font-mono text-[length:var(--font-size-xs)] text-muted-foreground"
+      meta={formatEventMeta([
+        meta.status,
+        meta.exitCode !== null ? `exit ${meta.exitCode}` : null,
+        meta.durationMs !== null ? formatDurationMs(meta.durationMs) : null,
+        outputLineCount > 0 ? formatCount(outputLineCount, "line") : null,
+        meta.capReached ? "truncated" : null,
+      ])}
+      summary={
+        <span
+          className="truncate font-mono text-[length:var(--font-size-xs)] text-[var(--text-secondary)]"
           title={meta.cwd ?? undefined}
         >
-          {meta.command}
-        </p>
-      )}
+          {meta.command ?? meta.stream ?? "output"}
+        </span>
+      }
+      title="Command"
+    >
       {(meta.status || meta.exitCode !== null || meta.durationMs !== null) && (
         <div className="mb-2 flex flex-wrap gap-1.5">
           {meta.status && (
@@ -4637,24 +4641,46 @@ function FileEventCard({ message }: { message: VisibleMessageRecord }) {
   const meta = getFileEventMeta(message);
   const output = getRichEventText(message);
   if (message.eventType === "item/fileChange/outputDelta") {
+    const outputLineCount = getTextLineCount(output);
     return (
       <RichEventShell
+        defaultOpen={false}
         icon={<FileText className="size-4" />}
-        meta="output"
-        title="File change output"
+        meta={formatEventMeta([
+          "output",
+          outputLineCount > 0 ? formatCount(outputLineCount, "line") : null,
+        ])}
+        summary={
+          <span className="truncate text-muted-foreground">
+            File change output
+          </span>
+        }
+        title="File"
       >
         <CollapsibleCode title="Output" value={output} />
       </RichEventShell>
     );
   }
+  const lineDelta = getFileChangesLineDelta(changes);
   return (
     <RichEventShell
+      defaultOpen={false}
       icon={<FileText className="size-4" />}
-      meta={
-        meta.status ??
-        `${changes.length} file${changes.length === 1 ? "" : "s"}`
+      meta={formatEventMeta([
+        meta.status,
+        formatCount(changes.length, "file"),
+        formatLineDelta(lineDelta),
+      ])}
+      summary={
+        changes.length > 0 ? (
+          <CompactPathList paths={changes.map((change) => change.path)} />
+        ) : (
+          <span className="truncate text-muted-foreground">
+            {message.text || "No files"}
+          </span>
+        )
       }
-      title="File patch updated"
+      title="File edit"
     >
       {meta.status && (
         <div className="mb-2 flex flex-wrap gap-1.5">
@@ -4671,10 +4697,10 @@ function FileEventCard({ message }: { message: VisibleMessageRecord }) {
           {message.text}
         </p>
       ) : (
-        <div className="space-y-2">
+        <div className="space-y-1.5">
           {changes.map((change) => (
             <div
-              className="rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--surface-panel)]"
+              className="rounded-[var(--radius-sm)] border border-[var(--border-subtle)] bg-[var(--surface-panel)]"
               key={`${change.kind}:${change.path}`}
             >
               <div className="flex min-w-0 items-center gap-2 px-2 py-1.5">
@@ -4683,6 +4709,9 @@ function FileEventCard({ message }: { message: VisibleMessageRecord }) {
                 </Badge>
                 <span className="truncate font-mono text-[length:var(--font-size-xs)]">
                   {change.path}
+                </span>
+                <span className="ml-auto shrink-0 font-mono text-[length:var(--font-size-xs)] text-muted-foreground">
+                  {formatLineDelta(getDiffLineDelta(change.diff))}
                 </span>
               </div>
               {change.diff && (
@@ -4722,22 +4751,104 @@ function formatDurationMs(durationMs: number): string {
     : `${durationMs}ms`;
 }
 
+function formatCount(count: number, label: string): string {
+  return `${count} ${label}${count === 1 ? "" : "s"}`;
+}
+
+function formatEventMeta(
+  parts: Array<null | string | undefined>,
+): string | undefined {
+  const visibleParts = parts.filter((part): part is string =>
+    Boolean(part && part.trim()),
+  );
+  return visibleParts.length > 0 ? visibleParts.join(" · ") : undefined;
+}
+
+function getTextLineCount(value: string): number {
+  const trimmedValue = value.trimEnd();
+  return trimmedValue ? trimmedValue.split(/\r?\n/).length : 0;
+}
+
+function getDiffLineDelta(diff: string): { added: number; removed: number } {
+  let added = 0;
+  let removed = 0;
+  for (const line of diff.split(/\r?\n/)) {
+    if (line.startsWith("+++") || line.startsWith("---")) {
+      continue;
+    }
+    if (line.startsWith("+")) {
+      added += 1;
+      continue;
+    }
+    if (line.startsWith("-")) {
+      removed += 1;
+    }
+  }
+  return { added, removed };
+}
+
+function getFileChangesLineDelta(changes: RichFileChange[]): {
+  added: number;
+  removed: number;
+} {
+  return changes.reduce(
+    (total, change) => {
+      const changeDelta = getDiffLineDelta(change.diff);
+      return {
+        added: total.added + changeDelta.added,
+        removed: total.removed + changeDelta.removed,
+      };
+    },
+    { added: 0, removed: 0 },
+  );
+}
+
+function formatLineDelta(delta: { added: number; removed: number }): string {
+  if (delta.added === 0 && delta.removed === 0) {
+    return "0 lines";
+  }
+  return `+${delta.added} -${delta.removed}`;
+}
+
+function CompactPathList({ paths }: { paths: string[] }) {
+  const visiblePaths = paths.slice(0, 3);
+  return (
+    <span className="flex min-w-0 flex-1 items-center gap-1 overflow-hidden">
+      {visiblePaths.map((path) => (
+        <span
+          className="min-w-0 max-w-48 truncate rounded-[var(--radius-xs)] border border-[var(--border-subtle)] bg-[var(--surface-panel)] px-1.5 py-0.5 font-mono text-[length:var(--font-size-xs)] text-[var(--text-secondary)]"
+          key={path}
+          title={path}
+        >
+          {path}
+        </span>
+      ))}
+      {paths.length > visiblePaths.length && (
+        <span className="shrink-0 text-[length:var(--font-size-xs)] text-muted-foreground">
+          +{paths.length - visiblePaths.length}
+        </span>
+      )}
+    </span>
+  );
+}
+
 function ReasoningEventCard({ message }: { message: VisibleMessageRecord }) {
   const text = getRichEventText(message);
   return (
     <RichEventShell
+      defaultOpen={false}
       icon={<Brain className="size-4" />}
-      meta="collapsed"
+      meta={formatCount(getTextLineCount(text), "line")}
+      summary={
+        <span className="truncate text-muted-foreground">
+          Reasoning details
+        </span>
+      }
       title="Reasoning updated"
     >
-      <details>
-        <summary className="cursor-pointer text-[length:var(--font-size-sm)] text-muted-foreground">
-          Show reasoning
-        </summary>
-        <pre className="mt-2 whitespace-pre-wrap break-words rounded-[var(--radius-md)] bg-[var(--surface-code)] p-2 font-mono text-[length:var(--font-size-xs)] leading-[var(--line-height-relaxed)]">
-          {text}
-        </pre>
-      </details>
+      <pre className="whitespace-pre-wrap break-words rounded-[var(--radius-md)] bg-[var(--surface-code)] p-2 font-mono text-[length:var(--font-size-xs)] leading-[var(--line-height-relaxed)]">
+        {text}
+      </pre>
     </RichEventShell>
   );
 }
@@ -4762,39 +4873,57 @@ function WarningEventCard({ message }: { message: VisibleMessageRecord }) {
 
 function RichEventShell({
   children,
+  defaultOpen = true,
   icon,
   meta,
+  summary,
   title,
   tone = "neutral",
 }: {
   children: ReactNode;
+  defaultOpen?: boolean;
   icon: ReactNode;
   meta?: string;
+  summary?: ReactNode;
   title: string;
   tone?: "neutral" | "warning";
 }) {
   return (
-    <article
+    <details
       className={cn(
-        "w-full rounded-[var(--radius-md)] border bg-[var(--surface-card)] px-3 py-2 text-[var(--text-primary)]",
+        "group w-full rounded-[var(--radius-md)] border bg-[var(--surface-card)] text-[var(--text-primary)]",
         tone === "neutral" && "border-[var(--border-subtle)]",
         tone === "warning" &&
           "border-[var(--semantic-warning-border)] bg-[var(--semantic-warning-bg)] text-[var(--semantic-warning-fg)]",
       )}
+      open={defaultOpen || undefined}
     >
-      <div className="mb-2 flex min-w-0 items-center gap-2">
+      <summary
+        className="grid min-h-9 cursor-pointer list-none grid-cols-[auto_auto_minmax(0,auto)_minmax(0,1fr)_auto] items-center gap-2 px-2.5 py-1.5 outline-none transition-colors hover:bg-[var(--state-hover-bg)] focus-visible:shadow-[var(--state-focus-ring)] [&::-webkit-details-marker]:hidden"
+        title={meta}
+      >
+        <ChevronRight className="size-3.5 shrink-0 text-muted-foreground transition-transform group-open:rotate-90" />
         <span className="shrink-0 text-muted-foreground">{icon}</span>
-        <p className="min-w-0 flex-1 truncate text-[length:var(--font-size-sm)] font-semibold">
+        <span className="truncate text-[length:var(--font-size-sm)] font-semibold">
           {title}
-        </p>
+        </span>
+        {summary && <span className="min-w-0">{summary}</span>}
         {meta && (
-          <span className="shrink-0 text-[length:var(--font-size-xs)] text-muted-foreground">
+          <span className="shrink-0 truncate text-[length:var(--font-size-xs)] text-muted-foreground">
             {meta}
           </span>
         )}
+      </summary>
+      <div
+        className={cn(
+          "border-t px-3 py-2",
+          tone === "neutral" && "border-[var(--border-subtle)]",
+          tone === "warning" && "border-[var(--semantic-warning-border)]",
+        )}
+      >
+        {children}
       </div>
-      {children}
-    </article>
+    </details>
   );
 }
 
@@ -4808,14 +4937,14 @@ function CollapsibleCode({ title, value }: { title: string; value: string }) {
     );
   }
   return (
-    <details open={trimmedValue.length < 1200}>
-      <summary className="cursor-pointer text-[length:var(--font-size-sm)] text-muted-foreground">
+    <div>
+      <p className="mb-1 text-[length:var(--font-size-sm)] text-muted-foreground">
         {title}
-      </summary>
-      <pre className="mt-2 max-h-72 overflow-auto whitespace-pre-wrap break-words rounded-[var(--radius-md)] bg-[var(--surface-code)] p-2 font-mono text-[length:var(--font-size-xs)] leading-[var(--line-height-relaxed)]">
+      </p>
+      <pre className="max-h-72 overflow-auto whitespace-pre-wrap break-words rounded-[var(--radius-md)] bg-[var(--surface-code)] p-2 font-mono text-[length:var(--font-size-xs)] leading-[var(--line-height-relaxed)]">
         {trimmedValue}
       </pre>
-    </details>
+    </div>
   );
 }
 

--- a/packages/web/src/routes/home.tsx
+++ b/packages/web/src/routes/home.tsx
@@ -139,15 +139,17 @@ import {
 import {
   getCommandEventMeta,
   getDiffEventData,
+  getDiffLineDelta,
+  getFileChangesLineDelta,
   getFileEventMeta,
   getFilePatchEventData,
   getPlanEventData,
   getRichEventKind,
   getRichEventText,
+  getTextLineCount,
   getWarningEventText,
   isRichEventMessage,
 } from "./rich-events";
-import type { RichFileChange } from "./rich-events";
 import { mergeStreamingMessagesForDisplay } from "./chat-message-stream-order";
 import type {
   ChatRecord,
@@ -4601,14 +4603,22 @@ function CommandEventCard({ message }: { message: VisibleMessageRecord }) {
       ])}
       summary={
         <span
-          className="truncate font-mono text-[length:var(--font-size-xs)] text-[var(--text-secondary)]"
-          title={meta.cwd ?? undefined}
+          className="block min-w-0 max-w-full truncate font-mono text-[length:var(--font-size-xs)] text-[var(--text-secondary)]"
+          title={meta.command ?? meta.cwd ?? undefined}
         >
           {meta.command ?? meta.stream ?? "output"}
         </span>
       }
       title="Command"
     >
+      {meta.command && (
+        <p
+          className="mb-2 min-w-0 break-words font-mono text-[length:var(--font-size-xs)] text-muted-foreground"
+          title={meta.cwd ?? undefined}
+        >
+          {meta.command}
+        </p>
+      )}
       {(meta.status || meta.exitCode !== null || meta.durationMs !== null) && (
         <div className="mb-2 flex flex-wrap gap-1.5">
           {meta.status && (
@@ -4651,7 +4661,7 @@ function FileEventCard({ message }: { message: VisibleMessageRecord }) {
           outputLineCount > 0 ? formatCount(outputLineCount, "line") : null,
         ])}
         summary={
-          <span className="truncate text-muted-foreground">
+          <span className="block min-w-0 max-w-full truncate text-muted-foreground">
             File change output
           </span>
         }
@@ -4764,45 +4774,6 @@ function formatEventMeta(
   return visibleParts.length > 0 ? visibleParts.join(" · ") : undefined;
 }
 
-function getTextLineCount(value: string): number {
-  const trimmedValue = value.trimEnd();
-  return trimmedValue ? trimmedValue.split(/\r?\n/).length : 0;
-}
-
-function getDiffLineDelta(diff: string): { added: number; removed: number } {
-  let added = 0;
-  let removed = 0;
-  for (const line of diff.split(/\r?\n/)) {
-    if (line.startsWith("+++") || line.startsWith("---")) {
-      continue;
-    }
-    if (line.startsWith("+")) {
-      added += 1;
-      continue;
-    }
-    if (line.startsWith("-")) {
-      removed += 1;
-    }
-  }
-  return { added, removed };
-}
-
-function getFileChangesLineDelta(changes: RichFileChange[]): {
-  added: number;
-  removed: number;
-} {
-  return changes.reduce(
-    (total, change) => {
-      const changeDelta = getDiffLineDelta(change.diff);
-      return {
-        added: total.added + changeDelta.added,
-        removed: total.removed + changeDelta.removed,
-      };
-    },
-    { added: 0, removed: 0 },
-  );
-}
-
 function formatLineDelta(delta: { added: number; removed: number }): string {
   if (delta.added === 0 && delta.removed === 0) {
     return "0 lines";
@@ -4840,7 +4811,7 @@ function ReasoningEventCard({ message }: { message: VisibleMessageRecord }) {
       icon={<Brain className="size-4" />}
       meta={formatCount(getTextLineCount(text), "line")}
       summary={
-        <span className="truncate text-muted-foreground">
+        <span className="block min-w-0 max-w-full truncate text-muted-foreground">
           Reasoning details
         </span>
       }
@@ -4858,6 +4829,11 @@ function WarningEventCard({ message }: { message: VisibleMessageRecord }) {
   return (
     <RichEventShell
       icon={<AlertTriangle className="size-4" />}
+      summary={
+        <span className="block min-w-0 max-w-full truncate">
+          {warning.summary}
+        </span>
+      }
       tone="warning"
       title="Warning"
     >
@@ -4907,7 +4883,9 @@ function RichEventShell({
         <span className="truncate text-[length:var(--font-size-sm)] font-semibold">
           {title}
         </span>
-        {summary && <span className="min-w-0">{summary}</span>}
+        {summary && (
+          <span className="min-w-0 max-w-full overflow-hidden">{summary}</span>
+        )}
         {meta && (
           <span className="shrink-0 truncate text-[length:var(--font-size-xs)] text-muted-foreground">
             {meta}

--- a/packages/web/src/routes/rich-events.test.ts
+++ b/packages/web/src/routes/rich-events.test.ts
@@ -3,10 +3,13 @@ import { describe, it } from "vitest";
 import {
   getCommandEventMeta,
   getDiffEventData,
+  getDiffLineDelta,
+  getFileChangesLineDelta,
   getFileEventMeta,
   getPlanEventData,
   getRichEventKind,
   getRichEventText,
+  getTextLineCount,
   isRichEventMessage,
 } from "./rich-events";
 import type { ChatMessageRecord } from "@phantompane/server";
@@ -139,6 +142,40 @@ describe("rich event helpers", () => {
         }),
       ),
       { status: "failed" },
+    );
+  });
+
+  it("summarizes compact event line counts without dropping hunk content", () => {
+    strictEqual(getTextLineCount("one\ntwo\n"), 2);
+    deepStrictEqual(
+      getDiffLineDelta(
+        [
+          "diff --git a/a.ts b/a.ts",
+          "--- a/a.ts",
+          "+++ b/a.ts",
+          "@@ -1,2 +1,2 @@",
+          "+++ valid added content",
+          "--- valid removed content",
+          "+normal add",
+          "-normal remove",
+        ].join("\n"),
+      ),
+      { added: 2, removed: 2 },
+    );
+    deepStrictEqual(
+      getFileChangesLineDelta([
+        {
+          diff: "@@ -1 +1 @@\n-old\n+new",
+          kind: "modify",
+          path: "a.ts",
+        },
+        {
+          diff: "@@ -1 +1 @@\n--- removed heading\n+++ added heading",
+          kind: "modify",
+          path: "b.ts",
+        },
+      ]),
+      { added: 2, removed: 2 },
     );
   });
 });

--- a/packages/web/src/routes/rich-events.ts
+++ b/packages/web/src/routes/rich-events.ts
@@ -172,6 +172,57 @@ export function getFileEventMeta(message: ChatMessageRecord): {
   };
 }
 
+export function getTextLineCount(value: string): number {
+  const trimmedValue = value.trimEnd();
+  return trimmedValue ? trimmedValue.split(/\r?\n/).length : 0;
+}
+
+export function getDiffLineDelta(diff: string): {
+  added: number;
+  removed: number;
+} {
+  let added = 0;
+  let removed = 0;
+  let inHunk = false;
+  for (const line of diff.split(/\r?\n/)) {
+    if (line.startsWith("diff --git ")) {
+      inHunk = false;
+      continue;
+    }
+    if (line.startsWith("@@")) {
+      inHunk = true;
+      continue;
+    }
+    if (!inHunk && (line.startsWith("+++") || line.startsWith("---"))) {
+      continue;
+    }
+    if (line.startsWith("+")) {
+      added += 1;
+      continue;
+    }
+    if (line.startsWith("-")) {
+      removed += 1;
+    }
+  }
+  return { added, removed };
+}
+
+export function getFileChangesLineDelta(changes: RichFileChange[]): {
+  added: number;
+  removed: number;
+} {
+  return changes.reduce(
+    (total, change) => {
+      const changeDelta = getDiffLineDelta(change.diff);
+      return {
+        added: total.added + changeDelta.added,
+        removed: total.removed + changeDelta.removed,
+      };
+    },
+    { added: 0, removed: 0 },
+  );
+}
+
 function getEventDataObject(
   message: ChatMessageRecord,
 ): Record<string, unknown> | null {


### PR DESCRIPTION
## Summary
- Compact command, diff, file-change, and reasoning rich events in the chat timeline.
- Move verbose output and patch details behind click-to-expand event rows.
- Surface the useful scan data in row headers: command or file names, status, exit/duration, line counts, and patch +/- counts.

## Impact
This keeps chat timelines readable while preserving access to detailed command output and file patches when needed.

## Validation
- `pnpm ready`