### PR TITLE
[codex] support chat image attachments

### DIFF
--- a/packages/codex/src/bridge.test.ts
+++ b/packages/codex/src/bridge.test.ts
@@ -241,11 +241,19 @@ describe("CodexBridge", () => {
     await expect(thread).resolves.toEqual({ thread: { id: "thread_1" } });
   });
 
-  it("passes model, effort, service tier, file mentions, and skills to new turns", async () => {
+  it("passes model, effort, service tier, file mentions, skills, and attachments to new turns", async () => {
     const { bridge, proc } = createBridge();
     await initializeBridge(bridge, proc);
 
     const turn = bridge.startTurn("thread_1", "please edit", "/repo", {
+      attachments: [
+        {
+          name: "screenshot.png",
+          path: "/tmp/phantom/attachments/screenshot.png",
+          mimeType: "image/png",
+          size: 123,
+        },
+      ],
       effort: "high",
       files: [{ name: "src/index.ts", path: "/repo/src/index.ts" }],
       model: "gpt-5.2",
@@ -273,6 +281,10 @@ describe("CodexBridge", () => {
           type: "mention",
           name: "src/index.ts",
           path: "/repo/src/index.ts",
+        },
+        {
+          type: "localImage",
+          path: "/tmp/phantom/attachments/screenshot.png",
         },
       ],
       model: "gpt-5.2",

--- a/packages/codex/src/bridge.ts
+++ b/packages/codex/src/bridge.ts
@@ -33,7 +33,15 @@ export interface CodexTurnContextItem {
   path: string;
 }
 
+export interface CodexTurnAttachment {
+  name: string;
+  path: string;
+  mimeType?: string;
+  size?: number;
+}
+
 export interface CodexTurnOptions {
+  attachments?: CodexTurnAttachment[];
   effort?: string;
   files?: CodexTurnContextItem[];
   model?: string;
@@ -107,6 +115,12 @@ function createUserInput(
       type: "mention",
       name: file.name,
       path: file.path,
+    });
+  }
+  for (const attachment of options.attachments ?? []) {
+    input.push({
+      type: "localImage",
+      path: attachment.path,
     });
   }
   return input;

--- a/packages/server/src/rpc.test.ts
+++ b/packages/server/src/rpc.test.ts
@@ -7,10 +7,12 @@ const services = vi.hoisted(() => ({
   getMessages: vi.fn(),
   listProjectGitHubCheckoutTargets: vi.fn(),
   listProjects: vi.fn(),
+  uploadAttachment: vi.fn(),
 }));
 
 vi.mock("./services", () => ({
   getServeServices: () => services,
+  maxAttachmentBytes: 10 * 1024 * 1024,
 }));
 
 const { rpcRoutes } = await import("./rpc");
@@ -108,6 +110,25 @@ describe("rpcRoutes", () => {
     deepStrictEqual(await response.json(), {
       error: {
         message: "Invalid input: expected string, received undefined",
+      },
+    });
+  });
+
+  it("rejects oversized attachment uploads before calling services", async () => {
+    const response = await rpcRoutes.request("/chats/chat_1/attachments", {
+      body: "x",
+      headers: {
+        "Content-Length": String(11 * 1024 * 1024),
+        "Content-Type": "multipart/form-data; boundary=phantom",
+      },
+      method: "POST",
+    });
+
+    strictEqual(response.status, 400);
+    strictEqual(services.uploadAttachment.mock.calls.length, 0);
+    deepStrictEqual(await response.json(), {
+      error: {
+        message: "Attachment file is too large",
       },
     });
   });

--- a/packages/server/src/rpc.ts
+++ b/packages/server/src/rpc.ts
@@ -15,6 +15,13 @@ const contextItemSchema = z.object({
   path: z.string().min(1),
 });
 
+const attachmentSchema = z.object({
+  name: z.string().min(1),
+  path: z.string().min(1),
+  mimeType: z.string().min(1),
+  size: z.number().int().nonnegative(),
+});
+
 const createProjectSchema = z.object({
   path: z.string().min(1, "Project path is required"),
 });
@@ -69,6 +76,7 @@ const deleteWorktreeSchema = worktreeSchema.extend({
 
 const sendMessageSchema = z.object({
   text: z.string().min(1, "Message text is required"),
+  attachments: z.array(attachmentSchema).optional(),
   effort: z.string().nullable().optional(),
   model: z.string().nullable().optional(),
   serviceTier: z.enum(["fast", "flex"]).nullable().optional(),
@@ -81,6 +89,7 @@ const chatMessageSchema = z.object({
   chatId: z.string().min(1),
   role: z.enum(["user"]),
   text: z.string(),
+  attachments: z.array(attachmentSchema).optional(),
   eventType: z.literal("chat.message.queued"),
   itemId: z.string().optional(),
   createdAt: z.string().min(1),
@@ -91,6 +100,7 @@ const queuedMessageSchema = z.object({
   chatId: z.string().min(1),
   messageId: z.string().min(1),
   text: z.string().min(1),
+  attachments: z.array(attachmentSchema).optional(),
   effort: z.string().optional(),
   files: z.array(contextItemSchema).optional(),
   model: z.string().optional(),
@@ -183,6 +193,20 @@ function contextItems(
     name: item.name,
     path: item.path,
   }));
+}
+
+async function parseAttachmentUpload(c: Context) {
+  const body = await c.req.parseBody();
+  const file = body.file;
+  if (!(file instanceof File)) {
+    throw new Error("Attachment file is required");
+  }
+  return {
+    bytes: new Uint8Array(await file.arrayBuffer()),
+    mimeType: file.type,
+    name: file.name,
+    size: file.size,
+  };
 }
 
 export const rpcRoutes = new Hono()
@@ -386,10 +410,22 @@ export const rpcRoutes = new Hono()
       return handleApiError(c, error);
     }
   })
+  .post("/chats/:chatId/attachments", async (c) => {
+    try {
+      const attachment = await getServeServices().uploadAttachment(
+        c.req.param("chatId"),
+        await parseAttachmentUpload(c),
+      );
+      return c.json({ attachment }, 201);
+    } catch (error) {
+      return handleApiError(c, error);
+    }
+  })
   .post("/chats/:chatId/messages", jsonBody(sendMessageSchema), async (c) => {
     try {
       const body = c.req.valid("json");
       const chat = await getServeServices().sendMessage(c.req.param("chatId"), {
+        attachments: body.attachments,
         effort: optionalString(body.effort),
         files: contextItems(body.files),
         model: optionalString(body.model),
@@ -443,6 +479,7 @@ export const rpcRoutes = new Hono()
       const chat = await getServeServices().steerMessage(
         c.req.param("chatId"),
         {
+          attachments: body.attachments,
           effort: optionalString(body.effort),
           files: contextItems(body.files),
           model: optionalString(body.model),
@@ -462,6 +499,7 @@ export const rpcRoutes = new Hono()
       const chat = await getServeServices().queueMessage(
         c.req.param("chatId"),
         {
+          attachments: body.attachments,
           effort: optionalString(body.effort),
           files: contextItems(body.files),
           model: optionalString(body.model),

--- a/packages/server/src/rpc.ts
+++ b/packages/server/src/rpc.ts
@@ -3,7 +3,7 @@ import { validator } from "hono/validator";
 import { z } from "zod";
 import { createSseResponse, parseLastEventId } from "./event-hub.ts";
 import { renderChatMessages } from "./markdown.ts";
-import { getServeServices } from "./services.ts";
+import { getServeServices, maxAttachmentBytes } from "./services.ts";
 import type {
   ApiErrorBody,
   CodexServiceTier,
@@ -132,6 +132,8 @@ const chatQuerySchema = z.object({
   fileQuery: z.string().optional(),
 });
 
+const maxAttachmentMultipartBytes = maxAttachmentBytes + 64 * 1024;
+
 function jsonError(c: Context, message: string, status: 400 | 404 = 400) {
   return c.json(
     {
@@ -196,8 +198,11 @@ function contextItems(
 }
 
 async function parseAttachmentUpload(c: Context) {
-  const body = await c.req.parseBody();
-  const file = body.file;
+  const formData = await parseLimitedFormData(
+    c.req.raw,
+    maxAttachmentMultipartBytes,
+  );
+  const file = formData.get("file");
   if (!(file instanceof File)) {
     throw new Error("Attachment file is required");
   }
@@ -207,6 +212,59 @@ async function parseAttachmentUpload(c: Context) {
     name: file.name,
     size: file.size,
   };
+}
+
+async function parseLimitedFormData(
+  request: Request,
+  maxBytes: number,
+): Promise<FormData> {
+  const bytes = await readRequestBodyWithLimit(request, maxBytes);
+  const body = new ArrayBuffer(bytes.byteLength);
+  new Uint8Array(body).set(bytes);
+  return await new Request(request.url, {
+    body,
+    headers: request.headers,
+    method: request.method,
+  }).formData();
+}
+
+async function readRequestBodyWithLimit(
+  request: Request,
+  maxBytes: number,
+): Promise<Uint8Array> {
+  const contentLength = Number(request.headers.get("content-length") ?? "");
+  if (Number.isFinite(contentLength) && contentLength > maxBytes) {
+    throw new Error("Attachment file is too large");
+  }
+
+  const body = request.body;
+  if (!body) {
+    return new Uint8Array();
+  }
+
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    totalBytes += value.byteLength;
+    if (totalBytes > maxBytes) {
+      await reader.cancel();
+      throw new Error("Attachment file is too large");
+    }
+    chunks.push(value);
+  }
+
+  const bytes = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes;
 }
 
 export const rpcRoutes = new Hono()

--- a/packages/server/src/services.test.ts
+++ b/packages/server/src/services.test.ts
@@ -46,6 +46,12 @@ const validPngBytes = new Uint8Array([
   99, 252, 255, 31, 0, 3, 3, 2, 0, 239, 162, 167, 91, 0, 0, 0, 0, 73, 69, 78,
   68, 174, 66, 96, 130,
 ]);
+const validInterlacedPngBytes = new Uint8Array([
+  137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0, 1, 0,
+  0, 0, 1, 8, 2, 0, 0, 1, 231, 112, 99, 72, 0, 0, 0, 12, 73, 68, 65, 84, 120,
+  156, 99, 96, 96, 96, 0, 0, 0, 4, 0, 1, 246, 23, 56, 85, 0, 0, 0, 0, 73, 69,
+  78, 68, 174, 66, 96, 130,
+]);
 
 class FakeCodexBridge {
   readonly notificationHandlers: Array<(message: CodexMessage) => void> = [];
@@ -7093,6 +7099,29 @@ describe("ServeServices", () => {
         },
       ],
     });
+  });
+
+  it("accepts interlaced PNG image attachments", async () => {
+    const worktreePath = await createTemporaryDirectory();
+    const attachmentDir = await createTemporaryDirectory();
+    const state = {
+      ...createTestState(),
+      projects: [createProject({ rootPath: worktreePath })],
+      chats: [createChat({ worktreePath })],
+    };
+    const { services } = await createHarness(state, {
+      attachmentDir,
+    });
+
+    const attachment = await services.uploadAttachment("chat_1", {
+      bytes: validInterlacedPngBytes,
+      mimeType: "image/png",
+      name: "interlaced.png",
+      size: validInterlacedPngBytes.byteLength,
+    });
+
+    strictEqual(attachment.mimeType, "image/png");
+    strictEqual(attachment.size, validInterlacedPngBytes.byteLength);
   });
 
   it("rejects attachments with spoofed image MIME types", async () => {

--- a/packages/server/src/services.test.ts
+++ b/packages/server/src/services.test.ts
@@ -7113,6 +7113,30 @@ describe("ServeServices", () => {
     ]);
   });
 
+  it("uses image bytes instead of client MIME type when uploading attachments", async () => {
+    const worktreePath = await createTemporaryDirectory();
+    const attachmentDir = await createTemporaryDirectory();
+    const state = {
+      ...createTestState(),
+      projects: [createProject({ rootPath: worktreePath })],
+      chats: [createChat({ worktreePath })],
+    };
+    const { services } = await createHarness(state, {
+      attachmentDir,
+    });
+
+    const attachment = await services.uploadAttachment("chat_1", {
+      bytes: validPngBytes,
+      mimeType: "application/octet-stream",
+      name: "screenshot",
+      size: validPngBytes.byteLength,
+    });
+
+    strictEqual(attachment.mimeType, "image/png");
+    strictEqual(attachment.name, "screenshot");
+    strictEqual(attachment.size, validPngBytes.byteLength);
+  });
+
   it("uses stored attachment bytes as the source of truth when sending", async () => {
     const worktreePath = await createTemporaryDirectory();
     const attachmentDir = await createTemporaryDirectory();

--- a/packages/server/src/services.test.ts
+++ b/packages/server/src/services.test.ts
@@ -40,6 +40,12 @@ vi.mock("@phantompane/git", () => gitMocks);
 
 const temporaryDirectories: string[] = [];
 const timestamp = "2026-04-25T00:00:00.000Z";
+const validPngBytes = new Uint8Array([
+  137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0, 1, 0,
+  0, 0, 1, 8, 4, 0, 0, 0, 181, 28, 12, 2, 0, 0, 0, 11, 73, 68, 65, 84, 120, 218,
+  99, 252, 255, 31, 0, 3, 3, 2, 0, 239, 162, 167, 91, 0, 0, 0, 0, 73, 69, 78,
+  68, 174, 66, 96, 130,
+]);
 
 class FakeCodexBridge {
   readonly notificationHandlers: Array<(message: CodexMessage) => void> = [];
@@ -7023,10 +7029,10 @@ describe("ServeServices", () => {
     codex.startTurn.mockResolvedValueOnce({ turn: { id: "turn_1" } });
 
     const attachment = await services.uploadAttachment("chat_1", {
-      bytes: new Uint8Array([137, 80, 78, 71]),
+      bytes: validPngBytes,
       mimeType: "image/png",
       name: "screenshot.png",
-      size: 4,
+      size: validPngBytes.byteLength,
     });
     await services.sendMessage("chat_1", {
       attachments: [attachment],
@@ -7044,6 +7050,353 @@ describe("ServeServices", () => {
     deepStrictEqual((await store.load()).messages[0]?.attachments, [
       attachment,
     ]);
+  });
+
+  it("uses stored attachment bytes as the source of truth when sending", async () => {
+    const worktreePath = await createTemporaryDirectory();
+    const attachmentDir = await createTemporaryDirectory();
+    const state = {
+      ...createTestState(),
+      projects: [createProject({ rootPath: worktreePath })],
+      chats: [createChat({ worktreePath })],
+    };
+    const { codex, services } = await createHarness(state, {
+      attachmentDir,
+    });
+    codex.startTurn.mockResolvedValueOnce({ turn: { id: "turn_1" } });
+
+    const attachment = await services.uploadAttachment("chat_1", {
+      bytes: validPngBytes,
+      mimeType: "image/png",
+      name: "screenshot.png",
+      size: validPngBytes.byteLength,
+    });
+    await services.sendMessage("chat_1", {
+      attachments: [
+        {
+          name: "spoof.webp",
+          path: attachment.path,
+          mimeType: "image/webp",
+          size: 1,
+        },
+      ],
+      text: "please inspect",
+    });
+
+    deepStrictEqual(codex.startTurn.mock.calls[0]?.[3], {
+      attachments: [
+        {
+          name: "spoof.webp",
+          path: attachment.path,
+          mimeType: "image/png",
+          size: validPngBytes.byteLength,
+        },
+      ],
+    });
+  });
+
+  it("rejects attachments with spoofed image MIME types", async () => {
+    const worktreePath = await createTemporaryDirectory();
+    const attachmentDir = await createTemporaryDirectory();
+    const state = {
+      ...createTestState(),
+      projects: [createProject({ rootPath: worktreePath })],
+      chats: [createChat({ worktreePath })],
+    };
+    const { services } = await createHarness(state, {
+      attachmentDir,
+    });
+
+    await rejects(
+      services.uploadAttachment("chat_1", {
+        bytes: new TextEncoder().encode("not an image"),
+        mimeType: "image/png",
+        name: "not-image.png",
+        size: 12,
+      }),
+      /Attachment file is not a supported image/,
+    );
+  });
+
+  it("rejects attachments with truncated image bodies", async () => {
+    const worktreePath = await createTemporaryDirectory();
+    const attachmentDir = await createTemporaryDirectory();
+    const state = {
+      ...createTestState(),
+      projects: [createProject({ rootPath: worktreePath })],
+      chats: [createChat({ worktreePath })],
+    };
+    const { services } = await createHarness(state, {
+      attachmentDir,
+    });
+
+    await rejects(
+      services.uploadAttachment("chat_1", {
+        bytes: validPngBytes.slice(0, 8),
+        mimeType: "image/png",
+        name: "truncated.png",
+        size: 8,
+      }),
+      /Attachment file is not a supported image/,
+    );
+  });
+
+  it("rejects structurally invalid PNG, JPEG, GIF, and WebP attachments", async () => {
+    const worktreePath = await createTemporaryDirectory();
+    const attachmentDir = await createTemporaryDirectory();
+    const state = {
+      ...createTestState(),
+      projects: [createProject({ rootPath: worktreePath })],
+      chats: [createChat({ worktreePath })],
+    };
+    const { services } = await createHarness(state, {
+      attachmentDir,
+    });
+
+    const invalidImages = [
+      {
+        bytes: new Uint8Array([
+          137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0,
+          1, 0, 0, 0, 1, 8, 4, 0, 0, 0, 181, 28, 12, 2, 0, 0, 0, 0, 73, 69, 78,
+          68, 174, 66, 96, 130,
+        ]),
+        mimeType: "image/png",
+        name: "no-idat.png",
+      },
+      {
+        bytes: new Uint8Array([
+          137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0,
+          0, 0, 0, 0, 1, 8, 4, 0, 0, 0, 90, 222, 103, 60, 0, 0, 0, 11, 73, 68,
+          65, 84, 120, 218, 99, 252, 255, 31, 0, 3, 3, 2, 0, 239, 162, 167, 91,
+          0, 0, 0, 0, 73, 69, 78, 68, 174, 66, 96, 130,
+        ]),
+        mimeType: "image/png",
+        name: "zero-width.png",
+      },
+      {
+        bytes: new Uint8Array([
+          137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0,
+          1, 0, 0, 0, 1, 1, 2, 0, 0, 0, 157, 103, 49, 175, 0, 0, 0, 11, 73, 68,
+          65, 84, 120, 218, 99, 252, 255, 31, 0, 3, 3, 2, 0, 239, 162, 167, 91,
+          0, 0, 0, 0, 73, 69, 78, 68, 174, 66, 96, 130,
+        ]),
+        mimeType: "image/png",
+        name: "invalid-ihdr.png",
+      },
+      {
+        bytes: new Uint8Array([
+          137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0,
+          1, 0, 0, 0, 1, 8, 4, 0, 0, 0, 181, 28, 12, 2, 0, 0, 0, 12, 73, 68, 65,
+          84, 120, 156, 99, 96, 96, 96, 0, 0, 0, 4, 0, 1, 246, 23, 56, 85, 0, 0,
+          0, 0, 73, 69, 78, 68, 174, 66, 96, 130,
+        ]),
+        mimeType: "image/png",
+        name: "oversized-scanline.png",
+      },
+      {
+        bytes: new Uint8Array([
+          137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0,
+          1, 0, 0, 0, 1, 8, 2, 0, 0, 0, 144, 119, 83, 222, 0, 0, 0, 11, 73, 68,
+          65, 84, 120, 156, 99, 101, 96, 0, 0, 0, 18, 0, 6, 115, 205, 104, 227,
+          0, 0, 0, 0, 73, 69, 78, 68, 174, 66, 96, 130,
+        ]),
+        mimeType: "image/png",
+        name: "unsupported-filter.png",
+      },
+      {
+        bytes: new Uint8Array([
+          137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0,
+          1, 0, 0, 0, 1, 1, 3, 0, 0, 0, 37, 219, 86, 202, 0, 0, 0, 10, 73, 68,
+          65, 84, 120, 156, 99, 96, 0, 0, 0, 2, 0, 1, 72, 175, 164, 113, 0, 0,
+          0, 0, 73, 69, 78, 68, 174, 66, 96, 130,
+        ]),
+        mimeType: "image/png",
+        name: "indexed-without-plte.png",
+      },
+      {
+        bytes: new Uint8Array([
+          137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0,
+          1, 0, 0, 0, 1, 8, 4, 0, 0, 0, 181, 28, 12, 2, 0, 0, 0, 13, 73, 72, 68,
+          82, 0, 0, 0, 1, 0, 0, 0, 1, 8, 4, 0, 0, 0, 181, 28, 12, 2, 0, 0, 0,
+          11, 73, 68, 65, 84, 120, 156, 99, 252, 255, 31, 0, 3, 3, 2, 0, 124, 6,
+          208, 188, 0, 0, 0, 0, 73, 69, 78, 68, 174, 66, 96, 130,
+        ]),
+        mimeType: "image/png",
+        name: "duplicate-ihdr.png",
+      },
+      {
+        bytes: new Uint8Array([
+          137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0,
+          1, 0, 0, 0, 1, 1, 3, 0, 0, 0, 37, 219, 86, 202, 0, 0, 0, 6, 80, 76,
+          84, 69, 0, 0, 0, 255, 255, 255, 165, 217, 159, 221, 0, 0, 0, 6, 80,
+          76, 84, 69, 0, 0, 0, 255, 255, 255, 165, 217, 159, 221, 0, 0, 0, 10,
+          73, 68, 65, 84, 120, 156, 99, 96, 0, 0, 0, 2, 0, 1, 72, 175, 164, 113,
+          0, 0, 0, 0, 73, 69, 78, 68, 174, 66, 96, 130,
+        ]),
+        mimeType: "image/png",
+        name: "duplicate-plte.png",
+      },
+      {
+        bytes: new Uint8Array([0xff, 0xd8, 0xff, 0xd9]),
+        mimeType: "image/jpeg",
+        name: "fake.jpg",
+      },
+      {
+        bytes: new Uint8Array([
+          0xff, 0xd8, 0xff, 0xc0, 0x00, 0x0b, 0x08, 0xff, 0xff, 0xff, 0xff,
+          0x01, 0x01, 0x11, 0x00, 0xff, 0xda, 0x00, 0x08, 0x01, 0x01, 0x00,
+          0x00, 0x3f, 0x00, 0x00, 0xff, 0xd9,
+        ]),
+        mimeType: "image/jpeg",
+        name: "huge-dimensions.jpg",
+      },
+      {
+        bytes: new Uint8Array([
+          0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 0x01, 0x00, 0x01, 0x00, 0x00,
+          0x00, 0x00, 0x3b,
+        ]),
+        mimeType: "image/gif",
+        name: "fake.gif",
+      },
+      {
+        bytes: new Uint8Array([
+          0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 0x01, 0x00, 0x01, 0x00, 0x00,
+          0x00, 0x00, 0x2c, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00,
+          0x00, 0x02, 0x01, 0x00, 0x00, 0x3b,
+        ]),
+        mimeType: "image/gif",
+        name: "no-color-table.gif",
+      },
+      {
+        bytes: new Uint8Array([
+          0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 0xff, 0xff, 0xff, 0xff, 0x80,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0x2c, 0x00, 0x00,
+          0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x02, 0x01, 0x00, 0x00,
+          0x3b,
+        ]),
+        mimeType: "image/gif",
+        name: "huge-logical-screen.gif",
+      },
+      {
+        bytes: new Uint8Array([
+          0x52, 0x49, 0x46, 0x46, 0x0c, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42,
+          0x50, 0x46, 0x41, 0x4b, 0x45, 0x00, 0x00, 0x00, 0x00,
+        ]),
+        mimeType: "image/webp",
+        name: "fake.webp",
+      },
+    ];
+
+    for (const image of invalidImages) {
+      await rejects(
+        services.uploadAttachment("chat_1", {
+          bytes: image.bytes,
+          mimeType: image.mimeType,
+          name: image.name,
+          size: image.bytes.byteLength,
+        }),
+        /Attachment file is not a supported image/,
+      );
+    }
+  });
+
+  it("rejects attachment paths from another chat", async () => {
+    const worktreePath = await createTemporaryDirectory();
+    const attachmentDir = await createTemporaryDirectory();
+    const state = {
+      ...createTestState(),
+      projects: [createProject({ rootPath: worktreePath })],
+      chats: [
+        createChat({ id: "chat_1", worktreePath }),
+        createChat({ id: "chat_2", worktreePath }),
+      ],
+    };
+    const { codex, services } = await createHarness(state, {
+      attachmentDir,
+    });
+
+    const attachment = await services.uploadAttachment("chat_2", {
+      bytes: validPngBytes,
+      mimeType: "image/png",
+      name: "screenshot.png",
+      size: validPngBytes.byteLength,
+    });
+
+    await rejects(
+      services.sendMessage("chat_1", {
+        attachments: [attachment],
+        text: "please inspect",
+      }),
+      /Attachment path must be within this chat's attachment storage/,
+    );
+    strictEqual(codex.startTurn.mock.calls.length, 0);
+  });
+
+  it("keeps queued messages editable when attachment validation fails during drain", async () => {
+    const worktreePath = await createTemporaryDirectory();
+    const attachmentDir = await createTemporaryDirectory();
+    const missingAttachmentPath = join(attachmentDir, "chat_1", "missing.png");
+    const state: ServeState = {
+      ...createTestState(),
+      projects: [createProject({ rootPath: worktreePath })],
+      chats: [createChat({ worktreePath })],
+      messages: [
+        {
+          id: "msg_queued",
+          chatId: "chat_1",
+          role: "user",
+          text: "please inspect",
+          attachments: [
+            {
+              name: "missing.png",
+              path: missingAttachmentPath,
+              mimeType: "image/png",
+              size: 4,
+            },
+          ],
+          eventType: "chat.message.queued",
+          createdAt: timestamp,
+        },
+      ],
+      queuedMessages: [
+        {
+          id: "queue_1",
+          chatId: "chat_1",
+          messageId: "msg_queued",
+          text: "please inspect",
+          attachments: [
+            {
+              name: "missing.png",
+              path: missingAttachmentPath,
+              mimeType: "image/png",
+              size: 4,
+            },
+          ],
+          createdAt: timestamp,
+        },
+      ],
+    };
+    const { codex, services, store } = await createHarness(state, {
+      attachmentDir,
+    });
+
+    await services.queueMessage("chat_1", { text: "next queued" });
+
+    const nextState = await store.load();
+    strictEqual(nextState.messages[0]?.eventType, "chat.message.queued");
+    strictEqual(
+      nextState.queuedMessages.some((message) => message.id === "queue_1"),
+      true,
+    );
+    strictEqual(
+      nextState.messages.some(
+        (message) =>
+          message.role === "error" &&
+          message.text.includes("Attachment path is not an existing file"),
+      ),
+      true,
+    );
+    strictEqual(codex.startTurn.mock.calls.length, 0);
   });
 
   it("rejects file context paths outside the chat worktree", async () => {

--- a/packages/server/src/services.test.ts
+++ b/packages/server/src/services.test.ts
@@ -152,7 +152,10 @@ function createTestState(overrides: Partial<ServeState> = {}): ServeState {
   };
 }
 
-async function createHarness(state: ServeState): Promise<{
+async function createHarness(
+  state: ServeState,
+  options: { attachmentDir?: string } = {},
+): Promise<{
   codex: FakeCodexBridge;
   codexHome: string;
   services: ServeServices;
@@ -163,6 +166,7 @@ async function createHarness(state: ServeState): Promise<{
   const codex = new FakeCodexBridge();
   const codexHome = await createTemporaryDirectory();
   const services = new ServeServices({
+    attachmentDir: options.attachmentDir,
     codex: codex as unknown as CodexBridge,
     codexHome,
     store,
@@ -7001,6 +7005,44 @@ describe("ServeServices", () => {
         serviceTier: "fast",
         skills: [{ name: "review", path: "/skills/review/SKILL.md" }],
       },
+    ]);
+  });
+
+  it("uploads image attachments and passes them to Codex turns", async () => {
+    const worktreePath = await createTemporaryDirectory();
+    const attachmentDir = await createTemporaryDirectory();
+    const state = {
+      ...createTestState(),
+      projects: [createProject({ rootPath: worktreePath })],
+      chats: [createChat({ worktreePath })],
+    };
+    const { codex, services, store } = await createHarness(state, {
+      attachmentDir,
+    });
+    codex.resumeThread.mockResolvedValueOnce({});
+    codex.startTurn.mockResolvedValueOnce({ turn: { id: "turn_1" } });
+
+    const attachment = await services.uploadAttachment("chat_1", {
+      bytes: new Uint8Array([137, 80, 78, 71]),
+      mimeType: "image/png",
+      name: "screenshot.png",
+      size: 4,
+    });
+    await services.sendMessage("chat_1", {
+      attachments: [attachment],
+      text: "please inspect",
+    });
+
+    deepStrictEqual(codex.startTurn.mock.calls[0], [
+      "thread_1",
+      "please inspect",
+      worktreePath,
+      {
+        attachments: [attachment],
+      },
+    ]);
+    deepStrictEqual((await store.load()).messages[0]?.attachments, [
+      attachment,
     ]);
   });
 

--- a/packages/server/src/services.test.ts
+++ b/packages/server/src/services.test.ts
@@ -1850,6 +1850,61 @@ describe("ServeServices", () => {
     );
   });
 
+  it("preserves local attachment metadata when Codex thread history matches a sent user message", async () => {
+    const attachment = {
+      name: "screenshot.png",
+      path: "/tmp/phantom-attachments/chat_1/screenshot.png",
+      mimeType: "image/png",
+      size: 68,
+    };
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat()],
+      messages: [
+        {
+          id: "msg_with_attachment",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "inspect this",
+          attachments: [attachment],
+          createdAt: "2026-04-25T00:00:00.000Z",
+        },
+      ],
+    };
+    const { codex, services } = await createHarness(state);
+    codex.readThread.mockResolvedValueOnce({
+      thread: {
+        turns: [
+          {
+            id: "turn_1",
+            createdAt: "2026-04-25T00:00:00.000Z",
+            items: [{ type: "userMessage", text: "inspect this" }],
+          },
+        ],
+      },
+    });
+
+    const messages = await services.getMessages("chat_1");
+
+    deepStrictEqual(
+      messages.map((message) => ({
+        attachments: message.attachments,
+        id: message.id,
+        role: message.role,
+        text: message.text,
+      })),
+      [
+        {
+          attachments: [attachment],
+          id: "chat_1_codex_turn_1_0",
+          role: "user",
+          text: "inspect this",
+        },
+      ],
+    );
+  });
+
   it("keeps a repeated pending message when only an older Codex message matches", async () => {
     const state = {
       ...createTestState(),

--- a/packages/server/src/services.ts
+++ b/packages/server/src/services.ts
@@ -1,5 +1,13 @@
-import { realpath, stat } from "node:fs/promises";
-import { basename, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { mkdir, realpath, stat, writeFile } from "node:fs/promises";
+import {
+  basename,
+  extname,
+  isAbsolute,
+  join,
+  relative,
+  resolve,
+  sep,
+} from "node:path";
 import {
   branchExists,
   getGitRoot,
@@ -36,11 +44,13 @@ import {
 import {
   createRecordId,
   createTimestamp,
+  getServeDataDir,
   ServeStateStore,
   touchProject,
 } from "@phantompane/state";
 import { EventHub } from "./event-hub.ts";
 import type {
+  ChatAttachmentRecord,
   ChatMessageRecord,
   ChatRecord,
   ChatStatus,
@@ -88,12 +98,20 @@ export interface SyncProjectWorktreeBranchResult {
 }
 
 export interface SendMessageInput {
+  attachments?: ChatAttachmentRecord[];
   effort?: string;
   files?: CodexTurnContextItem[];
   model?: string;
   serviceTier?: CodexServiceTier;
   skills?: CodexTurnContextItem[];
   text: string;
+}
+
+export interface UploadAttachmentInput {
+  bytes: Uint8Array;
+  mimeType: string;
+  name: string;
+  size: number;
 }
 
 export interface DeletePendingMessageResult {
@@ -108,6 +126,7 @@ export interface ApprovalInput {
 }
 
 export interface ServeServicesOptions {
+  attachmentDir?: string;
   eventHub?: EventHub;
   store?: ServeStateStore;
   codex?: CodexBridge;
@@ -136,6 +155,7 @@ interface SubmitMessageOptions {
 }
 
 const worktreeNameInferenceModel = "gpt-5.4-mini";
+const maxAttachmentBytes = 10 * 1024 * 1024;
 
 function createWorktreeNameInferencePrompt(message: string): string {
   return [
@@ -249,6 +269,7 @@ export class ServeServices {
   readonly eventHub: EventHub;
   readonly store: ServeStateStore;
   readonly codex: CodexBridge;
+  private readonly attachmentDir: string;
   private readonly loadedThreadIds = new Set<string>();
   private readonly approvalRequests = new Map<string, PendingApprovalRequest>();
   private readonly pendingTurnEvents = new Map<
@@ -273,6 +294,8 @@ export class ServeServices {
     this.eventHub = options.eventHub ?? new EventHub();
     this.store = options.store ?? new ServeStateStore();
     this.codex = options.codex ?? new CodexBridge();
+    this.attachmentDir =
+      options.attachmentDir ?? join(getServeDataDir(), "attachments");
     this.codex.onNotification((message) => {
       void this.handleCodexNotification(message);
     });
@@ -1227,6 +1250,46 @@ export class ServeServices {
     return this.submitMessage(chatId, input, { requireActiveTurn: false });
   }
 
+  async uploadAttachment(
+    chatId: string,
+    input: UploadAttachmentInput,
+  ): Promise<ChatAttachmentRecord> {
+    const state = await this.store.load();
+    this.requireChat(state, chatId);
+
+    const mimeType = input.mimeType.trim().toLowerCase();
+    if (!mimeType.startsWith("image/")) {
+      throw new Error("Only image attachments are supported");
+    }
+    if (input.size <= 0 || input.bytes.byteLength <= 0) {
+      throw new Error("Attachment file is empty");
+    }
+    if (
+      input.size > maxAttachmentBytes ||
+      input.bytes.byteLength > maxAttachmentBytes
+    ) {
+      throw new Error("Attachment file is too large");
+    }
+
+    const safeName = sanitizeAttachmentName(input.name);
+    const extension = sanitizeAttachmentExtension(safeName, mimeType);
+    const attachmentId = createRecordId("att");
+    const chatAttachmentDir = join(this.attachmentDir, chatId);
+    const attachmentPath = join(
+      chatAttachmentDir,
+      `${attachmentId}${extension}`,
+    );
+    await mkdir(chatAttachmentDir, { recursive: true });
+    await writeFile(attachmentPath, input.bytes);
+
+    return {
+      name: safeName,
+      path: attachmentPath,
+      mimeType,
+      size: input.size,
+    };
+  }
+
   async steerMessage(
     chatId: string,
     input: SendMessageInput,
@@ -1274,6 +1337,7 @@ export class ServeServices {
         text,
         "chat.message.queued",
       );
+      userMessage.attachments = cloneAttachmentRecords(input.attachments);
       const queuedMessage = createQueuedMessage(chat.id, userMessage.id, input);
       queuedUserMessage = userMessage;
       return {
@@ -1520,13 +1584,16 @@ export class ServeServices {
           ...existingUserMessage,
           eventType: undefined,
         }
-      : createMessage(
-          chat.id,
-          "user",
-          text,
-          isSteeringActiveTurn ? "chat.message.steered" : undefined,
-          isSteeringActiveTurn ? (chat.activeTurnId ?? undefined) : undefined,
-        );
+      : {
+          ...createMessage(
+            chat.id,
+            "user",
+            text,
+            isSteeringActiveTurn ? "chat.message.steered" : undefined,
+            isSteeringActiveTurn ? (chat.activeTurnId ?? undefined) : undefined,
+          ),
+          attachments: cloneAttachmentRecords(input.attachments),
+        };
     let nextStatus: ChatStatus | null = null;
     let nextActiveTurnId: string | null | undefined;
     let pendingTurnThreadId: string | null = null;
@@ -1762,6 +1829,7 @@ export class ServeServices {
     chat: ChatRecord,
   ): Promise<
     | {
+        attachments?: ChatAttachmentRecord[];
         effort?: string;
         files?: CodexTurnContextItem[];
         model?: string;
@@ -1770,6 +1838,7 @@ export class ServeServices {
       }
     | undefined
   > {
+    const attachments = await this.normalizeAttachmentItems(input.attachments);
     const files = await normalizeFileContextItems(
       input.files,
       chat.worktreePath,
@@ -1782,18 +1851,23 @@ export class ServeServices {
       !input.effort &&
       !input.model &&
       !input.serviceTier &&
+      attachments.length === 0 &&
       files.length === 0 &&
       skills.length === 0
     ) {
       return undefined;
     }
     const options: {
+      attachments?: ChatAttachmentRecord[];
       effort?: string;
       files?: CodexTurnContextItem[];
       model?: string;
       serviceTier?: CodexServiceTier;
       skills?: CodexTurnContextItem[];
     } = {};
+    if (attachments.length > 0) {
+      options.attachments = attachments;
+    }
     if (input.effort) {
       options.effort = input.effort;
     }
@@ -1810,6 +1884,51 @@ export class ServeServices {
       options.skills = skills;
     }
     return options;
+  }
+
+  private async normalizeAttachmentItems(
+    items: ChatAttachmentRecord[] | undefined,
+  ): Promise<ChatAttachmentRecord[]> {
+    const normalized = normalizeAttachmentRecords(items);
+    if (normalized.length === 0) {
+      return [];
+    }
+
+    const realAttachmentDir = await realpath(this.attachmentDir);
+    return await Promise.all(
+      normalized.map(async (item) => {
+        const resolvedPath = resolve(item.path);
+        if (!isPathInside(this.attachmentDir, resolvedPath)) {
+          throw new Error(
+            `Attachment path must be within Phantom attachment storage: ${item.path}`,
+          );
+        }
+
+        let realAttachmentPath: string;
+        try {
+          realAttachmentPath = await realpath(resolvedPath);
+        } catch {
+          throw new Error(
+            `Attachment path is not an existing file: ${item.path}`,
+          );
+        }
+        if (!isPathInside(realAttachmentDir, realAttachmentPath)) {
+          throw new Error(
+            `Attachment path must resolve within Phantom attachment storage: ${item.path}`,
+          );
+        }
+        if (!(await stat(realAttachmentPath)).isFile()) {
+          throw new Error(`Attachment path is not a file: ${item.path}`);
+        }
+
+        return {
+          name: item.name,
+          path: resolvedPath,
+          mimeType: item.mimeType,
+          size: item.size,
+        };
+      }),
+    );
   }
 
   private async normalizeSkillContextItems(
@@ -3229,6 +3348,7 @@ function createQueuedMessage(
     chatId,
     messageId,
     text: input.text.trim(),
+    attachments: cloneAttachmentRecords(input.attachments),
     effort: input.effort,
     files: cloneContextItems(input.files),
     model: input.model,
@@ -3242,6 +3362,7 @@ function queuedMessageToSendInput(
   message: QueuedMessageRecord,
 ): SendMessageInput {
   return {
+    attachments: cloneAttachmentRecords(message.attachments),
     effort: message.effort,
     files: cloneContextItems(message.files),
     model: message.model,
@@ -3261,6 +3382,13 @@ function cloneContextItems(
     name: item.name,
     path: item.path,
   }));
+}
+
+function cloneAttachmentRecords(
+  items: ChatAttachmentRecord[] | undefined,
+): ChatAttachmentRecord[] | undefined {
+  const normalized = normalizeAttachmentRecords(items);
+  return normalized.length > 0 ? normalized : undefined;
 }
 
 function isChatInActiveTurn(chat: ChatRecord): boolean {
@@ -4876,6 +5004,52 @@ function normalizeTurnContextItems(
       path: item.path.trim(),
     }))
     .filter((item) => item.name && item.path);
+}
+
+function normalizeAttachmentRecords(
+  items: ChatAttachmentRecord[] | undefined,
+): ChatAttachmentRecord[] {
+  return (items ?? [])
+    .map((item) => ({
+      name: item.name.trim(),
+      path: item.path.trim(),
+      mimeType: item.mimeType.trim().toLowerCase(),
+      size: item.size,
+    }))
+    .filter(
+      (item) =>
+        item.name &&
+        item.path &&
+        item.mimeType.startsWith("image/") &&
+        Number.isInteger(item.size) &&
+        item.size > 0 &&
+        item.size <= maxAttachmentBytes,
+    );
+}
+
+function sanitizeAttachmentName(name: string): string {
+  const trimmedName = basename(name.trim());
+  const safeName = trimmedName.replace(/[^\w .-]+/g, "_").trim();
+  return safeName || "attachment";
+}
+
+function sanitizeAttachmentExtension(name: string, mimeType: string): string {
+  const currentExtension = extname(name).toLowerCase();
+  if (/^\.[a-z0-9]{1,8}$/.test(currentExtension)) {
+    return currentExtension;
+  }
+  switch (mimeType) {
+    case "image/jpeg":
+      return ".jpg";
+    case "image/png":
+      return ".png";
+    case "image/gif":
+      return ".gif";
+    case "image/webp":
+      return ".webp";
+    default:
+      return ".img";
+  }
 }
 
 async function normalizeFileContextItems(

--- a/packages/server/src/services.ts
+++ b/packages/server/src/services.ts
@@ -1,4 +1,4 @@
-import { mkdir, realpath, stat, writeFile } from "node:fs/promises";
+import { mkdir, readFile, realpath, stat, writeFile } from "node:fs/promises";
 import {
   basename,
   extname,
@@ -8,6 +8,7 @@ import {
   resolve,
   sep,
 } from "node:path";
+import { inflateSync } from "node:zlib";
 import {
   branchExists,
   getGitRoot,
@@ -40,6 +41,7 @@ import {
   mapCodexMethodToEvent,
   summarizeCodexEvent,
   type CodexMessage,
+  type CodexTurnOptions,
 } from "@phantompane/codex";
 import {
   createRecordId,
@@ -150,12 +152,28 @@ interface PendingTurnEventBuffer {
 
 interface SubmitMessageOptions {
   existingUserMessageId?: string;
+  prevalidatedTurnOptions?: CodexTurnOptions | undefined;
   queuedMessageId?: string;
   requireActiveTurn: boolean;
 }
 
 const worktreeNameInferenceModel = "gpt-5.4-mini";
-const maxAttachmentBytes = 10 * 1024 * 1024;
+export const maxAttachmentBytes = 10 * 1024 * 1024;
+const maxDecodedImageBytes = 64 * 1024 * 1024;
+
+class QueuedAttachmentValidationError extends Error {
+  constructor(error: unknown) {
+    super(toErrorMessage(error));
+    this.name = "QueuedAttachmentValidationError";
+  }
+}
+
+interface PngHeader {
+  bitDepth: number;
+  colorType: number;
+  height: number;
+  width: number;
+}
 
 function createWorktreeNameInferencePrompt(message: string): string {
   return [
@@ -1257,8 +1275,8 @@ export class ServeServices {
     const state = await this.store.load();
     this.requireChat(state, chatId);
 
-    const mimeType = input.mimeType.trim().toLowerCase();
-    if (!mimeType.startsWith("image/")) {
+    const requestedMimeType = input.mimeType.trim().toLowerCase();
+    if (!requestedMimeType.startsWith("image/")) {
       throw new Error("Only image attachments are supported");
     }
     if (input.size <= 0 || input.bytes.byteLength <= 0) {
@@ -1269,6 +1287,10 @@ export class ServeServices {
       input.bytes.byteLength > maxAttachmentBytes
     ) {
       throw new Error("Attachment file is too large");
+    }
+    const mimeType = detectSupportedImageMimeType(input.bytes);
+    if (!mimeType) {
+      throw new Error("Attachment file is not a supported image");
     }
 
     const safeName = sanitizeAttachmentName(input.name);
@@ -1556,8 +1578,9 @@ export class ServeServices {
       this.pendingChatTurns.add(chatId);
     }
 
-    const turnOptions = await this.createCodexTurnOptions(input, chat).catch(
-      async (error) => {
+    const turnOptions =
+      options.prevalidatedTurnOptions ??
+      (await this.createCodexTurnOptions(input, chat).catch(async (error) => {
         clearPendingChatTurn();
         if (options.queuedMessageId) {
           await this.store.update((nextState) => ({
@@ -1576,8 +1599,7 @@ export class ServeServices {
         }
         await this.drainQueuedMessagesAndReport(chatId);
         throw error;
-      },
-    );
+      }));
 
     const userMessage = existingUserMessage
       ? {
@@ -1838,7 +1860,10 @@ export class ServeServices {
       }
     | undefined
   > {
-    const attachments = await this.normalizeAttachmentItems(input.attachments);
+    const attachments = await this.normalizeAttachmentItems(
+      input.attachments,
+      chat.id,
+    );
     const files = await normalizeFileContextItems(
       input.files,
       chat.worktreePath,
@@ -1888,22 +1913,31 @@ export class ServeServices {
 
   private async normalizeAttachmentItems(
     items: ChatAttachmentRecord[] | undefined,
+    chatId: string,
   ): Promise<ChatAttachmentRecord[]> {
     const normalized = normalizeAttachmentRecords(items);
     if (normalized.length === 0) {
       return [];
     }
 
-    const realAttachmentDir = await realpath(this.attachmentDir);
+    const chatAttachmentDir = join(this.attachmentDir, chatId);
     return await Promise.all(
       normalized.map(async (item) => {
         const resolvedPath = resolve(item.path);
-        if (!isPathInside(this.attachmentDir, resolvedPath)) {
+        if (!isPathInside(chatAttachmentDir, resolvedPath)) {
           throw new Error(
-            `Attachment path must be within Phantom attachment storage: ${item.path}`,
+            `Attachment path must be within this chat's attachment storage: ${item.path}`,
           );
         }
 
+        let realChatAttachmentDir: string;
+        try {
+          realChatAttachmentDir = await realpath(chatAttachmentDir);
+        } catch {
+          throw new Error(
+            `Attachment path is not an existing file: ${item.path}`,
+          );
+        }
         let realAttachmentPath: string;
         try {
           realAttachmentPath = await realpath(resolvedPath);
@@ -1912,20 +1946,32 @@ export class ServeServices {
             `Attachment path is not an existing file: ${item.path}`,
           );
         }
-        if (!isPathInside(realAttachmentDir, realAttachmentPath)) {
+        if (!isPathInside(realChatAttachmentDir, realAttachmentPath)) {
           throw new Error(
-            `Attachment path must resolve within Phantom attachment storage: ${item.path}`,
+            `Attachment path must resolve within this chat's attachment storage: ${item.path}`,
           );
         }
-        if (!(await stat(realAttachmentPath)).isFile()) {
+        const attachmentStat = await stat(realAttachmentPath);
+        if (!attachmentStat.isFile()) {
           throw new Error(`Attachment path is not a file: ${item.path}`);
+        }
+        if (
+          attachmentStat.size <= 0 ||
+          attachmentStat.size > maxAttachmentBytes
+        ) {
+          throw new Error("Attachment file is too large");
+        }
+        const bytes = await readFile(realAttachmentPath);
+        const mimeType = detectSupportedImageMimeType(bytes);
+        if (!mimeType) {
+          throw new Error("Attachment file is not a supported image");
         }
 
         return {
           name: item.name,
-          path: resolvedPath,
-          mimeType: item.mimeType,
-          size: item.size,
+          path: realAttachmentPath,
+          mimeType,
+          size: attachmentStat.size,
         };
       }),
     );
@@ -2188,6 +2234,17 @@ export class ServeServices {
     if (!queuedMessage) {
       return;
     }
+    let prevalidatedTurnOptions: CodexTurnOptions | undefined;
+    if ((queuedMessage.attachments ?? []).length > 0) {
+      try {
+        prevalidatedTurnOptions = await this.createCodexTurnOptions(
+          queuedMessageToSendInput(queuedMessage),
+          chat,
+        );
+      } catch (error) {
+        throw new QueuedAttachmentValidationError(error);
+      }
+    }
     const claimedQueuedMessageRef: { current: QueuedMessageRecord | null } = {
       current: null,
     };
@@ -2244,6 +2301,7 @@ export class ServeServices {
       queuedMessageToSendInput(claimedQueuedMessage),
       {
         existingUserMessageId: claimedQueuedMessage.messageId,
+        prevalidatedTurnOptions,
         requireActiveTurn: false,
       },
     );
@@ -2266,6 +2324,7 @@ export class ServeServices {
           await this.addAgentErrorMessage(chatId, error);
           const state = await this.store.load();
           if (
+            !(error instanceof QueuedAttachmentValidationError) &&
             state.queuedMessages.some((message) => message.chatId === chatId)
           ) {
             this.pendingQueuedMessageDrainChatIds.add(chatId);
@@ -5035,21 +5094,302 @@ function sanitizeAttachmentName(name: string): string {
 
 function sanitizeAttachmentExtension(name: string, mimeType: string): string {
   const currentExtension = extname(name).toLowerCase();
-  if (/^\.[a-z0-9]{1,8}$/.test(currentExtension)) {
+  if (mimeType === "image/png" && currentExtension === ".png") {
     return currentExtension;
   }
-  switch (mimeType) {
-    case "image/jpeg":
-      return ".jpg";
-    case "image/png":
-      return ".png";
-    case "image/gif":
-      return ".gif";
-    case "image/webp":
-      return ".webp";
-    default:
-      return ".img";
+  return ".png";
+}
+
+function detectSupportedImageMimeType(bytes: Uint8Array): string | null {
+  if (isValidPng(bytes)) {
+    return "image/png";
   }
+  return null;
+}
+
+function isValidPng(bytes: Uint8Array): boolean {
+  if (
+    bytes.length < 33 ||
+    bytes[0] !== 0x89 ||
+    bytes[1] !== 0x50 ||
+    bytes[2] !== 0x4e ||
+    bytes[3] !== 0x47 ||
+    bytes[4] !== 0x0d ||
+    bytes[5] !== 0x0a ||
+    bytes[6] !== 0x1a ||
+    bytes[7] !== 0x0a
+  ) {
+    return false;
+  }
+
+  let offset = 8;
+  let sawIhdr = false;
+  const idatChunks: Uint8Array[] = [];
+  let pngHeader: PngHeader | null = null;
+  let finishedIdat = false;
+  let sawIdat = false;
+  let sawPlte = false;
+  while (offset + 12 <= bytes.length) {
+    const chunkLength = readUint32(bytes, offset);
+    const chunkTypeOffset = offset + 4;
+    const chunkDataOffset = offset + 8;
+    const nextOffset = chunkDataOffset + chunkLength + 4;
+    if (nextOffset > bytes.length) {
+      return false;
+    }
+
+    const chunkType = readAscii(bytes, chunkTypeOffset, 4);
+    if (!sawIhdr) {
+      const header = parsePngHeader(
+        bytes.subarray(chunkDataOffset, chunkDataOffset + 13),
+      );
+      if (chunkType !== "IHDR" || chunkLength !== 13 || !header) {
+        return false;
+      }
+      pngHeader = header;
+      sawIhdr = true;
+    } else if (chunkType === "IHDR") {
+      return false;
+    }
+    if (
+      crc32(bytes.subarray(chunkTypeOffset, chunkDataOffset + chunkLength)) !==
+      readUint32(bytes, chunkDataOffset + chunkLength)
+    ) {
+      return false;
+    }
+    if (chunkType === "IEND") {
+      return (
+        chunkLength === 0 &&
+        sawIdat &&
+        isValidPngPaletteState(pngHeader, sawPlte) &&
+        pngHeader != null &&
+        nextOffset === bytes.length &&
+        isValidPngImageData(idatChunks, pngHeader)
+      );
+    }
+    if (sawIdat && chunkType !== "IDAT") {
+      finishedIdat = true;
+    }
+    if (chunkType === "PLTE") {
+      if (
+        !pngHeader ||
+        sawIdat ||
+        sawPlte ||
+        !isValidPngPaletteChunk(chunkLength, pngHeader)
+      ) {
+        return false;
+      }
+      sawPlte = true;
+    }
+    if (chunkType === "IDAT") {
+      if (
+        chunkLength === 0 ||
+        finishedIdat ||
+        !isValidPngPaletteState(pngHeader, sawPlte)
+      ) {
+        return false;
+      }
+      idatChunks.push(
+        bytes.subarray(chunkDataOffset, chunkDataOffset + chunkLength),
+      );
+      sawIdat = true;
+    }
+    offset = nextOffset;
+  }
+
+  return false;
+}
+
+function isValidPngPaletteState(
+  header: PngHeader | null,
+  sawPlte: boolean,
+): boolean {
+  if (!header) {
+    return false;
+  }
+  if (header.colorType === 3) {
+    return sawPlte;
+  }
+  return header.colorType === 2 || header.colorType === 6 ? true : !sawPlte;
+}
+
+function isValidPngPaletteChunk(
+  chunkLength: number,
+  header: PngHeader,
+): boolean {
+  if (
+    header.colorType !== 3 &&
+    header.colorType !== 2 &&
+    header.colorType !== 6
+  ) {
+    return false;
+  }
+  const paletteEntries = chunkLength / 3;
+  return (
+    Number.isInteger(paletteEntries) &&
+    paletteEntries >= 1 &&
+    paletteEntries <= 256 &&
+    (header.colorType !== 3 || paletteEntries <= 2 ** header.bitDepth)
+  );
+}
+
+function isValidPngImageData(chunks: Uint8Array[], header: PngHeader): boolean {
+  const expectedByteLength = getExpectedPngImageDataByteLength(header);
+  if (
+    expectedByteLength == null ||
+    expectedByteLength <= 0 ||
+    expectedByteLength > maxDecodedImageBytes
+  ) {
+    return false;
+  }
+
+  const totalLength = chunks.reduce((total, chunk) => total + chunk.length, 0);
+  const bytes = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.length;
+  }
+
+  try {
+    const inflated = inflateSync(bytes, {
+      maxOutputLength: expectedByteLength + 1,
+    });
+    return (
+      inflated.byteLength === expectedByteLength &&
+      hasValidPngScanlineFilters(inflated, header)
+    );
+  } catch {
+    return false;
+  }
+}
+
+function hasValidPngScanlineFilters(
+  bytes: Uint8Array,
+  header: PngHeader,
+): boolean {
+  const bytesPerScanline = getPngBytesPerScanline(header);
+  if (bytesPerScanline == null) {
+    return false;
+  }
+
+  const rowLength = bytesPerScanline + 1;
+  for (let offset = 0; offset < bytes.length; offset += rowLength) {
+    const filterType = bytes[offset];
+    if (filterType == null || filterType > 4) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function parsePngHeader(bytes: Uint8Array): PngHeader | null {
+  const width = readUint32(bytes, 0);
+  const height = readUint32(bytes, 4);
+  const bitDepth = bytes[8];
+  const colorType = bytes[9];
+  const compressionMethod = bytes[10];
+  const filterMethod = bytes[11];
+  const interlaceMethod = bytes[12];
+  if (
+    bytes.length === 13 &&
+    width > 0 &&
+    height > 0 &&
+    isValidPngColorTypeAndBitDepth(colorType, bitDepth) &&
+    compressionMethod === 0 &&
+    filterMethod === 0 &&
+    interlaceMethod === 0
+  ) {
+    return {
+      bitDepth: bitDepth ?? 0,
+      colorType: colorType ?? 0,
+      height,
+      width,
+    };
+  }
+  return null;
+}
+
+function getExpectedPngImageDataByteLength(header: PngHeader): number | null {
+  const bytesPerScanline = getPngBytesPerScanline(header);
+  if (bytesPerScanline == null) {
+    return null;
+  }
+  const totalByteLength = header.height * (bytesPerScanline + 1);
+  return Number.isSafeInteger(totalByteLength) ? totalByteLength : null;
+}
+
+function getPngBytesPerScanline(header: PngHeader): number | null {
+  const samplesPerPixel = getPngSamplesPerPixel(header.colorType);
+  if (samplesPerPixel == null) {
+    return null;
+  }
+  const bitsPerScanline = header.width * samplesPerPixel * header.bitDepth;
+  const bytesPerScanline = Math.ceil(bitsPerScanline / 8);
+  return Number.isSafeInteger(bytesPerScanline) ? bytesPerScanline : null;
+}
+
+function getPngSamplesPerPixel(colorType: number): number | null {
+  switch (colorType) {
+    case 0:
+    case 3:
+      return 1;
+    case 2:
+      return 3;
+    case 4:
+      return 2;
+    case 6:
+      return 4;
+    default:
+      return null;
+  }
+}
+
+function isValidPngColorTypeAndBitDepth(
+  colorType: number | undefined,
+  bitDepth: number | undefined,
+): boolean {
+  switch (colorType) {
+    case 0:
+      return [1, 2, 4, 8, 16].includes(bitDepth ?? 0);
+    case 2:
+    case 4:
+    case 6:
+      return bitDepth === 8 || bitDepth === 16;
+    case 3:
+      return [1, 2, 4, 8].includes(bitDepth ?? 0);
+    default:
+      return false;
+  }
+}
+
+function readUint32(bytes: Uint8Array, offset: number): number {
+  return (
+    ((bytes[offset] ?? 0) * 0x1000000 +
+      ((bytes[offset + 1] ?? 0) << 16) +
+      ((bytes[offset + 2] ?? 0) << 8) +
+      (bytes[offset + 3] ?? 0)) >>>
+    0
+  );
+}
+
+function readAscii(bytes: Uint8Array, offset: number, length: number): string {
+  let value = "";
+  for (let index = 0; index < length; index += 1) {
+    value += String.fromCharCode(bytes[offset + index] ?? 0);
+  }
+  return value;
+}
+
+function crc32(bytes: Uint8Array): number {
+  let crc = 0xffffffff;
+  for (const byte of bytes) {
+    crc ^= byte;
+    for (let bit = 0; bit < 8; bit += 1) {
+      crc = (crc >>> 1) ^ (crc & 1 ? 0xedb88320 : 0);
+    }
+  }
+  return (crc ^ 0xffffffff) >>> 0;
 }
 
 async function normalizeFileContextItems(

--- a/packages/server/src/services.ts
+++ b/packages/server/src/services.ts
@@ -172,6 +172,7 @@ interface PngHeader {
   bitDepth: number;
   colorType: number;
   height: number;
+  interlaceMethod: number;
   width: number;
 }
 
@@ -5268,19 +5269,20 @@ function hasValidPngScanlineFilters(
   bytes: Uint8Array,
   header: PngHeader,
 ): boolean {
-  const bytesPerScanline = getPngBytesPerScanline(header);
-  if (bytesPerScanline == null) {
+  const rowLengths = getPngImageDataRowLengths(header);
+  if (!rowLengths) {
     return false;
   }
 
-  const rowLength = bytesPerScanline + 1;
-  for (let offset = 0; offset < bytes.length; offset += rowLength) {
+  let offset = 0;
+  for (const rowLength of rowLengths) {
     const filterType = bytes[offset];
     if (filterType == null || filterType > 4) {
       return false;
     }
+    offset += rowLength;
   }
-  return true;
+  return offset === bytes.length;
 }
 
 function parsePngHeader(bytes: Uint8Array): PngHeader | null {
@@ -5298,12 +5300,13 @@ function parsePngHeader(bytes: Uint8Array): PngHeader | null {
     isValidPngColorTypeAndBitDepth(colorType, bitDepth) &&
     compressionMethod === 0 &&
     filterMethod === 0 &&
-    interlaceMethod === 0
+    (interlaceMethod === 0 || interlaceMethod === 1)
   ) {
     return {
       bitDepth: bitDepth ?? 0,
       colorType: colorType ?? 0,
       height,
+      interlaceMethod,
       width,
     };
   }
@@ -5311,22 +5314,75 @@ function parsePngHeader(bytes: Uint8Array): PngHeader | null {
 }
 
 function getExpectedPngImageDataByteLength(header: PngHeader): number | null {
-  const bytesPerScanline = getPngBytesPerScanline(header);
-  if (bytesPerScanline == null) {
+  const rowLengths = getPngImageDataRowLengths(header);
+  if (!rowLengths) {
     return null;
   }
-  const totalByteLength = header.height * (bytesPerScanline + 1);
+  const totalByteLength = rowLengths.reduce(
+    (total, rowLength) => total + rowLength,
+    0,
+  );
   return Number.isSafeInteger(totalByteLength) ? totalByteLength : null;
 }
 
-function getPngBytesPerScanline(header: PngHeader): number | null {
+function getPngImageDataRowLengths(header: PngHeader): number[] | null {
   const samplesPerPixel = getPngSamplesPerPixel(header.colorType);
   if (samplesPerPixel == null) {
     return null;
   }
-  const bitsPerScanline = header.width * samplesPerPixel * header.bitDepth;
+  if (header.interlaceMethod === 0) {
+    const rowLength = getPngRowLength(header.width, samplesPerPixel, header);
+    return rowLength == null ? null : Array(header.height).fill(rowLength);
+  }
+  if (header.interlaceMethod !== 1) {
+    return null;
+  }
+
+  const rowLengths: number[] = [];
+  for (const pass of adam7Passes) {
+    const passWidth = getAdam7PassSize(header.width, pass.xStart, pass.xStep);
+    const passHeight = getAdam7PassSize(header.height, pass.yStart, pass.yStep);
+    if (passWidth === 0 || passHeight === 0) {
+      continue;
+    }
+    const rowLength = getPngRowLength(passWidth, samplesPerPixel, header);
+    if (rowLength == null) {
+      return null;
+    }
+    rowLengths.push(...Array(passHeight).fill(rowLength));
+  }
+  return rowLengths.length > 0 ? rowLengths : null;
+}
+
+const adam7Passes = [
+  { xStart: 0, xStep: 8, yStart: 0, yStep: 8 },
+  { xStart: 4, xStep: 8, yStart: 0, yStep: 8 },
+  { xStart: 0, xStep: 4, yStart: 4, yStep: 8 },
+  { xStart: 2, xStep: 4, yStart: 0, yStep: 4 },
+  { xStart: 0, xStep: 2, yStart: 2, yStep: 4 },
+  { xStart: 1, xStep: 2, yStart: 0, yStep: 2 },
+  { xStart: 0, xStep: 1, yStart: 1, yStep: 2 },
+] as const;
+
+function getAdam7PassSize(
+  imageSize: number,
+  passStart: number,
+  passStep: number,
+): number {
+  return imageSize > passStart
+    ? Math.floor((imageSize - passStart + passStep - 1) / passStep)
+    : 0;
+}
+
+function getPngRowLength(
+  width: number,
+  samplesPerPixel: number,
+  header: PngHeader,
+): number | null {
+  const bitsPerScanline = width * samplesPerPixel * header.bitDepth;
   const bytesPerScanline = Math.ceil(bitsPerScanline / 8);
-  return Number.isSafeInteger(bytesPerScanline) ? bytesPerScanline : null;
+  const rowLength = bytesPerScanline + 1;
+  return Number.isSafeInteger(rowLength) ? rowLength : null;
 }
 
 function getPngSamplesPerPixel(colorType: number): number | null {

--- a/packages/server/src/services.ts
+++ b/packages/server/src/services.ts
@@ -3948,6 +3948,11 @@ function mergeCodexAndLocalMessages(
           message.id,
           fallbackCodexMessage.codexOrder ?? fallbackTranscriptCodexIndex,
         );
+        mergedCodexMessages[fallbackTranscriptCodexIndex] =
+          mergeLocalMessageMetadataIntoCodexMessage(
+            fallbackCodexMessage,
+            message,
+          );
       }
       unmatchedCodexMessageIndexes.splice(
         unmatchedCodexMessageIndexes.indexOf(fallbackTranscriptCodexIndex),
@@ -3998,10 +4003,12 @@ function mergeCodexAndLocalMessages(
         message.id,
         matchedCodexMessage.codexOrder ?? matchedCodexIndex,
       );
+      mergedCodexMessages[matchedCodexIndex] =
+        mergeLocalMessageMetadataIntoCodexMessage(matchedCodexMessage, message);
     }
     if (message.eventType === "chat.message.steered" && matchedCodexMessage) {
       mergedCodexMessages[matchedCodexIndex] = {
-        ...matchedCodexMessage,
+        ...mergedCodexMessages[matchedCodexIndex],
         createdAt: message.createdAt,
       };
     }
@@ -4022,6 +4029,14 @@ function mergeCodexAndLocalMessages(
   )
     .sort(compareMergedMessages)
     .map(stripInternalCodexMessageMetadata);
+}
+
+function mergeLocalMessageMetadataIntoCodexMessage(
+  codexMessage: InternalChatMessageRecord,
+  localMessage: ChatMessageRecord,
+): InternalChatMessageRecord {
+  const attachments = cloneAttachmentRecords(localMessage.attachments);
+  return attachments ? { ...codexMessage, attachments } : codexMessage;
 }
 
 function localMessagesWithoutStaleSteeredState(

--- a/packages/server/src/services.ts
+++ b/packages/server/src/services.ts
@@ -1276,10 +1276,6 @@ export class ServeServices {
     const state = await this.store.load();
     this.requireChat(state, chatId);
 
-    const requestedMimeType = input.mimeType.trim().toLowerCase();
-    if (!requestedMimeType.startsWith("image/")) {
-      throw new Error("Only image attachments are supported");
-    }
     if (input.size <= 0 || input.bytes.byteLength <= 0) {
       throw new Error("Attachment file is empty");
     }

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -1,6 +1,7 @@
 import type { ChatMessageRecord, ChatStatus } from "@phantompane/state";
 
 export type {
+  ChatAttachmentRecord,
   ChatMessageRecord,
   ChatRecord,
   ChatStatus,

--- a/packages/state/src/types.ts
+++ b/packages/state/src/types.ts
@@ -17,11 +17,19 @@ const projectRecordBaseSchema = z.object({
   lastOpenedAt: z.string(),
 });
 
+const chatAttachmentRecordBaseSchema = z.object({
+  name: z.string(),
+  path: z.string(),
+  mimeType: z.string(),
+  size: z.number().int().nonnegative(),
+});
+
 const chatMessageRecordBaseSchema = z.object({
   id: z.string(),
   chatId: z.string(),
   role: z.enum(["user", "assistant", "event", "error"]),
   text: z.string(),
+  attachments: z.array(chatAttachmentRecordBaseSchema).optional(),
   eventType: z.string().optional(),
   eventData: z.unknown().optional(),
   itemId: z.string().optional(),
@@ -38,6 +46,7 @@ const queuedMessageRecordBaseSchema = z.object({
   chatId: z.string(),
   messageId: z.string(),
   text: z.string(),
+  attachments: z.array(chatAttachmentRecordBaseSchema).optional(),
   effort: z.string().optional(),
   files: z.array(turnContextItemBaseSchema).optional(),
   model: z.string().optional(),
@@ -78,6 +87,9 @@ const serveStateBaseSchema = z.object({
 });
 
 export type ChatStatus = z.infer<typeof chatStatusSchema>;
+export type ChatAttachmentRecord = z.infer<
+  typeof chatAttachmentRecordBaseSchema
+>;
 export type ProjectRecord = z.infer<typeof projectRecordBaseSchema>;
 export type ChatMessageRecord = z.infer<typeof chatMessageRecordBaseSchema>;
 export type QueuedMessageRecord = z.infer<typeof queuedMessageRecordBaseSchema>;

--- a/packages/web/src/api/mutations.ts
+++ b/packages/web/src/api/mutations.ts
@@ -1,5 +1,6 @@
-import { api, readRpcJson, routeParam } from "./client";
+import { api, apiUrl, readRpcJson, routeParam } from "./client";
 import type {
+  ChatAttachmentRecord,
   ChatMessageRecord,
   ChatRecord,
   CodexServiceTier,
@@ -16,12 +17,24 @@ export interface DeleteWorktreeInput {
 }
 
 export interface SendMessageInput {
+  attachments?: ChatAttachmentRecord[];
   effort?: string | null;
   files?: CodexTurnContextItem[];
   model?: string | null;
   serviceTier?: CodexServiceTier | null;
   skills?: CodexTurnContextItem[];
   text: string;
+}
+
+export async function uploadChatAttachmentMutation(chatId: string, file: File) {
+  const formData = new FormData();
+  formData.append("file", file);
+  return readRpcJson<{ attachment: ChatAttachmentRecord }>(
+    await fetch(apiUrl(`/chats/${routeParam(chatId)}/attachments`), {
+      body: formData,
+      method: "POST",
+    }),
+  );
 }
 
 export interface CreateChatInput {

--- a/packages/web/src/routes/home.tsx
+++ b/packages/web/src/routes/home.tsx
@@ -19,6 +19,7 @@ import {
   MessageSquare,
   MessageSquarePlus,
   MoreHorizontal,
+  Paperclip,
   Pencil,
   Plus,
   RefreshCw,
@@ -56,6 +57,7 @@ import {
   sendMessageMutation,
   steerMessageMutation,
   syncWorktreeMutation,
+  uploadChatAttachmentMutation,
   type SendMessageInput,
 } from "../api/mutations";
 import {
@@ -159,6 +161,7 @@ import {
 } from "./rich-events";
 import { mergeStreamingMessagesForDisplay } from "./chat-message-stream-order";
 import type {
+  ChatAttachmentRecord,
   ChatRecord,
   ChatStatus,
   CodexFileRecord,
@@ -288,6 +291,15 @@ interface RestoredPendingComposerContext {
   serviceTier: "fast" | "flex" | null;
 }
 
+interface SelectedAttachment {
+  file?: File;
+  id: string;
+  record?: ChatAttachmentRecord;
+  mimeType: string;
+  name: string;
+  size: number;
+}
+
 type VisibleMessageRecord = RenderedChatMessageRecord & {
   role: "assistant" | "error" | "event" | "user";
 };
@@ -309,6 +321,11 @@ interface TransientFileSearchQuery {
 
 const toastDismissDelayMs = 6000;
 const maxVisibleToasts = 3;
+const maxComposerAttachmentBytes = 10 * 1024 * 1024;
+const pngSignature = new Uint8Array([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+]);
+const supportedComposerAttachmentAccept = ".png,image/png";
 
 function firstProjectWorktree(
   projectId: string | null,
@@ -566,6 +583,9 @@ export function HomeRoute() {
     [],
   );
   const [selectedFiles, setSelectedFiles] = useState<CodexFileRecord[]>([]);
+  const [selectedAttachments, setSelectedAttachments] = useState<
+    SelectedAttachment[]
+  >([]);
   const [status, setStatus] = useState("Starting");
   const [sidebarError, setSidebarError] = useState<string | null>(null);
   const [timelineError, setTimelineError] = useState<string | null>(null);
@@ -627,6 +647,7 @@ export function HomeRoute() {
   const githubTargetsByProjectRef = useRef(githubTargetsByProject);
   const messagesRefreshRequestIdRef = useRef(0);
   const sendMessageRequestIdRef = useRef(0);
+  const attachmentInputRef = useRef<HTMLInputElement | null>(null);
   const composerTextareaRef = useRef<HTMLTextAreaElement | null>(null);
   const composerTextRef = useRef(composerText);
   const hasSelectedContextRef = useRef(false);
@@ -976,11 +997,15 @@ export function HomeRoute() {
     [selectedSkillPaths, skills],
   );
   const hasSelectedContext =
-    selectedFiles.length > 0 || selectedSkills.length > 0;
+    selectedAttachments.length > 0 ||
+    selectedFiles.length > 0 ||
+    selectedSkills.length > 0;
   composerTextRef.current = composerText;
   hasSelectedContextRef.current = hasSelectedContext;
   const canStartNewProjectChat =
-    Boolean(selectedProject) && !selectedChatId && Boolean(composerText.trim());
+    Boolean(selectedProject) &&
+    !selectedChatId &&
+    Boolean(composerText.trim() || hasSelectedContext);
   const canSendMessage =
     (hasSelectedChat &&
       !isSelectedChatArchived &&
@@ -1272,6 +1297,7 @@ export function HomeRoute() {
       setMessagesChatId(null);
       updatePendingApproval(null);
       setSelectedFiles([]);
+      setSelectedAttachments([]);
       setSelectedSkillPaths(new Set());
       setFileSearchResults([]);
       setSkills([]);
@@ -1286,6 +1312,7 @@ export function HomeRoute() {
       setMessagesChatId(null);
       updatePendingApproval(null);
       setSelectedFiles([]);
+      setSelectedAttachments([]);
       setSelectedSkillPaths(new Set());
       setFileSearchResults([]);
       setSkills([]);
@@ -1296,6 +1323,7 @@ export function HomeRoute() {
     }
 
     setSelectedFiles([]);
+    setSelectedAttachments([]);
     setSelectedSkillPaths(new Set());
     setFileSearchResults([]);
     setSkills([]);
@@ -2112,6 +2140,7 @@ export function HomeRoute() {
       if (shouldClearComposerContext) {
         setComposerText("");
         setSelectedFiles([]);
+        setSelectedAttachments([]);
         setSelectedSkillPaths(new Set());
         setTransientFileSearchQuery(null);
         setFileSearchResults([]);
@@ -2414,6 +2443,7 @@ export function HomeRoute() {
         restoredPendingComposerContextRef.current = null;
         setComposerText("");
         setSelectedFiles([]);
+        setSelectedAttachments([]);
         setSelectedSkillPaths(new Set());
       }
       await refreshChats(chat.projectId, { updateSelection: false });
@@ -2459,6 +2489,7 @@ export function HomeRoute() {
   function createComposerMessageInput(
     text: string,
     restoredPendingContext: RestoredPendingComposerContext | null,
+    attachments: ChatAttachmentRecord[] = [],
   ): SendMessageInput {
     const turnModel =
       selectedModel?.id ??
@@ -2480,6 +2511,7 @@ export function HomeRoute() {
       path: file.path,
     }));
     return {
+      attachments,
       effort: turnEffort,
       files,
       model: turnModel,
@@ -2489,10 +2521,31 @@ export function HomeRoute() {
     };
   }
 
+  async function uploadSelectedAttachments(
+    chatId: string,
+    attachments: SelectedAttachment[],
+  ): Promise<ChatAttachmentRecord[]> {
+    const uploadedAttachments: ChatAttachmentRecord[] = [];
+    for (const attachment of attachments) {
+      if (attachment.record) {
+        uploadedAttachments.push(attachment.record);
+        continue;
+      }
+      if (!attachment.file) {
+        continue;
+      }
+      const { attachment: uploadedAttachment } =
+        await uploadChatAttachmentMutation(chatId, attachment.file);
+      uploadedAttachments.push(uploadedAttachment);
+    }
+    return uploadedAttachments;
+  }
+
   async function submitNewProjectChat(
     projectId: string,
     input: SendMessageInput,
     composerInput: string,
+    composerAttachments: SelectedAttachment[],
     requestWorkspaceSelectionKey: string,
     githubTargetNumber: number | null,
   ) {
@@ -2519,16 +2572,22 @@ export function HomeRoute() {
       if (!chat) {
         if (isRequestWorkspaceSelected()) {
           setComposerText(composerInput);
+          setSelectedAttachments(composerAttachments);
         }
         return;
       }
 
       createdChatId = chat.id;
+      const attachments = await uploadSelectedAttachments(
+        chat.id,
+        composerAttachments,
+      );
+      const sendInput = { ...input, attachments };
       pendingSendChatIdsRef.current.add(chat.id);
       pendingComposerModesByChatRef.current.set(chat.id, "send");
       const sentData = await sendMessageRequest.mutateAsync({
         chatId: chat.id,
-        input,
+        input: sendInput,
       });
       upsertChatRecord(sentData.chat);
       void queryClient.invalidateQueries({
@@ -2539,6 +2598,7 @@ export function HomeRoute() {
       });
       if (isCreatedChatSelected()) {
         setSelectedFiles([]);
+        setSelectedAttachments([]);
         setSelectedSkillPaths(new Set());
         setSelectedGitHubTargetNumber(null);
         setFileSearchQuery("");
@@ -2549,6 +2609,7 @@ export function HomeRoute() {
         createdChatId ? isCreatedChatSelected() : isRequestWorkspaceSelected()
       ) {
         setComposerText(composerInput);
+        setSelectedAttachments(composerAttachments);
         setComposerError(formatErrorMessage("Could not send message", err));
       }
     } finally {
@@ -2585,10 +2646,12 @@ export function HomeRoute() {
       selectedChatVersionRef.current === requestChatVersion &&
       sendMessageRequestIdRef.current === requestId;
     const composerInput = composerText;
+    const composerAttachments = selectedAttachments;
     const text =
       composerInput.trim().length > 0
         ? composerInput
         : getContextOnlyMessage({
+            hasAttachments: selectedAttachments.length > 0,
             hasFiles: selectedFiles.length > 0,
             hasSkills: selectedSkills.length > 0,
           });
@@ -2598,20 +2661,21 @@ export function HomeRoute() {
       restoredPendingComposerContextRef.current?.chatId === requestChatId
         ? restoredPendingComposerContextRef.current
         : null;
-    const messageInput = createComposerMessageInput(
-      text,
-      restoredPendingContext,
-    );
     if (!requestChatId) {
       if (!selectedProjectId) {
         return;
       }
+      const messageInput = createComposerMessageInput(
+        text,
+        restoredPendingContext,
+      );
       setIsSendingMessage(true);
       setPendingComposerMode("send");
       await submitNewProjectChat(
         selectedProjectId,
         messageInput,
         composerInput,
+        composerAttachments,
         workspaceSelectionKeyRef.current,
         selectedGitHubTarget?.number ?? null,
       );
@@ -2624,6 +2688,15 @@ export function HomeRoute() {
     setIsSendingMessage(true);
     setPendingComposerMode(mode);
     try {
+      const attachments = await uploadSelectedAttachments(
+        requestChatId,
+        composerAttachments,
+      );
+      const messageInput = createComposerMessageInput(
+        text,
+        restoredPendingContext,
+        attachments,
+      );
       const mutation =
         mode === "steer"
           ? steerMessageRequest
@@ -2644,6 +2717,7 @@ export function HomeRoute() {
         return;
       }
       setSelectedFiles([]);
+      setSelectedAttachments([]);
       setSelectedSkillPaths(new Set());
       setFileSearchQuery("");
       await refreshMessages(requestChatId);
@@ -2741,6 +2815,11 @@ export function HomeRoute() {
     setSelectedFiles(
       (deletedPendingMessage.queuedMessage.files ?? []).map(
         contextItemToSelectedFile,
+      ),
+    );
+    setSelectedAttachments(
+      (deletedPendingMessage.queuedMessage.attachments ?? []).map(
+        attachmentRecordToSelectedAttachment,
       ),
     );
     setSelectedSkillPaths(
@@ -2883,6 +2962,7 @@ export function HomeRoute() {
     restoredPendingComposerContextRef.current = null;
     setComposerText("");
     setSelectedFiles([]);
+    setSelectedAttachments([]);
     setSelectedSkillPaths(new Set());
     setFileSearchResults([]);
     setSkills([]);
@@ -2945,6 +3025,52 @@ export function HomeRoute() {
         : [...current, file],
     );
     setFileSearchQuery("");
+  }
+
+  async function selectAttachments(files: FileList | null) {
+    if (!files || files.length === 0) {
+      return;
+    }
+
+    const nextAttachments: SelectedAttachment[] = [];
+    const rejectedNames: string[] = [];
+    for (const file of Array.from(files)) {
+      if (file.size <= 0 || file.size > maxComposerAttachmentBytes) {
+        rejectedNames.push(file.name);
+        continue;
+      }
+      if (!(await fileHasPngSignature(file))) {
+        rejectedNames.push(file.name);
+        continue;
+      }
+      nextAttachments.push({
+        file,
+        id: `${file.name}:${file.size}:${file.lastModified}:${crypto.randomUUID()}`,
+        mimeType: "image/png",
+        name: file.name,
+        size: file.size,
+      });
+    }
+
+    if (nextAttachments.length > 0) {
+      setSelectedAttachments((current) => [
+        ...current,
+        ...nextAttachments.filter(
+          (attachment) =>
+            !current.some(
+              (selectedAttachment) =>
+                selectedAttachment.name === attachment.name &&
+                selectedAttachment.size === attachment.size,
+            ),
+        ),
+      ]);
+      setComposerError(null);
+    }
+    if (rejectedNames.length > 0) {
+      setComposerError(
+        `Only PNG images up to ${formatFileSize(maxComposerAttachmentBytes)} can be attached: ${rejectedNames.join(", ")}`,
+      );
+    }
   }
 
   function selectSkill(path: string) {
@@ -3792,8 +3918,25 @@ export function HomeRoute() {
                     onDismiss={() => setModelError(null)}
                   />
                 )}
-                {(selectedFiles.length > 0 || selectedSkills.length > 0) && (
+                {(selectedAttachments.length > 0 ||
+                  selectedFiles.length > 0 ||
+                  selectedSkills.length > 0) && (
                   <div className="flex min-h-8 flex-wrap items-center gap-2 px-1">
+                    {selectedAttachments.map((attachment) => (
+                      <ContextChip
+                        icon={<Paperclip className="size-3.5" />}
+                        key={attachment.id}
+                        label={`${attachment.name} (${formatFileSize(attachment.size)})`}
+                        onRemove={() =>
+                          setSelectedAttachments((current) =>
+                            current.filter(
+                              (selectedAttachment) =>
+                                selectedAttachment.id !== attachment.id,
+                            ),
+                          )
+                        }
+                      />
+                    ))}
                     {selectedFiles.map((file) => (
                       <ContextChip
                         icon={<FileText className="size-3.5" />}
@@ -3856,6 +3999,29 @@ export function HomeRoute() {
                     />
                   </div>
                   <div className="flex shrink-0 items-end gap-1.5">
+                    <input
+                      accept={supportedComposerAttachmentAccept}
+                      className="sr-only"
+                      multiple
+                      ref={attachmentInputRef}
+                      type="file"
+                      onChange={(event) => {
+                        void selectAttachments(event.target.files);
+                        event.target.value = "";
+                      }}
+                    />
+                    <Button
+                      aria-label="Attach image"
+                      className="size-10"
+                      disabled={!selectedProject || isComposerBlocked}
+                      onClick={() => attachmentInputRef.current?.click()}
+                      size="icon"
+                      title="Attach image"
+                      type="button"
+                      variant="outline"
+                    >
+                      <Paperclip />
+                    </Button>
                     {hasSelectedChat && primaryComposerMode !== "queue" && (
                       <Button
                         aria-label={
@@ -4271,14 +4437,28 @@ function formatComposerModeBusy(mode: ComposerSubmitMode): string {
 }
 
 function getContextOnlyMessage({
+  hasAttachments,
   hasFiles,
   hasSkills,
 }: {
+  hasAttachments: boolean;
   hasFiles: boolean;
   hasSkills: boolean;
 }): string {
+  if (hasAttachments && hasFiles && hasSkills) {
+    return "Use the attached images, selected files, and selected skills as context.";
+  }
+  if (hasAttachments && hasFiles) {
+    return "Use the attached images and selected files as context.";
+  }
+  if (hasAttachments && hasSkills) {
+    return "Use the attached images and selected skills as context.";
+  }
   if (hasFiles && hasSkills) {
     return "Use the selected files and skills as context.";
+  }
+  if (hasAttachments) {
+    return "Use the attached images as context.";
   }
   if (hasFiles) {
     return "Use the selected files as context.";
@@ -4540,6 +4720,7 @@ function MessageCard({
   const isUser = message.role === "user";
   const isError = message.role === "error";
   const deliveryState = getMessageDeliveryState(message);
+  const attachments = message.attachments ?? [];
 
   return (
     <article
@@ -4568,6 +4749,25 @@ function MessageCard({
         <pre className="whitespace-pre-wrap break-words font-sans text-[length:var(--font-size-md)] leading-[var(--line-height-relaxed)]">
           {message.text}
         </pre>
+      )}
+      {attachments.length > 0 && (
+        <div
+          className={cn(
+            "mt-2 flex flex-wrap gap-1.5",
+            isUser ? "justify-end" : "justify-start",
+          )}
+        >
+          {attachments.map((attachment) => (
+            <span
+              className="inline-flex h-6 max-w-full items-center gap-1.5 rounded-[var(--radius-sm)] border border-current/20 bg-[var(--surface-floating)] px-2 text-[length:var(--font-size-xs)] font-medium text-current"
+              key={`${attachment.path}:${attachment.name}`}
+              title={`${attachment.name} (${formatFileSize(attachment.size)})`}
+            >
+              <Paperclip className="size-3.5 shrink-0" />
+              <span className="truncate">{attachment.name}</span>
+            </span>
+          ))}
+        </div>
       )}
       {deliveryState && (
         <MessageDeliveryBadge
@@ -5072,4 +5272,37 @@ function contextItemToSelectedFile(
     root: "",
     score: 0,
   };
+}
+
+function attachmentRecordToSelectedAttachment(
+  record: ChatAttachmentRecord,
+): SelectedAttachment {
+  return {
+    id: `${record.path}:${record.name}`,
+    mimeType: record.mimeType,
+    name: record.name,
+    record,
+    size: record.size,
+  };
+}
+
+async function fileHasPngSignature(file: File): Promise<boolean> {
+  try {
+    const bytes = new Uint8Array(
+      await file.slice(0, pngSignature.length).arrayBuffer(),
+    );
+    return pngSignature.every((byte, index) => bytes[index] === byte);
+  } catch {
+    return false;
+  }
+}
+
+function formatFileSize(size: number): string {
+  if (size < 1024) {
+    return `${size} B`;
+  }
+  if (size < 1024 * 1024) {
+    return `${Math.ceil(size / 1024)} KB`;
+  }
+  return `${(size / (1024 * 1024)).toFixed(1)} MB`;
 }


### PR DESCRIPTION
## Summary

- Add chat attachment metadata to Phantom state, queued messages, and rendered messages.
- Add bounded upload handling that stores PNG images under chat-scoped attachment storage and revalidates stored file bytes before send/queue use.
- Send uploaded PNG images to Codex app-server as `localImage` turn input items, matching the current app-server `UserInput` protocol.
- Add composer UI for selecting/removing PNG attachments and showing attachments on user messages.

## Notes

Codex app-server currently exposes text, image/localImage, skills, and mentions. There is no generic binary/PDF/Markdown attachment item in the generated protocol, so this PR keeps scope to PNG image attachments.

## Validation

- `pnpm --filter @phantompane/server typecheck`
- `pnpm --filter @phantompane/server test`
- `pnpm --filter @phantompane/web typecheck`
- `pnpm ready`
