### PR TITLE
fix: create chat when selecting empty worktree

### DIFF
--- a/packages/web/src/routes/home.tsx
+++ b/packages/web/src/routes/home.tsx
@@ -2904,6 +2904,11 @@ export function HomeRoute() {
   }
 
   function selectWorktree(projectId: string, worktree: ProjectWorktreeRecord) {
+    if (!worktree.chatId) {
+      void createChat(projectId, worktree);
+      return;
+    }
+
     updateWorkspaceSearchParams({
       projectId,
       chatId: worktree.chatId,
@@ -3180,7 +3185,7 @@ export function HomeRoute() {
                                       </button>
                                       <SidebarMenuSubButton
                                         className="flex-1"
-                                        disabled={!worktree.chatId}
+                                        disabled={!worktree.chatId && isBusy}
                                         isActive={isSelectedWorktree}
                                         onClick={() =>
                                           selectWorktree(project.id, worktree)


### PR DESCRIPTION
## Summary
- create a chat when selecting a worktree with no existing chat history
- keep empty worktree rows clickable while only disabling them during busy state

## Verification
- pnpm --filter @phantompane/web run typecheck
- pnpm --filter @phantompane/web run test
- pnpm ready
- in-app browser: clicked a no-chat worktree and confirmed a new chat opened