### PR TITLE
[codex] hide heavy chat event bodies

### DIFF
--- a/packages/server/src/services.test.ts
+++ b/packages/server/src/services.test.ts
@@ -170,6 +170,28 @@ async function createHarness(state: ServeState): Promise<{
   return { codex, codexHome, services, store };
 }
 
+function getEmittedCodexParams(
+  calls: Array<[string, unknown, ...unknown[]]>,
+  eventType: string,
+  method: string,
+  itemType?: string,
+): Record<string, unknown> | undefined {
+  const call = calls.find(([type, data]) => {
+    const message = data as CodexMessage;
+    if (type !== eventType || message.method !== method) {
+      return false;
+    }
+    if (!itemType) {
+      return true;
+    }
+    const params = message.params as { item?: { type?: unknown } } | undefined;
+    return params?.item?.type === itemType;
+  });
+  return (call?.[1] as CodexMessage | undefined)?.params as
+    | Record<string, unknown>
+    | undefined;
+}
+
 function markChatActiveInCurrentProcess(
   services: ServeServices,
   chatId: string,
@@ -210,6 +232,95 @@ class ImportRaceStore extends ServeStateStore {
 }
 
 describe("ServeServices", () => {
+  it("strips hidden rich event bodies from existing state on service access", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat()],
+      messages: [
+        {
+          id: "msg_command",
+          chatId: "chat_1",
+          role: "event" as const,
+          text: "large command output",
+          eventType: "item/commandExecution/outputDelta",
+          eventData: {
+            command: "pnpm test",
+            text: "large command output",
+          },
+          createdAt: timestamp,
+        },
+        {
+          id: "msg_diff",
+          chatId: "chat_1",
+          role: "event" as const,
+          text: "Diff updated: 1 file",
+          eventType: "turn/diff/updated",
+          eventData: {
+            diff: "large diff",
+            files: ["src/app.ts"],
+            hasDiff: true,
+          },
+          createdAt: timestamp,
+        },
+        {
+          id: "msg_patch",
+          chatId: "chat_1",
+          role: "event" as const,
+          text: "File patch updated: 1 file",
+          eventType: "item/fileChange/patchUpdated",
+          eventData: {
+            changes: [
+              {
+                diff: "large patch",
+                kind: "modify",
+                path: "src/app.ts",
+              },
+            ],
+          },
+          createdAt: timestamp,
+        },
+      ],
+    };
+    const { services, store } = await createHarness(state);
+
+    await services.listProjects();
+
+    const savedState = await store.load();
+    deepStrictEqual(
+      savedState.messages.map((message) => ({
+        eventData: message.eventData,
+        text: message.text,
+      })),
+      [
+        {
+          eventData: {
+            command: "pnpm test",
+          },
+          text: "",
+        },
+        {
+          eventData: {
+            files: ["src/app.ts"],
+            hasDiff: true,
+          },
+          text: "Diff updated: 1 file",
+        },
+        {
+          eventData: {
+            changes: [
+              {
+                kind: "modify",
+                path: "src/app.ts",
+              },
+            ],
+          },
+          text: "File patch updated: 1 file",
+        },
+      ],
+    );
+  });
+
   it("lists project worktrees with phantom list data without creating chat records", async () => {
     const state = {
       ...createTestState(),
@@ -1810,12 +1921,7 @@ describe("ServeServices", () => {
       [
         ["chat_1_codex_turn_old_0", "user", "retry", undefined],
         ["msg_pending_retry", "user", "retry", undefined],
-        [
-          "msg_command_event",
-          "event",
-          "pnpm test",
-          "item/commandExecution/outputDelta",
-        ],
+        ["msg_command_event", "event", "", "item/commandExecution/outputDelta"],
       ],
     );
   });
@@ -2500,7 +2606,7 @@ describe("ServeServices", () => {
       [
         ["user", "retry", undefined],
         ["assistant", "still working", "item/agentMessage/delta"],
-        ["event", "pnpm test", "item/commandExecution/outputDelta"],
+        ["event", "", "item/commandExecution/outputDelta"],
         ["user", "retry", undefined],
       ],
     );
@@ -2567,7 +2673,7 @@ describe("ServeServices", () => {
       [
         ["user", "retry", undefined],
         ["assistant", "still working", "item/agentMessage/delta"],
-        ["event", "pnpm test", "item/commandExecution/outputDelta"],
+        ["event", "", "item/commandExecution/outputDelta"],
         ["user", "retry", undefined],
       ],
     );
@@ -2614,7 +2720,7 @@ describe("ServeServices", () => {
       [
         ["user", "fix the UI", undefined],
         ["assistant", "working", undefined],
-        ["event", "pnpm test", "item/commandExecution/outputDelta"],
+        ["event", "", "item/commandExecution/outputDelta"],
       ],
     );
   });
@@ -2680,7 +2786,7 @@ describe("ServeServices", () => {
       [
         ["user", "fix the UI", undefined],
         ["assistant", "done", undefined],
-        ["event", "pnpm test", "item/commandExecution/outputDelta"],
+        ["event", "", "item/commandExecution/outputDelta"],
         ["assistant", "still working", "item/agentMessage/delta"],
         ["user", "next request", undefined],
       ],
@@ -2750,7 +2856,7 @@ describe("ServeServices", () => {
       ]),
       [
         ["user", "fix the UI", undefined],
-        ["event", "pnpm test", "item/commandExecution/outputDelta"],
+        ["event", "", "item/commandExecution/outputDelta"],
         ["assistant", "still working", "item/agentMessage/delta"],
       ],
     );
@@ -2820,7 +2926,7 @@ describe("ServeServices", () => {
       ]),
       [
         ["user", "fix the UI", undefined],
-        ["event", "pnpm test", "item/commandExecution/outputDelta"],
+        ["event", "", "item/commandExecution/outputDelta"],
         ["assistant", "done", undefined],
       ],
     );
@@ -2888,7 +2994,7 @@ describe("ServeServices", () => {
         ["user", "fix the UI", undefined],
         ["assistant", "done", undefined],
         ["assistant", "still working", "item/agentMessage/delta"],
-        ["event", "pnpm test", "item/commandExecution/outputDelta"],
+        ["event", "", "item/commandExecution/outputDelta"],
         ["user", "next request", undefined],
       ],
     );
@@ -2942,7 +3048,7 @@ describe("ServeServices", () => {
       ]),
       [
         ["user", "fix the UI", undefined],
-        ["event", "pnpm test", "item/commandExecution/outputDelta"],
+        ["event", "", "item/commandExecution/outputDelta"],
         ["assistant", "done", undefined],
       ],
     );
@@ -3007,7 +3113,7 @@ describe("ServeServices", () => {
         ["user", "previous request", undefined],
         ["assistant", "previous response", undefined],
         ["user", "new request", undefined],
-        ["event", "pnpm test", "item/commandExecution/outputDelta"],
+        ["event", "", "item/commandExecution/outputDelta"],
         ["assistant", "still working", "item/agentMessage/delta"],
       ],
     );
@@ -3065,7 +3171,7 @@ describe("ServeServices", () => {
       [
         ["user", "previous request", undefined],
         ["user", "middle request", undefined],
-        ["event", "pnpm test", "item/commandExecution/outputDelta"],
+        ["event", "", "item/commandExecution/outputDelta"],
         ["assistant", "later response", undefined],
       ],
     );
@@ -3141,7 +3247,7 @@ describe("ServeServices", () => {
       [
         ["user", "repeat", undefined],
         ["user", "repeat", undefined],
-        ["event", "pnpm test", "item/commandExecution/outputDelta"],
+        ["event", "", "item/commandExecution/outputDelta"],
         ["assistant", "done", undefined],
       ],
     );
@@ -3215,7 +3321,7 @@ describe("ServeServices", () => {
       ]),
       [
         ["user", "repeat", undefined],
-        ["event", "pnpm test", "item/commandExecution/outputDelta"],
+        ["event", "", "item/commandExecution/outputDelta"],
         ["assistant", "still working", "item/agentMessage/delta"],
         ["user", "repeat", undefined],
       ],
@@ -3286,7 +3392,7 @@ describe("ServeServices", () => {
       [
         ["user", "retry", undefined],
         ["assistant", "still working", "item/agentMessage/delta"],
-        ["event", "pnpm test", "item/commandExecution/outputDelta"],
+        ["event", "", "item/commandExecution/outputDelta"],
         ["user", "retry", undefined],
       ],
     );
@@ -3366,7 +3472,7 @@ describe("ServeServices", () => {
       [
         ["user", "repeat", undefined],
         ["assistant", "still working", "item/agentMessage/delta"],
-        ["event", "pnpm test", "item/commandExecution/outputDelta"],
+        ["event", "", "item/commandExecution/outputDelta"],
         ["user", "repeat", undefined],
       ],
     );
@@ -5561,7 +5667,7 @@ describe("ServeServices", () => {
     });
     const approvalRequest = emitSpy.mock.calls.find(
       (call) => call[0] === "agent.approval.requested",
-    )?.[1] as { requestId: string } | undefined;
+    )?.[1] as { params: unknown; requestId: string } | undefined;
     const approvalRequestId = approvalRequest?.requestId;
     strictEqual(typeof approvalRequestId, "string");
     if (!approvalRequestId) {
@@ -5627,11 +5733,19 @@ describe("ServeServices", () => {
     };
     const { codex, services, store } = await createHarness(state);
     const emitSpy = vi.spyOn(services.eventHub, "emit");
-    const params = { threadId: "thread_1", turnId: "turn_1" };
+    const params = {
+      threadId: "thread_1",
+      turnId: "turn_1",
+      changes: [{ path: "src/app.ts", kind: "modify", diff: "@@ patch" }],
+      item: {
+        type: "commandExecution",
+        aggregatedOutput: "large output",
+      },
+    };
 
     codex.emitServerRequest({
       id: 101,
-      method: "item/commandExecution/requestApproval",
+      method: "item/fileChange/requestApproval",
       params,
     });
     await vi.waitFor(async () => {
@@ -5639,15 +5753,30 @@ describe("ServeServices", () => {
     });
     const approvalRequest = emitSpy.mock.calls.find(
       (call) => call[0] === "agent.approval.requested",
-    )?.[1] as { requestId: string } | undefined;
+    )?.[1] as { params: unknown; requestId: string } | undefined;
     if (!approvalRequest) {
       throw new Error("Approval request was not emitted");
     }
 
     deepStrictEqual(await services.getPendingApproval("chat_1"), {
       requestId: approvalRequest.requestId,
-      method: "item/commandExecution/requestApproval",
-      params,
+      method: "item/fileChange/requestApproval",
+      params: {
+        threadId: "thread_1",
+        turnId: "turn_1",
+        changes: [{ path: "src/app.ts", kind: "modify" }],
+        item: {
+          type: "commandExecution",
+        },
+      },
+    });
+    deepStrictEqual(approvalRequest.params, {
+      threadId: "thread_1",
+      turnId: "turn_1",
+      changes: [{ path: "src/app.ts", kind: "modify" }],
+      item: {
+        type: "commandExecution",
+      },
     });
 
     await services.answerApproval("chat_1", approvalRequest.requestId, {
@@ -7461,6 +7590,13 @@ describe("ServeServices", () => {
       },
     });
     codex.emitNotification({
+      method: "turn/diff/updated",
+      params: {
+        turnId: "turn_1",
+        diff: "diff --git a/src/app.ts b/src/app.ts\n@@ -1 +1 @@\n-old\n+new",
+      },
+    });
+    codex.emitNotification({
       method: "item/commandExecution/outputDelta",
       params: {
         threadId: "thread_1",
@@ -7565,7 +7701,7 @@ describe("ServeServices", () => {
     });
 
     await vi.waitFor(async () => {
-      strictEqual((await store.load()).messages.length, 5);
+      strictEqual((await store.load()).messages.length, 6);
     });
 
     const savedState = await store.load();
@@ -7574,6 +7710,9 @@ describe("ServeServices", () => {
     );
     const commandMessage = savedState.messages.find(
       (message) => message.eventType === "item/commandExecution/outputDelta",
+    );
+    const diffMessage = savedState.messages.find(
+      (message) => message.eventType === "turn/diff/updated",
     );
     const patchMessage = savedState.messages.find(
       (message) => message.eventType === "item/fileChange/patchUpdated",
@@ -7594,10 +7733,16 @@ describe("ServeServices", () => {
         { step: "Patch UI", status: "inProgress" },
       ],
     );
-    strictEqual(commandMessage?.text, "first second");
+    strictEqual(diffMessage?.text, "Diff updated: 1 file");
+    deepStrictEqual(diffMessage?.eventData, {
+      files: ["src/app.ts"],
+      hasDiff: true,
+      hiddenContentUpdateCount: 1,
+    });
+    strictEqual(commandMessage?.text, "");
     strictEqual(
       (commandMessage?.eventData as { text?: string } | undefined)?.text,
-      "first second",
+      undefined,
     );
     deepStrictEqual(
       {
@@ -7610,6 +7755,11 @@ describe("ServeServices", () => {
         exitCode: (
           commandMessage?.eventData as { exitCode?: unknown } | undefined
         )?.exitCode,
+        hiddenContentDeltaCount: (
+          commandMessage?.eventData as
+            | { hiddenContentDeltaCount?: unknown }
+            | undefined
+        )?.hiddenContentDeltaCount,
         status: (commandMessage?.eventData as { status?: unknown } | undefined)
           ?.status,
       },
@@ -7617,6 +7767,7 @@ describe("ServeServices", () => {
         command: "pnpm test",
         durationMs: 42,
         exitCode: 0,
+        hiddenContentDeltaCount: 2,
         status: "completed",
       },
     );
@@ -7625,19 +7776,35 @@ describe("ServeServices", () => {
       "item/commandExecution/outputDelta",
     );
     strictEqual(emptyCommandMessage?.text, "");
-    strictEqual(shellCommandMessage?.text, "log");
+    strictEqual(shellCommandMessage?.text, "");
     strictEqual(
       (shellCommandMessage?.eventData as { capReached?: boolean } | undefined)
         ?.capReached,
       true,
     );
+    strictEqual(
+      (
+        shellCommandMessage?.eventData as
+          | { hiddenContentDeltaCount?: unknown }
+          | undefined
+      )?.hiddenContentDeltaCount,
+      1,
+    );
     deepStrictEqual(
       (patchMessage?.eventData as { changes?: unknown[] } | undefined)?.changes,
-      [{ path: "src/app.ts", kind: "modify", diff: "@@ final patch" }],
+      [{ path: "src/app.ts", kind: "modify" }],
     );
     strictEqual(
       (patchMessage?.eventData as { status?: string } | undefined)?.status,
       "completed",
+    );
+    strictEqual(
+      (
+        patchMessage?.eventData as
+          | { hiddenContentUpdateCount?: unknown }
+          | undefined
+      )?.hiddenContentUpdateCount,
+      2,
     );
     strictEqual(
       emitSpy.mock.calls.some((call) => call[0] === "agent.plan.updated"),
@@ -7647,6 +7814,216 @@ describe("ServeServices", () => {
       emitSpy.mock.calls.some((call) => call[0] === "agent.command.output"),
       true,
     );
+    const emittedCommandParams = getEmittedCodexParams(
+      emitSpy.mock.calls,
+      "agent.command.output",
+      "item/commandExecution/outputDelta",
+    );
+    const emittedShellCommandParams = getEmittedCodexParams(
+      emitSpy.mock.calls,
+      "agent.command.output",
+      "command/exec/outputDelta",
+    );
+    const emittedDiffParams = getEmittedCodexParams(
+      emitSpy.mock.calls,
+      "agent.diff.updated",
+      "turn/diff/updated",
+    );
+    const emittedPatchParams = getEmittedCodexParams(
+      emitSpy.mock.calls,
+      "agent.file.updated",
+      "item/fileChange/patchUpdated",
+    );
+    const emittedCommandCompletedParams = getEmittedCodexParams(
+      emitSpy.mock.calls,
+      "agent.item.updated",
+      "item/completed",
+      "commandExecution",
+    );
+    const emittedFileCompletedParams = getEmittedCodexParams(
+      emitSpy.mock.calls,
+      "agent.item.updated",
+      "item/completed",
+      "fileChange",
+    );
+    const emittedPatchChanges = emittedPatchParams?.changes as
+      | Array<Record<string, unknown>>
+      | undefined;
+    const emittedFileCompletedItem = emittedFileCompletedParams?.item as
+      | Record<string, unknown>
+      | undefined;
+    const emittedFileCompletedChanges = emittedFileCompletedItem?.changes as
+      | Array<Record<string, unknown>>
+      | undefined;
+    strictEqual(emittedCommandParams?.delta, undefined);
+    strictEqual(emittedShellCommandParams?.deltaBase64, undefined);
+    strictEqual(emittedDiffParams?.diff, undefined);
+    strictEqual(emittedPatchChanges?.[0]?.diff, undefined);
+    strictEqual(
+      (
+        emittedCommandCompletedParams?.item as
+          | Record<string, unknown>
+          | undefined
+      )?.aggregatedOutput,
+      undefined,
+    );
+    strictEqual(emittedFileCompletedChanges?.[0]?.diff, undefined);
+  });
+
+  it("preserves lightweight markers for repeated hidden diff and patch updates", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "running", activeTurnId: "turn_1" })],
+    };
+    const { codex, store } = await createHarness(state);
+
+    codex.emitNotification({
+      method: "turn/diff/updated",
+      params: {
+        turnId: "turn_1",
+        diff: "diff --git a/src/app.ts b/src/app.ts\n@@ -1 +1 @@\n-old\n+new",
+      },
+    });
+    codex.emitNotification({
+      method: "turn/diff/updated",
+      params: {
+        turnId: "turn_1",
+        diff: "diff --git a/src/app.ts b/src/app.ts\n@@ -1 +1 @@\n-new\n+newer",
+      },
+    });
+    codex.emitNotification({
+      method: "item/fileChange/patchUpdated",
+      params: {
+        threadId: "thread_1",
+        turnId: "turn_1",
+        itemId: "patch_1",
+        changes: [{ path: "src/app.ts", kind: "modify", diff: "@@ patch 1" }],
+      },
+    });
+    codex.emitNotification({
+      method: "item/fileChange/patchUpdated",
+      params: {
+        threadId: "thread_1",
+        turnId: "turn_1",
+        itemId: "patch_1",
+        changes: [{ path: "src/app.ts", kind: "modify", diff: "@@ patch 2" }],
+      },
+    });
+
+    let savedState = await store.load();
+    await vi.waitFor(async () => {
+      savedState = await store.load();
+      const diffMessage = savedState.messages.find(
+        (message) => message.eventType === "turn/diff/updated",
+      );
+      const patchMessage = savedState.messages.find(
+        (message) => message.eventType === "item/fileChange/patchUpdated",
+      );
+      strictEqual(
+        (
+          diffMessage?.eventData as
+            | { hiddenContentUpdateCount?: unknown }
+            | undefined
+        )?.hiddenContentUpdateCount,
+        2,
+      );
+      strictEqual(
+        (
+          patchMessage?.eventData as
+            | { hiddenContentUpdateCount?: unknown }
+            | undefined
+        )?.hiddenContentUpdateCount,
+        2,
+      );
+    });
+
+    const diffMessage = savedState.messages.find(
+      (message) => message.eventType === "turn/diff/updated",
+    );
+    const patchMessage = savedState.messages.find(
+      (message) => message.eventType === "item/fileChange/patchUpdated",
+    );
+
+    deepStrictEqual(diffMessage?.eventData, {
+      files: ["src/app.ts"],
+      hasDiff: true,
+      hiddenContentUpdateCount: 2,
+    });
+    deepStrictEqual(patchMessage?.eventData, {
+      changes: [{ path: "src/app.ts", kind: "modify" }],
+      hiddenContentUpdateCount: 2,
+    });
+  });
+
+  it("flushes sanitized hidden events buffered during turn startup", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat()],
+    };
+    const { codex, services, store } = await createHarness(state);
+    codex.resumeThread.mockResolvedValueOnce({});
+    codex.startTurn.mockImplementationOnce(async () => {
+      codex.emitNotification({
+        method: "item/commandExecution/outputDelta",
+        params: {
+          threadId: "thread_1",
+          turnId: "turn_1",
+          itemId: "cmd_1",
+          delta: "large output",
+        },
+      });
+      codex.emitNotification({
+        method: "turn/diff/updated",
+        params: {
+          turnId: "turn_1",
+          diff: "diff --git a/src/app.ts b/src/app.ts\n@@ -1 +1 @@\n-old\n+new",
+        },
+      });
+      codex.emitNotification({
+        method: "item/fileChange/patchUpdated",
+        params: {
+          threadId: "thread_1",
+          turnId: "turn_1",
+          itemId: "patch_1",
+          changes: [{ path: "src/app.ts", kind: "modify", diff: "@@ patch" }],
+        },
+      });
+      return { turn: { id: "turn_1" } };
+    });
+
+    await services.sendMessage("chat_1", { text: "hello" });
+    await vi.waitFor(async () => {
+      strictEqual((await store.load()).messages.length, 4);
+    });
+
+    const savedState = await store.load();
+    const commandMessage = savedState.messages.find(
+      (message) => message.eventType === "item/commandExecution/outputDelta",
+    );
+    const diffMessage = savedState.messages.find(
+      (message) => message.eventType === "turn/diff/updated",
+    );
+    const patchMessage = savedState.messages.find(
+      (message) => message.eventType === "item/fileChange/patchUpdated",
+    );
+
+    strictEqual(commandMessage?.text, "");
+    deepStrictEqual(commandMessage?.eventData, {
+      hiddenContentDeltaCount: 1,
+      hiddenContentLength: 12,
+      kind: "commandExecutionOutput",
+    });
+    deepStrictEqual(diffMessage?.eventData, {
+      files: ["src/app.ts"],
+      hasDiff: true,
+      hiddenContentUpdateCount: 1,
+    });
+    deepStrictEqual(patchMessage?.eventData, {
+      changes: [{ path: "src/app.ts", kind: "modify" }],
+      hiddenContentUpdateCount: 1,
+    });
   });
 
   it("ignores empty reasoning summary parts before summary text arrives", async () => {

--- a/packages/server/src/services.ts
+++ b/packages/server/src/services.ts
@@ -1939,7 +1939,9 @@ export class ServeServices {
         return;
       }
       await this.addMessageFromCodexEvent(chat.id, method, message.params);
-      this.eventHub.emit(eventType, message, { chatId: chat.id });
+      this.eventHub.emit(eventType, sanitizeCodexMessageForEventHub(message), {
+        chatId: chat.id,
+      });
       if (method === "turn/completed") {
         await this.drainQueuedMessagesAndReport(chat.id);
       }
@@ -1947,7 +1949,7 @@ export class ServeServices {
       if (method === "serverRequest/resolved") {
         return;
       }
-      this.eventHub.emit(eventType, message);
+      this.eventHub.emit(eventType, sanitizeCodexMessageForEventHub(message));
     }
   }
 
@@ -2024,10 +2026,14 @@ export class ServeServices {
 
     const approvalMethod = message.method ?? "unknown";
     const approvalRequestId = createRecordId("approval");
+    const approvalParams = sanitizeCodexEventParams(
+      approvalMethod,
+      message.params,
+    );
     this.approvalRequests.set(approvalRequestId, {
       chatId: chat.id,
       method: approvalMethod,
-      params: message.params,
+      params: approvalParams,
       serverRequestId,
       responded: false,
     });
@@ -2041,7 +2047,7 @@ export class ServeServices {
       {
         requestId: approvalRequestId,
         method: approvalMethod,
-        params: message.params,
+        params: approvalParams,
       },
       { chatId: chat.id },
     );
@@ -2291,7 +2297,7 @@ export class ServeServices {
   ): PendingTurnEvent {
     return {
       kind,
-      message,
+      message: sanitizeCodexMessageForEventHub(message),
       order: this.pendingTurnEventOrder++,
     };
   }
@@ -2546,7 +2552,13 @@ export class ServeServices {
 
   private async resetStaleTransientChatState(): Promise<ReadonlySet<string>> {
     const state = await this.store.load();
-    if (!state.chats.some((chat) => this.isStaleTransientChat(chat))) {
+    const hasStaleTransientChat = state.chats.some((chat) =>
+      this.isStaleTransientChat(chat),
+    );
+    const hasStoredHiddenRichEventContent = state.messages.some(
+      hasHiddenRichEventContent,
+    );
+    if (!hasStaleTransientChat && !hasStoredHiddenRichEventContent) {
       return new Set();
     }
 
@@ -2566,18 +2578,20 @@ export class ServeServices {
           updatedAt: timestamp,
         };
       });
-      if (resetChatIds.size === 0) {
+      if (resetChatIds.size === 0 && !hasStoredHiddenRichEventContent) {
         return nextState;
       }
       return {
         ...nextState,
         chats,
-        messages: nextState.messages.map((message) =>
-          resetChatIds.has(message.chatId) &&
-          message.eventType === "chat.message.steered"
-            ? { ...message, eventType: undefined }
-            : message,
-        ),
+        messages: nextState.messages.map((message) => {
+          const nextMessage =
+            resetChatIds.has(message.chatId) &&
+            message.eventType === "chat.message.steered"
+              ? { ...message, eventType: undefined }
+              : message;
+          return stripHiddenRichEventContent(nextMessage);
+        }),
       };
     });
     return resetChatIds;
@@ -2797,6 +2811,16 @@ export class ServeServices {
       const delta = extractCommandOutputDelta(method, params);
       const eventData = createCommandOutputEventData(method, params);
       if (!delta) {
+        if (hasHiddenOutputDelta(params)) {
+          await this.appendRichEventMessage({
+            chatId,
+            delta: "",
+            eventData,
+            eventType: method,
+            itemId: getCommandOutputItemId(method, params),
+          });
+          return;
+        }
         if (hasCommandOutputMetadataUpdate(method, params)) {
           await this.mergeRichEventMessage({
             chatId,
@@ -2832,12 +2856,21 @@ export class ServeServices {
     if (method === "item/fileChange/outputDelta") {
       const delta = getRecordString(params, "delta") ?? "";
       if (!delta) {
+        if (hasHiddenOutputDelta(params)) {
+          await this.appendRichEventMessage({
+            chatId,
+            delta: "",
+            eventData: createFileChangeOutputEventData(params),
+            eventType: method,
+            itemId: getRecordString(params, "itemId") ?? method,
+          });
+        }
         return;
       }
       await this.appendRichEventMessage({
         chatId,
         delta,
-        eventData: { kind: "fileChangeOutput" },
+        eventData: createFileChangeOutputEventData(params),
         eventType: method,
         itemId: getRecordString(params, "itemId") ?? method,
       });
@@ -2970,12 +3003,29 @@ export class ServeServices {
           message.eventType === eventType &&
           message.itemId === itemId,
       );
+      const existingEventData = isRecord(existingMessage?.eventData)
+        ? existingMessage.eventData
+        : {};
+      const nextEventData = withHiddenContentUpdateCount(
+        eventType,
+        existingEventData,
+        eventData,
+      );
       if (!existingMessage) {
         return {
           ...state,
           messages: [
             ...state.messages,
-            createMessage(chatId, "event", text, eventType, itemId, eventData),
+            stripHiddenRichEventContent(
+              createMessage(
+                chatId,
+                "event",
+                text,
+                eventType,
+                itemId,
+                nextEventData,
+              ),
+            ),
           ],
         };
       }
@@ -2983,7 +3033,11 @@ export class ServeServices {
         ...state,
         messages: state.messages.map((message) =>
           message.id === existingMessage.id
-            ? { ...message, eventData, text }
+            ? stripHiddenRichEventContent({
+                ...message,
+                eventData: nextEventData,
+                text,
+              })
             : message,
         ),
       };
@@ -3011,23 +3065,35 @@ export class ServeServices {
           message.eventType === eventType &&
           message.itemId === itemId,
       );
-      const text = `${existingMessage?.text ?? ""}${delta}`;
+      const text = shouldStripHiddenRichEventContent(eventType)
+        ? ""
+        : `${existingMessage?.text ?? ""}${delta}`;
       const existingEventData = isRecord(existingMessage?.eventData)
         ? existingMessage.eventData
         : {};
-      const nextEventData = { ...existingEventData, ...eventData, text };
+      const nextEventData = shouldStripHiddenRichEventContent(eventType)
+        ? {
+            ...existingEventData,
+            ...eventData,
+            hiddenContentDeltaCount:
+              (getRecordNumber(existingEventData, "hiddenContentDeltaCount") ??
+                0) + 1,
+          }
+        : { ...existingEventData, ...eventData, text };
       if (!existingMessage) {
         return {
           ...state,
           messages: [
             ...state.messages,
-            createMessage(
-              chatId,
-              "event",
-              text,
-              eventType,
-              itemId,
-              nextEventData,
+            stripHiddenRichEventContent(
+              createMessage(
+                chatId,
+                "event",
+                text,
+                eventType,
+                itemId,
+                nextEventData,
+              ),
             ),
           ],
         };
@@ -3036,7 +3102,11 @@ export class ServeServices {
         ...state,
         messages: state.messages.map((message) =>
           message.id === existingMessage.id
-            ? { ...message, eventData: nextEventData, text }
+            ? stripHiddenRichEventContent({
+                ...message,
+                eventData: nextEventData,
+                text,
+              })
             : message,
         ),
       };
@@ -3067,24 +3137,30 @@ export class ServeServices {
       const existingEventData = isRecord(existingMessage?.eventData)
         ? existingMessage.eventData
         : {};
-      const nextText = text ?? existingMessage?.text ?? "";
+      const nextText = shouldStripHiddenRichEventContent(eventType)
+        ? ""
+        : (text ?? existingMessage?.text ?? "");
       const nextEventData = {
         ...existingEventData,
         ...eventData,
-        text: nextText,
+        ...(shouldStripHiddenRichEventContent(eventType)
+          ? {}
+          : { text: nextText }),
       };
       if (!existingMessage) {
         return {
           ...state,
           messages: [
             ...state.messages,
-            createMessage(
-              chatId,
-              "event",
-              nextText,
-              eventType,
-              itemId,
-              nextEventData,
+            stripHiddenRichEventContent(
+              createMessage(
+                chatId,
+                "event",
+                nextText,
+                eventType,
+                itemId,
+                nextEventData,
+              ),
             ),
           ],
         };
@@ -3093,7 +3169,11 @@ export class ServeServices {
         ...state,
         messages: state.messages.map((message) =>
           message.id === existingMessage.id
-            ? { ...message, eventData: nextEventData, text: nextText }
+            ? stripHiddenRichEventContent({
+                ...message,
+                eventData: nextEventData,
+                text: nextText,
+              })
             : message,
         ),
       };
@@ -4955,16 +5035,17 @@ interface PlanEventData {
 }
 
 interface DiffEventData {
-  diff: string;
   files: string[];
+  hasDiff: boolean;
+  hiddenContentUpdateCount?: number;
 }
 
 interface FilePatchEventData {
   changes: Array<{
-    diff: string;
     kind: string;
     path: string;
   }>;
+  hiddenContentUpdateCount?: number;
 }
 
 function normalizePlanEventData(params: unknown): PlanEventData {
@@ -4989,9 +5070,11 @@ function normalizePlanEventData(params: unknown): PlanEventData {
 
 function normalizeDiffEventData(params: unknown): DiffEventData {
   const diff = getRecordString(params, "diff") ?? "";
+  const files =
+    diff === "" ? (getRecordStringArray(params, "files") ?? []) : [];
   return {
-    diff,
-    files: extractDiffFilePaths(diff),
+    files: diff === "" ? files : extractDiffFilePaths(diff),
+    hasDiff: getRecordBoolean(params, "hasDiff") ?? Boolean(diff),
   };
 }
 
@@ -5005,7 +5088,6 @@ function normalizeFilePatchEventData(params: unknown): FilePatchEventData {
       return {
         path,
         kind: getRecordString(change, "kind") ?? "update",
-        diff: getRecordString(change, "diff") ?? "",
       };
     })
     .filter((change): change is FilePatchEventData["changes"][number] =>
@@ -5016,7 +5098,7 @@ function normalizeFilePatchEventData(params: unknown): FilePatchEventData {
 
 function summarizeDiffEvent(eventData: DiffEventData): string {
   if (eventData.files.length === 0) {
-    return eventData.diff ? "Diff updated" : "Diff cleared";
+    return eventData.hasDiff ? "Diff updated" : "Diff cleared";
   }
   return `Diff updated: ${eventData.files.length} file${
     eventData.files.length === 1 ? "" : "s"
@@ -5044,15 +5126,34 @@ function createCommandOutputEventData(
   method: string,
   params: unknown,
 ): Record<string, unknown> {
+  const hiddenContentLength = getRecordNumber(params, "hiddenContentLength");
   if (method === "command/exec/outputDelta") {
     return {
       kind: "commandExecOutput",
       processId: getRecordString(params, "processId") ?? null,
       stream: getRecordString(params, "stream") ?? "stdout",
       capReached: Boolean(isRecord(params) && params.capReached === true),
+      ...(hiddenContentLength === undefined ? {} : { hiddenContentLength }),
     };
   }
-  return { kind: "commandExecutionOutput" };
+  return {
+    kind: "commandExecutionOutput",
+    ...(hiddenContentLength === undefined ? {} : { hiddenContentLength }),
+  };
+}
+
+function createFileChangeOutputEventData(
+  params: unknown,
+): Record<string, unknown> {
+  const hiddenContentLength = getRecordNumber(params, "hiddenContentLength");
+  return {
+    kind: "fileChangeOutput",
+    ...(hiddenContentLength === undefined ? {} : { hiddenContentLength }),
+  };
+}
+
+function hasHiddenOutputDelta(params: unknown): boolean {
+  return (getRecordNumber(params, "hiddenContentDeltaCount") ?? 0) > 0;
 }
 
 function hasCommandOutputMetadataUpdate(
@@ -5127,6 +5228,233 @@ function getReasoningEventItemId(method: string, params: unknown): string {
   return `${itemId}:text:${getRecordNumber(params, "contentIndex") ?? 0}`;
 }
 
+function sanitizeCodexMessageForEventHub(message: CodexMessage): CodexMessage {
+  const method = message.method ?? "";
+  const params = sanitizeCodexEventParams(method, message.params);
+  return params === message.params ? message : { ...message, params };
+}
+
+function sanitizeCodexEventParams(method: string, params: unknown): unknown {
+  if (!isRecord(params)) {
+    return params;
+  }
+
+  if (
+    method === "item/commandExecution/outputDelta" ||
+    method === "command/exec/outputDelta" ||
+    method === "item/fileChange/outputDelta"
+  ) {
+    const delta =
+      method === "command/exec/outputDelta"
+        ? getRecordString(params, "deltaBase64")
+        : getRecordString(params, "delta");
+    const nextParams = { ...params };
+    delete nextParams.delta;
+    delete nextParams.deltaBase64;
+    if (delta) {
+      nextParams.hiddenContentDeltaCount = 1;
+      nextParams.hiddenContentLength =
+        method === "command/exec/outputDelta"
+          ? Buffer.from(delta, "base64").byteLength
+          : delta.length;
+    }
+    return nextParams;
+  }
+
+  if (method === "turn/diff/updated") {
+    return stripDiffEventData(params);
+  }
+
+  if (method === "item/fileChange/patchUpdated") {
+    return stripFilePatchDiffs(params);
+  }
+
+  if (method.endsWith("/requestApproval")) {
+    return stripHiddenCodexPayloadContent(params);
+  }
+
+  if (method === "item/started" || method === "item/completed") {
+    const item = getRecordObject(params, "item");
+    if (!item) {
+      return params;
+    }
+    const nextItem = sanitizeCodexEventItem(item);
+    return nextItem === item ? params : { ...params, item: nextItem };
+  }
+
+  return params;
+}
+
+function sanitizeCodexEventItem(item: Record<string, unknown>): unknown {
+  const itemType = getRecordString(item, "type");
+  if (itemType === "commandExecution") {
+    return stripRecordKey(item, "aggregatedOutput");
+  }
+  if (itemType === "fileChange") {
+    return stripFilePatchDiffs(item);
+  }
+  return item;
+}
+
+function stripHiddenRichEventContent(
+  message: ChatMessageRecord,
+): ChatMessageRecord {
+  if (!hasHiddenRichEventContent(message)) {
+    return message;
+  }
+
+  if (
+    message.eventType === "item/commandExecution/outputDelta" ||
+    message.eventType === "command/exec/outputDelta" ||
+    message.eventType === "item/fileChange/outputDelta"
+  ) {
+    return {
+      ...message,
+      eventData: stripRecordKey(message.eventData, "text"),
+      text: "",
+    };
+  }
+
+  if (message.eventType === "turn/diff/updated") {
+    return {
+      ...message,
+      eventData: stripDiffEventData(message.eventData),
+    };
+  }
+
+  if (message.eventType === "item/fileChange/patchUpdated") {
+    return {
+      ...message,
+      eventData: stripFilePatchDiffs(message.eventData),
+    };
+  }
+
+  return message;
+}
+
+function hasHiddenRichEventContent(message: ChatMessageRecord): boolean {
+  if (message.role !== "event") {
+    return false;
+  }
+
+  if (
+    message.eventType === "item/commandExecution/outputDelta" ||
+    message.eventType === "command/exec/outputDelta" ||
+    message.eventType === "item/fileChange/outputDelta"
+  ) {
+    return (
+      message.text !== "" ||
+      getRecordString(message.eventData, "text") !== undefined
+    );
+  }
+
+  if (message.eventType === "turn/diff/updated") {
+    return getRecordString(message.eventData, "diff") !== undefined;
+  }
+
+  if (message.eventType === "item/fileChange/patchUpdated") {
+    const changes = getRecordArray(message.eventData, "changes") ?? [];
+    return changes.some(
+      (change) => getRecordString(change, "diff") !== undefined,
+    );
+  }
+
+  return false;
+}
+
+function shouldStripHiddenRichEventContent(eventType: string): boolean {
+  return (
+    eventType === "item/commandExecution/outputDelta" ||
+    eventType === "command/exec/outputDelta" ||
+    eventType === "item/fileChange/outputDelta"
+  );
+}
+
+function stripRecordKey(value: unknown, key: string): unknown {
+  if (!isRecord(value)) {
+    return value;
+  }
+  const nextValue = { ...value };
+  delete nextValue[key];
+  return nextValue;
+}
+
+function withHiddenContentUpdateCount(
+  eventType: string,
+  existingEventData: Record<string, unknown>,
+  eventData: unknown,
+): unknown {
+  if (!shouldTrackHiddenContentUpdate(eventType) || !isRecord(eventData)) {
+    return eventData;
+  }
+  return {
+    ...eventData,
+    hiddenContentUpdateCount:
+      (getRecordNumber(existingEventData, "hiddenContentUpdateCount") ?? 0) + 1,
+  };
+}
+
+function shouldTrackHiddenContentUpdate(eventType: string): boolean {
+  return (
+    eventType === "turn/diff/updated" ||
+    eventType === "item/fileChange/patchUpdated"
+  );
+}
+
+function stripDiffEventData(value: unknown): unknown {
+  if (!isRecord(value)) {
+    return value;
+  }
+  const diff = getRecordString(value, "diff");
+  const nextValue = { ...value };
+  delete nextValue.diff;
+  if (diff) {
+    if (!Array.isArray(nextValue.files)) {
+      nextValue.files = extractDiffFilePaths(diff);
+    }
+    if (typeof nextValue.hasDiff !== "boolean") {
+      nextValue.hasDiff = true;
+    }
+  }
+  return nextValue;
+}
+
+function stripFilePatchDiffs(value: unknown): unknown {
+  if (!isRecord(value)) {
+    return value;
+  }
+  const changes = value.changes;
+  if (!Array.isArray(changes)) {
+    return value;
+  }
+  return {
+    ...value,
+    changes: changes.map((change) => stripRecordKey(change, "diff")),
+  };
+}
+
+function stripHiddenCodexPayloadContent(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(stripHiddenCodexPayloadContent);
+  }
+  if (!isRecord(value)) {
+    return value;
+  }
+  const nextValue: Record<string, unknown> = {};
+  for (const [key, childValue] of Object.entries(value)) {
+    if (
+      key === "aggregatedOutput" ||
+      key === "delta" ||
+      key === "deltaBase64" ||
+      key === "diff"
+    ) {
+      continue;
+    }
+    nextValue[key] = stripHiddenCodexPayloadContent(childValue);
+  }
+  return nextValue;
+}
+
 function extractDiffFilePaths(diff: string): string[] {
   const files = new Set<string>();
   for (const line of diff.split(/\r?\n/)) {
@@ -5198,6 +5526,30 @@ function getRecordNumber(value: unknown, key: string): number | undefined {
   return typeof candidate === "number" && Number.isFinite(candidate)
     ? candidate
     : undefined;
+}
+
+function getRecordBoolean(value: unknown, key: string): boolean | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const candidate = value[key];
+  return typeof candidate === "boolean" ? candidate : undefined;
+}
+
+function getRecordStringArray(
+  value: unknown,
+  key: string,
+): string[] | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const candidate = value[key];
+  if (!Array.isArray(candidate)) {
+    return undefined;
+  }
+  return candidate.filter(
+    (entry): entry is string => typeof entry === "string",
+  );
 }
 
 function getStringArray(value: unknown): string[] {

--- a/packages/web/src/api/queries.test.ts
+++ b/packages/web/src/api/queries.test.ts
@@ -1,0 +1,129 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "vitest";
+import { stripHiddenRichEventContentFromMessages } from "./queries";
+import type { RenderedChatMessageRecord } from "@phantompane/server";
+
+function createMessage(
+  overrides: Partial<RenderedChatMessageRecord> = {},
+): RenderedChatMessageRecord {
+  return {
+    chatId: "chat_1",
+    createdAt: "2026-05-07T00:00:00.000Z",
+    id: "msg_1",
+    role: "event",
+    text: "event",
+    ...overrides,
+  };
+}
+
+describe("stripHiddenRichEventContentFromMessages", () => {
+  it("drops command and file output bodies while preserving metadata", () => {
+    const [commandMessage, fileOutputMessage, textOnlyOutputMessage] =
+      stripHiddenRichEventContentFromMessages([
+        createMessage({
+          eventData: {
+            command: "pnpm test",
+            exitCode: 0,
+            status: "completed",
+            text: "large command output",
+          },
+          eventType: "item/commandExecution/outputDelta",
+          text: "large command output",
+          textHtml: "<pre>large command output</pre>\n",
+        }),
+        createMessage({
+          eventData: {
+            kind: "fileChangeOutput",
+            text: "large file output",
+          },
+          eventType: "item/fileChange/outputDelta",
+          id: "msg_2",
+          text: "large file output",
+        }),
+        createMessage({
+          eventType: "item/commandExecution/outputDelta",
+          id: "msg_3",
+          text: "raw output without event data",
+        }),
+      ]);
+
+    strictEqual(commandMessage?.text, "");
+    strictEqual(commandMessage?.textHtml, "");
+    deepStrictEqual(commandMessage?.eventData, {
+      command: "pnpm test",
+      exitCode: 0,
+      hiddenContentLength: 20,
+      status: "completed",
+    });
+    strictEqual(fileOutputMessage?.text, "");
+    deepStrictEqual(fileOutputMessage?.eventData, {
+      hiddenContentLength: 17,
+      kind: "fileChangeOutput",
+    });
+    strictEqual(textOnlyOutputMessage?.text, "");
+    deepStrictEqual(textOnlyOutputMessage?.eventData, {
+      hiddenContentLength: 29,
+    });
+  });
+
+  it("drops hidden diff and patch bodies while preserving summaries", () => {
+    const [diffMessage, patchMessage] = stripHiddenRichEventContentFromMessages(
+      [
+        createMessage({
+          eventData: {
+            diff: "large diff",
+            files: ["a.ts"],
+          },
+          eventType: "turn/diff/updated",
+          text: "Diff updated: 1 file",
+        }),
+        createMessage({
+          eventData: {
+            changes: [
+              {
+                diff: "large patch",
+                kind: "update",
+                path: "a.ts",
+              },
+            ],
+            status: "completed",
+          },
+          eventType: "item/fileChange/patchUpdated",
+          id: "msg_2",
+          text: "File patch updated: 1 file",
+        }),
+      ],
+    );
+
+    strictEqual(diffMessage?.text, "Diff updated: 1 file");
+    deepStrictEqual(diffMessage?.eventData, {
+      files: ["a.ts"],
+      hasDiff: true,
+    });
+    strictEqual(patchMessage?.text, "File patch updated: 1 file");
+    deepStrictEqual(patchMessage?.eventData, {
+      changes: [
+        {
+          kind: "update",
+          path: "a.ts",
+        },
+      ],
+      status: "completed",
+    });
+  });
+
+  it("keeps regular chat messages unchanged", () => {
+    const assistantMessage = createMessage({
+      id: "msg_3",
+      role: "assistant",
+      text: "hello",
+      textHtml: "<p>hello</p>\n",
+    });
+
+    const [result] = stripHiddenRichEventContentFromMessages([
+      assistantMessage,
+    ]);
+
+    strictEqual(result, assistantMessage);
+  });
+});

--- a/packages/web/src/api/queries.ts
+++ b/packages/web/src/api/queries.ts
@@ -106,12 +106,18 @@ export function chatApprovalQueryOptions(chatId: string, signal?: AbortSignal) {
 export function messagesQueryOptions(chatId: string) {
   return queryOptions({
     queryKey: queryKeys.messages(chatId),
-    queryFn: async () =>
-      readRpcJson<{ messages: RenderedChatMessageRecord[] }>(
+    queryFn: async () => {
+      const data = await readRpcJson<{
+        messages: RenderedChatMessageRecord[];
+      }>(
         await api.chats[":chatId"].messages.$get({
           param: { chatId: routeParam(chatId) },
         }),
-      ),
+      );
+      return {
+        messages: stripHiddenRichEventContentFromMessages(data.messages),
+      };
+    },
   });
 }
 
@@ -153,4 +159,122 @@ export function fileSearchQueryOptions(
         ),
       ),
   });
+}
+
+export function stripHiddenRichEventContentFromMessages(
+  messages: RenderedChatMessageRecord[],
+): RenderedChatMessageRecord[] {
+  return messages.map(stripHiddenRichEventContent);
+}
+
+function stripHiddenRichEventContent(
+  message: RenderedChatMessageRecord,
+): RenderedChatMessageRecord {
+  if (message.role !== "event") {
+    return message;
+  }
+
+  if (
+    message.eventType === "item/commandExecution/outputDelta" ||
+    message.eventType === "command/exec/outputDelta" ||
+    message.eventType === "item/fileChange/outputDelta"
+  ) {
+    const hiddenText = getHiddenOutputText(message);
+    return {
+      ...message,
+      eventData: withHiddenContentLength(
+        stripRecordKey(message.eventData, "text"),
+        hiddenText,
+      ),
+      text: "",
+      textHtml: "",
+    };
+  }
+
+  if (message.eventType === "turn/diff/updated") {
+    return {
+      ...message,
+      eventData: stripDiffEventData(message.eventData),
+    };
+  }
+
+  if (message.eventType === "item/fileChange/patchUpdated") {
+    return {
+      ...message,
+      eventData: stripFilePatchDiffs(message.eventData),
+    };
+  }
+
+  return message;
+}
+
+function stripRecordKey(value: unknown, key: string): unknown {
+  if (!isRecord(value)) {
+    return value;
+  }
+  const nextValue = { ...value };
+  delete nextValue[key];
+  return nextValue;
+}
+
+function getHiddenOutputText(message: RenderedChatMessageRecord): string {
+  if (
+    isRecord(message.eventData) &&
+    typeof message.eventData.text === "string"
+  ) {
+    return message.eventData.text;
+  }
+  return message.text;
+}
+
+function withHiddenContentLength(value: unknown, hiddenText: string): unknown {
+  if (!hiddenText) {
+    return value;
+  }
+  if (!isRecord(value)) {
+    return {
+      hiddenContentLength: hiddenText.length,
+    };
+  }
+  if (
+    typeof value.hiddenContentDeltaCount === "number" ||
+    typeof value.hiddenContentLength === "number"
+  ) {
+    return value;
+  }
+  return {
+    ...value,
+    hiddenContentLength: hiddenText.length,
+  };
+}
+
+function stripDiffEventData(value: unknown): unknown {
+  if (!isRecord(value)) {
+    return value;
+  }
+  const diff = typeof value.diff === "string" ? value.diff : "";
+  const nextValue = { ...value };
+  delete nextValue.diff;
+  if (diff && typeof nextValue.hasDiff !== "boolean") {
+    nextValue.hasDiff = true;
+  }
+  return nextValue;
+}
+
+function stripFilePatchDiffs(value: unknown): unknown {
+  if (!isRecord(value)) {
+    return value;
+  }
+  const changes = value.changes;
+  if (!Array.isArray(changes)) {
+    return value;
+  }
+  return {
+    ...value,
+    changes: changes.map((change) => stripRecordKey(change, "diff")),
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/packages/web/src/routes/chat-message-stream-order.test.ts
+++ b/packages/web/src/routes/chat-message-stream-order.test.ts
@@ -80,6 +80,102 @@ describe("mergeStreamingMessagesForDisplay", () => {
     );
   });
 
+  it("moves hidden output stream events when only lightweight metadata changes", () => {
+    const currentMessages = [
+      createMessage("msg_user", "user", "fix chat"),
+      createMessage("msg_event", "event", "", {
+        eventData: {
+          hiddenContentDeltaCount: 1,
+          kind: "commandExecutionOutput",
+        },
+        eventType: "item/commandExecution/outputDelta",
+        itemId: "cmd_1",
+      }),
+      createMessage("msg_assistant", "assistant", "working"),
+    ];
+    const incomingMessages = [
+      currentMessages[0]!,
+      createMessage("msg_event", "event", "", {
+        eventData: {
+          hiddenContentDeltaCount: 2,
+          kind: "commandExecutionOutput",
+        },
+        eventType: "item/commandExecution/outputDelta",
+        itemId: "cmd_1",
+      }),
+      currentMessages[2]!,
+    ];
+
+    const mergedMessages = mergeStreamingMessagesForDisplay(
+      currentMessages,
+      incomingMessages,
+    );
+
+    deepStrictEqual(
+      mergedMessages.map((message) => [message.id, message.text]),
+      [
+        ["msg_user", "fix chat"],
+        ["msg_assistant", "working"],
+        ["msg_event", ""],
+      ],
+    );
+  });
+
+  it("moves hidden diff and patch events when only lightweight metadata changes", () => {
+    const currentMessages = [
+      createMessage("msg_user", "user", "fix chat"),
+      createMessage("msg_diff", "event", "Diff updated: 1 file", {
+        eventData: {
+          files: ["src/app.ts"],
+          hasDiff: true,
+          hiddenContentUpdateCount: 1,
+        },
+        eventType: "turn/diff/updated",
+        itemId: "turn_1",
+      }),
+      createMessage("msg_patch", "event", "File patch updated: 1 file", {
+        eventData: {
+          changes: [{ kind: "modify", path: "src/app.ts" }],
+          hiddenContentUpdateCount: 1,
+        },
+        eventType: "item/fileChange/patchUpdated",
+        itemId: "patch_1",
+      }),
+      createMessage("msg_assistant", "assistant", "working"),
+    ];
+    const incomingMessages = [
+      currentMessages[0]!,
+      createMessage("msg_diff", "event", "Diff updated: 1 file", {
+        eventData: {
+          files: ["src/app.ts"],
+          hasDiff: true,
+          hiddenContentUpdateCount: 2,
+        },
+        eventType: "turn/diff/updated",
+        itemId: "turn_1",
+      }),
+      createMessage("msg_patch", "event", "File patch updated: 1 file", {
+        eventData: {
+          changes: [{ kind: "modify", path: "src/app.ts" }],
+          hiddenContentUpdateCount: 2,
+        },
+        eventType: "item/fileChange/patchUpdated",
+        itemId: "patch_1",
+      }),
+      currentMessages[3]!,
+    ];
+
+    const mergedMessages = mergeStreamingMessagesForDisplay(
+      currentMessages,
+      incomingMessages,
+    );
+
+    deepStrictEqual(
+      mergedMessages.map((message) => message.id),
+      ["msg_user", "msg_assistant", "msg_diff", "msg_patch"],
+    );
+  });
+
   it("keeps updated stream events below new assistant messages from the same refresh", () => {
     const currentMessages = [
       createMessage("msg_user", "user", "fix chat"),

--- a/packages/web/src/routes/home.tsx
+++ b/packages/web/src/routes/home.tsx
@@ -143,8 +143,6 @@ import {
 import {
   getCommandEventMeta,
   getDiffEventData,
-  getDiffLineDelta,
-  getFileChangesLineDelta,
   getFileEventMeta,
   getFilePatchEventData,
   getPlanEventData,
@@ -4598,34 +4596,33 @@ function PlanEventCard({ message }: { message: VisibleMessageRecord }) {
 }
 
 function DiffEventCard({ message }: { message: VisibleMessageRecord }) {
-  const { diff, files } = getDiffEventData(message);
-  const lineDelta = getDiffLineDelta(diff || message.text);
+  const { files, hasDiff } = getDiffEventData(message);
   return (
     <RichEventShell
       defaultOpen={false}
       icon={<FileDiff className="size-4" />}
       meta={formatEventMeta([
         formatCount(files.length, "file"),
-        formatLineDelta(lineDelta),
+        hasDiff ? "diff hidden" : "cleared",
       ])}
       summary={
         files.length > 0 ? (
           <CompactPathList paths={files} />
         ) : (
-          <span className="truncate text-muted-foreground">No files</span>
+          <span className="truncate text-muted-foreground">
+            {message.text || (hasDiff ? "Diff hidden" : "Diff cleared")}
+          </span>
         )
       }
       title="Diff"
     >
-      <CollapsibleCode title="Unified diff" value={diff || message.text} />
+      <HiddenEventContent label={hasDiff ? "Unified diff hidden" : "No diff"} />
     </RichEventShell>
   );
 }
 
 function CommandEventCard({ message }: { message: VisibleMessageRecord }) {
-  const output = getRichEventText(message);
   const meta = getCommandEventMeta(message);
-  const outputLineCount = getTextLineCount(output);
   return (
     <RichEventShell
       defaultOpen={false}
@@ -4634,8 +4631,8 @@ function CommandEventCard({ message }: { message: VisibleMessageRecord }) {
         meta.status,
         meta.exitCode !== null ? `exit ${meta.exitCode}` : null,
         meta.durationMs !== null ? formatDurationMs(meta.durationMs) : null,
-        outputLineCount > 0 ? formatCount(outputLineCount, "line") : null,
         meta.capReached ? "truncated" : null,
+        "output hidden",
       ])}
       summary={
         <span
@@ -4674,9 +4671,10 @@ function CommandEventCard({ message }: { message: VisibleMessageRecord }) {
           )}
         </div>
       )}
-      <CollapsibleCode
-        title={meta.capReached ? "Output truncated" : "Output"}
-        value={output}
+      <HiddenEventContent
+        label={
+          meta.capReached ? "Output hidden after truncation" : "Output hidden"
+        }
       />
     </RichEventShell>
   );
@@ -4685,17 +4683,12 @@ function CommandEventCard({ message }: { message: VisibleMessageRecord }) {
 function FileEventCard({ message }: { message: VisibleMessageRecord }) {
   const changes = getFilePatchEventData(message);
   const meta = getFileEventMeta(message);
-  const output = getRichEventText(message);
   if (message.eventType === "item/fileChange/outputDelta") {
-    const outputLineCount = getTextLineCount(output);
     return (
       <RichEventShell
         defaultOpen={false}
         icon={<FileText className="size-4" />}
-        meta={formatEventMeta([
-          "output",
-          outputLineCount > 0 ? formatCount(outputLineCount, "line") : null,
-        ])}
+        meta="output hidden"
         summary={
           <span className="block min-w-0 max-w-full truncate text-muted-foreground">
             File change output
@@ -4703,11 +4696,10 @@ function FileEventCard({ message }: { message: VisibleMessageRecord }) {
         }
         title="File"
       >
-        <CollapsibleCode title="Output" value={output} />
+        <HiddenEventContent label="Output hidden" />
       </RichEventShell>
     );
   }
-  const lineDelta = getFileChangesLineDelta(changes);
   return (
     <RichEventShell
       defaultOpen={false}
@@ -4715,7 +4707,7 @@ function FileEventCard({ message }: { message: VisibleMessageRecord }) {
       meta={formatEventMeta([
         meta.status,
         formatCount(changes.length, "file"),
-        formatLineDelta(lineDelta),
+        "patch hidden",
       ])}
       summary={
         changes.length > 0 ? (
@@ -4757,14 +4749,9 @@ function FileEventCard({ message }: { message: VisibleMessageRecord }) {
                   {change.path}
                 </span>
                 <span className="ml-auto shrink-0 font-mono text-[length:var(--font-size-xs)] text-muted-foreground">
-                  {formatLineDelta(getDiffLineDelta(change.diff))}
+                  patch hidden
                 </span>
               </div>
-              {change.diff && (
-                <div className="border-t border-[var(--border-subtle)]">
-                  <CollapsibleCode title="Patch" value={change.diff} />
-                </div>
-              )}
             </div>
           ))}
         </div>
@@ -4808,13 +4795,6 @@ function formatEventMeta(
     Boolean(part && part.trim()),
   );
   return visibleParts.length > 0 ? visibleParts.join(" · ") : undefined;
-}
-
-function formatLineDelta(delta: { added: number; removed: number }): string {
-  if (delta.added === 0 && delta.removed === 0) {
-    return "0 lines";
-  }
-  return `+${delta.added} -${delta.removed}`;
 }
 
 function CompactPathList({ paths }: { paths: string[] }) {
@@ -4941,24 +4921,11 @@ function RichEventShell({
   );
 }
 
-function CollapsibleCode({ title, value }: { title: string; value: string }) {
-  const trimmedValue = value.trimEnd();
-  if (!trimmedValue) {
-    return (
-      <p className="text-[length:var(--font-size-sm)] text-muted-foreground">
-        No output
-      </p>
-    );
-  }
+function HiddenEventContent({ label }: { label: string }) {
   return (
-    <div>
-      <p className="mb-1 text-[length:var(--font-size-sm)] text-muted-foreground">
-        {title}
-      </p>
-      <pre className="max-h-72 overflow-auto whitespace-pre-wrap break-words rounded-[var(--radius-md)] bg-[var(--surface-code)] p-2 font-mono text-[length:var(--font-size-xs)] leading-[var(--line-height-relaxed)]">
-        {trimmedValue}
-      </pre>
-    </div>
+    <p className="text-[length:var(--font-size-sm)] text-muted-foreground">
+      {label}
+    </p>
   );
 }
 

--- a/packages/web/src/routes/rich-events.test.ts
+++ b/packages/web/src/routes/rich-events.test.ts
@@ -95,6 +95,24 @@ describe("rich event helpers", () => {
       {
         diff: "diff --git a/a.ts b/a.ts",
         files: ["a.ts"],
+        hasDiff: true,
+      },
+    );
+    deepStrictEqual(
+      getDiffEventData(
+        createMessage({
+          eventType: "turn/diff/updated",
+          eventData: {
+            files: [],
+            hasDiff: false,
+          },
+          text: "Diff cleared",
+        }),
+      ),
+      {
+        diff: "",
+        files: [],
+        hasDiff: false,
       },
     );
     strictEqual(

--- a/packages/web/src/routes/rich-events.ts
+++ b/packages/web/src/routes/rich-events.ts
@@ -95,12 +95,14 @@ export function getPlanEventData(message: ChatMessageRecord): {
 export function getDiffEventData(message: ChatMessageRecord): {
   diff: string;
   files: string[];
+  hasDiff: boolean;
 } {
   const eventData = getEventDataObject(message);
-  const diff = getString(eventData, "diff") ?? message.text;
+  const diff = getString(eventData, "diff") ?? "";
   return {
     diff,
     files: getStringArray(eventData, "files").filter(Boolean),
+    hasDiff: getBoolean(eventData, "hasDiff") ?? Boolean(diff),
   };
 }
 
@@ -253,6 +255,14 @@ function getNumber(
   return typeof candidate === "number" && Number.isFinite(candidate)
     ? candidate
     : undefined;
+}
+
+function getBoolean(
+  value: Record<string, unknown> | null,
+  key: string,
+): boolean | undefined {
+  const candidate = value?.[key];
+  return typeof candidate === "boolean" ? candidate : undefined;
 }
 
 function getStringArray(


### PR DESCRIPTION
## Summary

- Stop rendering command output, unified diffs, and file patch bodies in the web chat timeline.
- Strip those heavy event bodies from web message query results before they enter React Query/state.
- Stop storing hidden command output, diff bodies, and patch bodies in server chat state, while preserving summaries and metadata such as status, command, files, and paths.
- Sanitize existing stored rich event bodies on the next service access.

## Why

Large Codex sessions can accumulate command output and file edit contents in chat history. Even when collapsed, those bodies were still held in browser memory and server state, which can make the browser freeze as chat volume grows.

## Impact

Users still see event summaries, command metadata, statuses, and touched file paths. The heavy raw output and patch contents are no longer available from the chat timeline.

## Validation

- `pnpm --filter @phantompane/server test`
- `pnpm --filter @phantompane/web test`
- `pnpm ready`