### PR TITLE
[codex] Add Codex fast mode toggle

### DIFF
--- a/packages/codex/src/bridge.test.ts
+++ b/packages/codex/src/bridge.test.ts
@@ -215,7 +215,33 @@ describe("CodexBridge", () => {
     await expect(unarchive).resolves.toEqual({ thread: { id: "thread_1" } });
   });
 
-  it("passes model, effort, file mentions, and skills to new turns", async () => {
+  it("passes model and service tier to new threads", async () => {
+    const { bridge, proc } = createBridge();
+    await initializeBridge(bridge, proc);
+
+    const thread = bridge.startThread("/repo", {
+      model: "gpt-5.2",
+      serviceTier: "fast",
+    });
+
+    await vi.waitFor(() =>
+      expect(findWrite(proc, "thread/start")).toBeDefined(),
+    );
+    const request = findWrite(proc, "thread/start");
+    expect(request?.params).toEqual({
+      cwd: "/repo",
+      model: "gpt-5.2",
+      serviceTier: "fast",
+      serviceName: "phantom_serve",
+      experimentalRawEvents: false,
+      persistExtendedHistory: true,
+    });
+
+    proc.send({ id: request?.id, result: { thread: { id: "thread_1" } } });
+    await expect(thread).resolves.toEqual({ thread: { id: "thread_1" } });
+  });
+
+  it("passes model, effort, service tier, file mentions, and skills to new turns", async () => {
     const { bridge, proc } = createBridge();
     await initializeBridge(bridge, proc);
 
@@ -223,6 +249,7 @@ describe("CodexBridge", () => {
       effort: "high",
       files: [{ name: "src/index.ts", path: "/repo/src/index.ts" }],
       model: "gpt-5.2",
+      serviceTier: "fast",
       skills: [{ name: "review", path: "/skills/review/SKILL.md" }],
     });
 
@@ -250,6 +277,7 @@ describe("CodexBridge", () => {
       ],
       model: "gpt-5.2",
       effort: "high",
+      serviceTier: "fast",
     });
 
     proc.send({ id: request?.id, result: { turn: { id: "turn_1" } } });
@@ -263,6 +291,7 @@ describe("CodexBridge", () => {
     const turn = bridge.steerTurn("thread_1", "turn_1", "continue", {
       effort: "high",
       model: "gpt-5.2",
+      serviceTier: "fast",
     });
 
     await vi.waitFor(() => expect(findWrite(proc, "turn/steer")).toBeDefined());

--- a/packages/codex/src/bridge.ts
+++ b/packages/codex/src/bridge.ts
@@ -37,6 +37,7 @@ export interface CodexTurnOptions {
   effort?: string;
   files?: CodexTurnContextItem[];
   model?: string;
+  serviceTier?: "fast" | "flex";
   skills?: CodexTurnContextItem[];
 }
 
@@ -329,6 +330,7 @@ export class CodexBridge {
     return this.request("thread/start", {
       cwd,
       model: options.model,
+      serviceTier: options.serviceTier,
       serviceName: "phantom_serve",
       experimentalRawEvents: false,
       persistExtendedHistory: true,
@@ -356,6 +358,7 @@ export class CodexBridge {
       input: createUserInput(text, options),
       model: options.model,
       effort: options.effort,
+      serviceTier: options.serviceTier,
     });
   }
 

--- a/packages/server/src/rpc.test.ts
+++ b/packages/server/src/rpc.test.ts
@@ -198,6 +198,7 @@ describe("rpcRoutes", () => {
       body: JSON.stringify({
         githubTargetNumber: 42,
         initialMessage: "Start from the selected target",
+        serviceTier: "fast",
       }),
       headers: {
         "Content-Type": "application/json",
@@ -212,6 +213,7 @@ describe("rpcRoutes", () => {
         base: undefined,
         githubTargetNumber: 42,
         initialMessage: "Start from the selected target",
+        serviceTier: "fast",
         worktreeName: undefined,
         worktreePath: undefined,
       },

--- a/packages/server/src/rpc.ts
+++ b/packages/server/src/rpc.ts
@@ -4,7 +4,11 @@ import { z } from "zod";
 import { createSseResponse, parseLastEventId } from "./event-hub.ts";
 import { renderChatMessages } from "./markdown.ts";
 import { getServeServices } from "./services.ts";
-import type { ApiErrorBody, CodexTurnContextItem } from "./types.ts";
+import type {
+  ApiErrorBody,
+  CodexServiceTier,
+  CodexTurnContextItem,
+} from "./types.ts";
 
 const contextItemSchema = z.object({
   name: z.string().min(1),
@@ -21,6 +25,7 @@ const createChatSchema = z
     base: z.string().optional(),
     githubTargetNumber: z.number().int().positive().optional(),
     initialMessage: z.string().optional(),
+    serviceTier: z.enum(["fast", "flex"]).nullable().optional(),
     worktreeName: z.string().optional(),
     worktreePath: z.string().optional(),
   })
@@ -66,6 +71,7 @@ const sendMessageSchema = z.object({
   text: z.string().min(1, "Message text is required"),
   effort: z.string().nullable().optional(),
   model: z.string().nullable().optional(),
+  serviceTier: z.enum(["fast", "flex"]).nullable().optional(),
   files: z.array(contextItemSchema).optional(),
   skills: z.array(contextItemSchema).optional(),
 });
@@ -88,6 +94,7 @@ const queuedMessageSchema = z.object({
   effort: z.string().optional(),
   files: z.array(contextItemSchema).optional(),
   model: z.string().optional(),
+  serviceTier: z.enum(["fast", "flex"]).optional(),
   skills: z.array(contextItemSchema).optional(),
   createdAt: z.string().min(1),
 });
@@ -160,6 +167,12 @@ function query<TSchema extends z.ZodType>(schema: TSchema) {
 }
 
 function optionalString(value: string | null | undefined): string | undefined {
+  return value ?? undefined;
+}
+
+function optionalServiceTier(
+  value: CodexServiceTier | null | undefined,
+): CodexServiceTier | undefined {
   return value ?? undefined;
 }
 
@@ -266,6 +279,7 @@ export const rpcRoutes = new Hono()
           base: body.base,
           githubTargetNumber: body.githubTargetNumber,
           initialMessage: body.initialMessage,
+          serviceTier: optionalServiceTier(body.serviceTier),
           worktreeName: body.worktreeName,
           worktreePath: body.worktreePath,
         },
@@ -379,6 +393,7 @@ export const rpcRoutes = new Hono()
         effort: optionalString(body.effort),
         files: contextItems(body.files),
         model: optionalString(body.model),
+        serviceTier: optionalServiceTier(body.serviceTier),
         skills: contextItems(body.skills),
         text: body.text,
       });
@@ -431,6 +446,7 @@ export const rpcRoutes = new Hono()
           effort: optionalString(body.effort),
           files: contextItems(body.files),
           model: optionalString(body.model),
+          serviceTier: optionalServiceTier(body.serviceTier),
           skills: contextItems(body.skills),
           text: body.text,
         },
@@ -449,6 +465,7 @@ export const rpcRoutes = new Hono()
           effort: optionalString(body.effort),
           files: contextItems(body.files),
           model: optionalString(body.model),
+          serviceTier: optionalServiceTier(body.serviceTier),
           skills: contextItems(body.skills),
           text: body.text,
         },

--- a/packages/server/src/services.test.ts
+++ b/packages/server/src/services.test.ts
@@ -4963,12 +4963,16 @@ describe("ServeServices", () => {
     });
     codex.startThread.mockResolvedValueOnce({ thread: { id: "thread_new" } });
 
-    const chat = await services.createChat("proj_1", { name: "feature" });
+    const chat = await services.createChat("proj_1", {
+      name: "feature",
+      serviceTier: "fast",
+    });
 
     strictEqual(chat.title, "feature");
     strictEqual(chat.codexThreadId, "thread_new");
     deepStrictEqual(codex.startThread.mock.calls[0], [
       "/repo/.git/phantom/worktrees/feature",
+      { serviceTier: "fast" },
     ]);
     const savedState = await store.load();
     strictEqual(savedState.selectedChatId, chat.id);
@@ -5011,6 +5015,7 @@ describe("ServeServices", () => {
     codex.startThread.mockResolvedValueOnce({ thread: { id: "thread_new" } });
 
     const chat = await services.createChat("proj_1", {
+      serviceTier: "fast",
       worktreeName: "feature",
       worktreePath: "/repo/.git/phantom/worktrees/feature",
     });
@@ -5022,6 +5027,7 @@ describe("ServeServices", () => {
     ]);
     deepStrictEqual(codex.startThread.mock.calls[0], [
       "/repo/.git/phantom/worktrees/feature",
+      { serviceTier: "fast" },
     ]);
     strictEqual(chat.worktreeName, "feature");
     strictEqual(chat.worktreePath, "/repo/.git/phantom/worktrees/feature");
@@ -5068,6 +5074,7 @@ describe("ServeServices", () => {
     const chat = await services.createChat("proj_1", {
       githubTargetNumber: 42,
       initialMessage: "Implement this PR feedback",
+      serviceTier: "fast",
     });
 
     deepStrictEqual(coreMocks.githubCheckout.mock.calls[0], [
@@ -5079,6 +5086,7 @@ describe("ServeServices", () => {
     ]);
     deepStrictEqual(codex.startThread.mock.calls[0], [
       "/repo/.git/phantom/worktrees/feature",
+      { serviceTier: "fast" },
     ]);
     strictEqual(chat.worktreeName, "feature");
     strictEqual(chat.worktreePath, "/repo/.git/phantom/worktrees/feature");
@@ -6817,7 +6825,7 @@ describe("ServeServices", () => {
     strictEqual(codex.startTurn.mock.calls.length, 1);
   });
 
-  it("passes selected model, effort, files, and skills to Codex turns", async () => {
+  it("passes selected model, effort, service tier, files, and skills to Codex turns", async () => {
     const worktreePath = await createTemporaryDirectory();
     await mkdir(join(worktreePath, "src"));
     const filePath = join(worktreePath, "src/index.ts");
@@ -6843,6 +6851,7 @@ describe("ServeServices", () => {
         },
       ],
       model: "gpt-5.2",
+      serviceTier: "fast",
       skills: [{ name: "review", path: "/skills/review/SKILL.md" }],
       text: "please edit",
     });
@@ -6860,6 +6869,7 @@ describe("ServeServices", () => {
           },
         ],
         model: "gpt-5.2",
+        serviceTier: "fast",
         skills: [{ name: "review", path: "/skills/review/SKILL.md" }],
       },
     ]);
@@ -7961,15 +7971,18 @@ describe("ServeServices", () => {
         messageId: "msg_queued",
         text: "queued draft",
         model: "gpt-5.2",
+        serviceTier: "fast",
         createdAt: timestamp,
       },
       queuedMessageIndex: 0,
     });
 
     strictEqual(result.queuedMessage.model, "gpt-5.2");
+    strictEqual(result.queuedMessage.serviceTier, "fast");
     const savedState = await store.load();
     strictEqual(savedState.messages.length, 1);
     strictEqual(savedState.queuedMessages.length, 1);
+    strictEqual(savedState.queuedMessages[0]?.serviceTier, "fast");
     strictEqual(codex.startTurn.mock.calls.length, 0);
     strictEqual(
       emitSpy.mock.calls.some((call) => call[0] === "chat.message.created"),
@@ -8351,11 +8364,15 @@ describe("ServeServices", () => {
     codex.resumeThread.mockResolvedValueOnce({});
     codex.startTurn.mockResolvedValueOnce({ turn: { id: "turn_2" } });
 
-    await services.queueMessage("chat_1", { text: "follow up next" });
+    await services.queueMessage("chat_1", {
+      serviceTier: "fast",
+      text: "follow up next",
+    });
 
     let savedState = await store.load();
     strictEqual(savedState.messages[0]?.text, "follow up next");
     strictEqual(savedState.queuedMessages[0]?.text, "follow up next");
+    strictEqual(savedState.queuedMessages[0]?.serviceTier, "fast");
     strictEqual(savedState.chats[0]?.status, "running");
     strictEqual(savedState.chats[0]?.activeTurnId, "turn_1");
     strictEqual(codex.startTurn.mock.calls.length, 0);
@@ -8376,6 +8393,7 @@ describe("ServeServices", () => {
       "thread_1",
       "follow up next",
       "/repo/.git/phantom/worktrees/worktree",
+      { serviceTier: "fast" },
     ]);
     savedState = await store.load();
     strictEqual(savedState.queuedMessages.length, 0);

--- a/packages/server/src/services.ts
+++ b/packages/server/src/services.ts
@@ -47,6 +47,7 @@ import type {
   CodexFileRecord,
   GitHubCheckoutTargetsResult,
   CodexModelRecord,
+  CodexServiceTier,
   CodexSkillRecord,
   CodexTurnContextItem,
   PendingApprovalRecord,
@@ -61,6 +62,7 @@ export interface CreateChatInput {
   base?: string;
   githubTargetNumber?: number;
   initialMessage?: string;
+  serviceTier?: CodexServiceTier;
   worktreeName?: string;
   worktreePath?: string;
 }
@@ -89,6 +91,7 @@ export interface SendMessageInput {
   effort?: string;
   files?: CodexTurnContextItem[];
   model?: string;
+  serviceTier?: CodexServiceTier;
   skills?: CodexTurnContextItem[];
   text: string;
 }
@@ -751,6 +754,7 @@ export class ServeServices {
     projectId: string,
     project: ProjectRecord,
     input: {
+      serviceTier?: CodexServiceTier;
       worktreeName?: string;
       worktreePath: string;
     },
@@ -775,7 +779,11 @@ export class ServeServices {
       throw new Error(`Worktree '${targetWorktreePath}' not found`);
     }
 
-    const threadResult = await this.codex.startThread(targetWorktree.path);
+    const threadResult = input.serviceTier
+      ? await this.codex.startThread(targetWorktree.path, {
+          serviceTier: input.serviceTier,
+        })
+      : await this.codex.startThread(targetWorktree.path);
     const codexThreadId = extractThreadId(threadResult);
     this.loadedThreadIds.add(codexThreadId);
     const timestamp = createTimestamp();
@@ -831,6 +839,7 @@ export class ServeServices {
       }
       try {
         return await this.createExistingWorktreeChat(projectId, project, {
+          serviceTier: input.serviceTier,
           worktreeName: result.value.worktree,
           worktreePath: result.value.path,
         });
@@ -856,6 +865,7 @@ export class ServeServices {
     }
     if (hasExistingWorktreeInput) {
       return this.createExistingWorktreeChat(projectId, project, {
+        serviceTier: input.serviceTier,
         worktreeName: targetWorktreeName,
         worktreePath: targetWorktreePath ?? "",
       });
@@ -899,9 +909,11 @@ export class ServeServices {
 
     let codexThreadId: string;
     try {
-      const threadResult = await this.codex.startThread(
-        createResult.value.path,
-      );
+      const threadResult = input.serviceTier
+        ? await this.codex.startThread(createResult.value.path, {
+            serviceTier: input.serviceTier,
+          })
+        : await this.codex.startThread(createResult.value.path);
       codexThreadId = extractThreadId(threadResult);
     } catch (error) {
       try {
@@ -1753,6 +1765,7 @@ export class ServeServices {
         effort?: string;
         files?: CodexTurnContextItem[];
         model?: string;
+        serviceTier?: CodexServiceTier;
         skills?: CodexTurnContextItem[];
       }
     | undefined
@@ -1768,17 +1781,35 @@ export class ServeServices {
     if (
       !input.effort &&
       !input.model &&
+      !input.serviceTier &&
       files.length === 0 &&
       skills.length === 0
     ) {
       return undefined;
     }
-    return {
-      effort: input.effort,
-      files: files.length > 0 ? files : undefined,
-      model: input.model,
-      skills: skills.length > 0 ? skills : undefined,
-    };
+    const options: {
+      effort?: string;
+      files?: CodexTurnContextItem[];
+      model?: string;
+      serviceTier?: CodexServiceTier;
+      skills?: CodexTurnContextItem[];
+    } = {};
+    if (input.effort) {
+      options.effort = input.effort;
+    }
+    if (files.length > 0) {
+      options.files = files;
+    }
+    if (input.model) {
+      options.model = input.model;
+    }
+    if (input.serviceTier) {
+      options.serviceTier = input.serviceTier;
+    }
+    if (skills.length > 0) {
+      options.skills = skills;
+    }
+    return options;
   }
 
   private async normalizeSkillContextItems(
@@ -3121,6 +3152,7 @@ function createQueuedMessage(
     effort: input.effort,
     files: cloneContextItems(input.files),
     model: input.model,
+    serviceTier: input.serviceTier,
     skills: cloneContextItems(input.skills),
     createdAt: createTimestamp(),
   };
@@ -3133,6 +3165,7 @@ function queuedMessageToSendInput(
     effort: message.effort,
     files: cloneContextItems(message.files),
     model: message.model,
+    serviceTier: message.serviceTier,
     skills: cloneContextItems(message.skills),
     text: message.text,
   };
@@ -4837,6 +4870,7 @@ function normalizeModelRecords(value: unknown): CodexModelRecord[] {
         model: modelName,
         displayName: getRecordString(model, "displayName") ?? id,
         description: getRecordString(model, "description") ?? "",
+        additionalSpeedTiers: getStringArray(model.additionalSpeedTiers),
         defaultReasoningEffort:
           getRecordString(model, "defaultReasoningEffort") ?? null,
         inputModalities: getStringArray(model.inputModalities),

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -53,11 +53,14 @@ export interface CodexModelRecord {
   model: string;
   displayName: string;
   description: string;
+  additionalSpeedTiers: string[];
   defaultReasoningEffort: string | null;
   inputModalities: string[];
   isDefault: boolean;
   supportedReasoningEfforts: string[];
 }
+
+export type CodexServiceTier = "fast" | "flex";
 
 export interface CodexSkillRecord {
   name: string;

--- a/packages/state/src/types.ts
+++ b/packages/state/src/types.ts
@@ -41,6 +41,7 @@ const queuedMessageRecordBaseSchema = z.object({
   effort: z.string().optional(),
   files: z.array(turnContextItemBaseSchema).optional(),
   model: z.string().optional(),
+  serviceTier: z.enum(["fast", "flex"]).optional(),
   skills: z.array(turnContextItemBaseSchema).optional(),
   createdAt: z.string(),
 });

--- a/packages/web/src/api/mutations.test.ts
+++ b/packages/web/src/api/mutations.test.ts
@@ -97,6 +97,7 @@ describe("createChatMutation", () => {
     await createChatMutation("proj_1", {
       githubTargetNumber: 42,
       initialMessage: "Start here",
+      serviceTier: "fast",
     });
 
     strictEqual(
@@ -104,6 +105,7 @@ describe("createChatMutation", () => {
       JSON.stringify({
         githubTargetNumber: 42,
         initialMessage: "Start here",
+        serviceTier: "fast",
       }),
     );
   });

--- a/packages/web/src/api/mutations.ts
+++ b/packages/web/src/api/mutations.ts
@@ -2,6 +2,7 @@ import { api, readRpcJson, routeParam } from "./client";
 import type {
   ChatMessageRecord,
   ChatRecord,
+  CodexServiceTier,
   CodexTurnContextItem,
   ProjectRecord,
   QueuedMessageRecord,
@@ -18,6 +19,7 @@ export interface SendMessageInput {
   effort?: string | null;
   files?: CodexTurnContextItem[];
   model?: string | null;
+  serviceTier?: CodexServiceTier | null;
   skills?: CodexTurnContextItem[];
   text: string;
 }
@@ -25,6 +27,7 @@ export interface SendMessageInput {
 export interface CreateChatInput {
   githubTargetNumber?: number;
   initialMessage?: string;
+  serviceTier?: CodexServiceTier | null;
   worktreeName?: string;
   worktreePath?: string;
 }

--- a/packages/web/src/routes/home-url-state.test.ts
+++ b/packages/web/src/routes/home-url-state.test.ts
@@ -4,10 +4,12 @@ import {
   findValidatedSelectedProjectChat,
   findValidatedSelectedChat,
   getSelectableReasoningEfforts,
+  getSelectedServiceTierForTurn,
   getSelectedSkillContextItems,
   isKnownWorktreeChat,
   isShareableFileSearchQuery,
   mergeWorktreesWithChats,
+  modelSupportsFastMode,
   retainRecordsForProjects,
   resolveRefreshedWorktreeChatId,
 } from "./home-url-state";
@@ -108,6 +110,41 @@ describe("getSelectableReasoningEfforts", () => {
     expect(
       getSelectableReasoningEfforts({ supportedReasoningEfforts: [] }),
     ).toEqual([]);
+  });
+});
+
+describe("modelSupportsFastMode", () => {
+  it("uses model-advertised speed tiers", () => {
+    expect(modelSupportsFastMode({ additionalSpeedTiers: ["fast"] })).toBe(
+      true,
+    );
+    expect(modelSupportsFastMode({ additionalSpeedTiers: ["flex"] })).toBe(
+      false,
+    );
+    expect(modelSupportsFastMode(null)).toBe(false);
+  });
+});
+
+describe("getSelectedServiceTierForTurn", () => {
+  it("selects fast only for fast-capable models and fast URL state", () => {
+    expect(
+      getSelectedServiceTierForTurn(
+        { additionalSpeedTiers: ["fast"] },
+        "fast",
+        null,
+      ),
+    ).toBe("fast");
+  });
+
+  it("clears fast mode for models that do not advertise fast support", () => {
+    expect(
+      getSelectedServiceTierForTurn({ additionalSpeedTiers: [] }, "fast", null),
+    ).toBeNull();
+  });
+
+  it("preserves restored fast pending context before model metadata loads", () => {
+    expect(getSelectedServiceTierForTurn(null, null, "fast")).toBe("fast");
+    expect(getSelectedServiceTierForTurn(null, null, "flex")).toBeNull();
   });
 });
 

--- a/packages/web/src/routes/home-url-state.ts
+++ b/packages/web/src/routes/home-url-state.ts
@@ -16,6 +16,10 @@ interface ModelReasoningEffortRecord {
   supportedReasoningEfforts: string[];
 }
 
+interface ModelSpeedTierRecord {
+  additionalSpeedTiers: string[];
+}
+
 interface SkillSelectionRecord {
   enabled: boolean;
   name: string;
@@ -237,6 +241,25 @@ export function getSelectableReasoningEfforts(
   return selectedModel
     ? selectedModel.supportedReasoningEfforts
     : fallbackReasoningEfforts;
+}
+
+export function modelSupportsFastMode(
+  selectedModel: ModelSpeedTierRecord | null,
+): boolean {
+  return Boolean(selectedModel?.additionalSpeedTiers.includes("fast"));
+}
+
+export function getSelectedServiceTierForTurn(
+  selectedModel: ModelSpeedTierRecord | null,
+  selectedServiceTier: string | null,
+  restoredPendingServiceTier: "fast" | "flex" | null,
+): "fast" | null {
+  if (!selectedModel) {
+    return restoredPendingServiceTier === "fast" ? "fast" : null;
+  }
+  return selectedServiceTier === "fast" && modelSupportsFastMode(selectedModel)
+    ? "fast"
+    : null;
 }
 
 export function getSelectedSkillContextItems<

--- a/packages/web/src/routes/home.tsx
+++ b/packages/web/src/routes/home.tsx
@@ -28,6 +28,7 @@ import {
   Terminal,
   Trash2,
   X,
+  Zap,
 } from "lucide-react";
 import type { ReactNode } from "react";
 import {
@@ -130,10 +131,12 @@ import {
   findValidatedSelectedProjectChat,
   findValidatedSelectedChat,
   getSelectableReasoningEfforts,
+  getSelectedServiceTierForTurn,
   getSelectedSkillContextItems,
   isKnownWorktreeChat,
   isShareableFileSearchQuery,
   mergeWorktreesWithChats,
+  modelSupportsFastMode,
   retainRecordsForProjects,
   resolveRefreshedWorktreeChatId,
 } from "./home-url-state";
@@ -209,6 +212,7 @@ const searchParamKeys = {
   fileQuery: "fileQuery",
   model: "model",
   project: "project",
+  serviceTier: "serviceTier",
 } as const;
 
 const statusMeta: Record<
@@ -278,6 +282,7 @@ interface RestoredPendingComposerContext {
   chatId: string;
   effort: string | null;
   model: string | null;
+  serviceTier: "fast" | "flex" | null;
 }
 
 type VisibleMessageRecord = RenderedChatMessageRecord & {
@@ -496,6 +501,10 @@ export function HomeRoute() {
   const selectedEffort = readNullableSearchParam(
     searchParams,
     searchParamKeys.effort,
+  );
+  const selectedServiceTier = readNullableSearchParam(
+    searchParams,
+    searchParamKeys.serviceTier,
   );
   const rawUrlFileSearchQuery =
     searchParams.get(searchParamKeys.fileQuery) ?? "";
@@ -952,6 +961,9 @@ export function HomeRoute() {
     () => getSelectableReasoningEfforts(selectedModel),
     [selectedModel],
   );
+  const selectedModelSupportsFastMode = modelSupportsFastMode(selectedModel);
+  const isFastModeEnabled =
+    selectedServiceTier === "fast" && selectedModelSupportsFastMode;
 
   const selectedSkills = useMemo(
     () =>
@@ -1423,6 +1435,20 @@ export function HomeRoute() {
     selectedModel,
     selectedModelSupportedEfforts,
   ]);
+
+  useEffect(() => {
+    if (!selectedServiceTier) {
+      return;
+    }
+    if (
+      selectedServiceTier !== "fast" ||
+      (selectedModel && !selectedModelSupportsFastMode)
+    ) {
+      setSearchParamValue(searchParamKeys.serviceTier, null, {
+        replace: true,
+      });
+    }
+  }, [selectedModel, selectedModelSupportsFastMode, selectedServiceTier]);
 
   useEffect(() => {
     const requestId = fileSearchRequestIdRef.current + 1;
@@ -2441,6 +2467,11 @@ export function HomeRoute() {
         ? selectedEffort
         : null
       : (restoredPendingContext?.effort ?? null);
+    const turnServiceTier = getSelectedServiceTierForTurn(
+      selectedModel,
+      selectedServiceTier,
+      restoredPendingContext?.serviceTier ?? null,
+    );
     const files = selectedFiles.map((file) => ({
       name: file.relativePath,
       path: file.path,
@@ -2449,6 +2480,7 @@ export function HomeRoute() {
       effort: turnEffort,
       files,
       model: turnModel,
+      serviceTier: turnServiceTier,
       skills: getSelectedSkillContextItems(skills, selectedSkillPaths),
       text,
     };
@@ -2478,6 +2510,7 @@ export function HomeRoute() {
         {
           githubTargetNumber: githubTargetNumber ?? undefined,
           initialMessage: input.text,
+          serviceTier: input.serviceTier,
         },
       );
       if (!chat) {
@@ -2699,6 +2732,7 @@ export function HomeRoute() {
       chatId: deletedPendingMessage.message.chatId,
       effort: deletedPendingMessage.queuedMessage.effort ?? null,
       model: deletedPendingMessage.queuedMessage.model ?? null,
+      serviceTier: deletedPendingMessage.queuedMessage.serviceTier ?? null,
     };
     setComposerText(deletedPendingMessage.message.text);
     setSelectedFiles(
@@ -2720,6 +2754,10 @@ export function HomeRoute() {
     setSearchParamValue(
       searchParamKeys.effort,
       deletedPendingMessage.queuedMessage.effort ?? null,
+    );
+    setSearchParamValue(
+      searchParamKeys.serviceTier,
+      deletedPendingMessage.queuedMessage.serviceTier ?? null,
     );
     requestAnimationFrame(() => {
       composerTextareaRef.current?.focus();
@@ -3885,6 +3923,36 @@ export function HomeRoute() {
                   )
                 }
               />
+              <Button
+                aria-label={
+                  isFastModeEnabled ? "Disable fast mode" : "Enable fast mode"
+                }
+                aria-pressed={isFastModeEnabled}
+                className="h-9 px-3"
+                disabled={
+                  !selectedModel ||
+                  !selectedModelSupportsFastMode ||
+                  isComposerBlocked
+                }
+                onClick={() =>
+                  setSearchParamValue(
+                    searchParamKeys.serviceTier,
+                    isFastModeEnabled ? null : "fast",
+                  )
+                }
+                title={
+                  selectedModelSupportsFastMode
+                    ? isFastModeEnabled
+                      ? "Disable fast mode"
+                      : "Enable fast mode"
+                    : "Fast mode unavailable for selected model"
+                }
+                type="button"
+                variant={isFastModeEnabled ? "secondary" : "outline"}
+              >
+                <Zap className="size-3.5" />
+                Fast
+              </Button>
               <Combobox
                 aria-label="Attach file"
                 className="w-32 max-w-full"


### PR DESCRIPTION
## Summary

- Add Codex app-server `serviceTier` support through the bridge, server RPC, queued message state, and web mutation payloads.
- Surface model `additionalSpeedTiers` from `/models` and use it to enable a compact Fast toggle in the composer.
- Preserve fast mode across queued-message edit/restore flows and cover the new option in bridge/server tests.

## Validation

- `pnpm install`
- `pnpm ready`
- `git diff --check`

## Notes

- Verified Codex app-server support by generating the experimental app-server TypeScript/JSON schema locally; fast mode maps to `serviceTier: "fast"` and model support is advertised via `additionalSpeedTiers`.