### PR TITLE
[codex] Move sidebar close button to logo position

### DIFF
--- a/packages/web/src/components/ui/sidebar.tsx
+++ b/packages/web/src/components/ui/sidebar.tsx
@@ -183,22 +183,28 @@ export function SidebarInset({ className, ...props }: ComponentProps<"main">) {
 
 export function SidebarTrigger({
   className,
+  "aria-label": ariaLabel,
+  title = "Toggle sidebar",
   ...props
 }: ComponentProps<"button">) {
   const { toggleSidebar } = useSidebar();
+  const accessibleLabel =
+    ariaLabel ?? (typeof title === "string" ? title : "Toggle sidebar");
+
   return (
     <button
+      aria-label={accessibleLabel}
       className={cn(
         "inline-flex size-8 shrink-0 items-center justify-center rounded-[var(--radius-sm)] text-muted-foreground outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:shadow-[var(--state-focus-ring)] disabled:pointer-events-none disabled:opacity-[var(--opacity-disabled)]",
         className,
       )}
       onClick={toggleSidebar}
-      title="Toggle sidebar"
+      title={title}
       type="button"
       {...props}
     >
       <PanelLeft className="size-4" />
-      <span className="sr-only">Toggle sidebar</span>
+      <span className="sr-only">{accessibleLabel}</span>
     </button>
   );
 }

--- a/packages/web/src/routes/home.tsx
+++ b/packages/web/src/routes/home.tsx
@@ -118,6 +118,7 @@ import {
   SidebarProvider,
   SidebarRail,
   SidebarTrigger,
+  useSidebar,
 } from "../components/ui/sidebar";
 import { Textarea } from "../components/ui/textarea";
 import {
@@ -2953,9 +2954,11 @@ export function HomeRoute() {
     <SidebarProvider className="app-shell">
       <Sidebar collapsible="offcanvas" variant="inset">
         <SidebarHeader>
-          <div className="flex size-8 shrink-0 items-center justify-center rounded-[var(--radius-sm)] bg-[var(--brand-mark-bg)] text-[var(--brand-mark-fg)]">
-            <FolderGit2 className="size-4" />
-          </div>
+          <SidebarTrigger
+            aria-label="Close sidebar"
+            className="text-[var(--icon-color-default)] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+            title="Close sidebar"
+          />
           <div className="min-w-0 flex-1 group-data-[state=collapsed]/sidebar:hidden">
             <h1 className="truncate text-[length:var(--font-size-lg)] font-semibold leading-tight">
               Phantom
@@ -3544,8 +3547,7 @@ export function HomeRoute() {
 
       <SidebarInset>
         <header className="flex min-h-[var(--layout-topbar-height)] items-center gap-3 border-b border-border bg-[var(--surface-panel)] px-4">
-          <SidebarTrigger className="-ml-1" />
-          <div className="h-5 w-px bg-[var(--border-divider)]" />
+          <TopbarSidebarTrigger />
           <div className="min-w-0 flex-1">
             <div className="flex min-w-0 items-center gap-2">
               <p className="truncate text-[length:var(--font-size-xl)] font-semibold leading-tight">
@@ -4003,6 +4005,25 @@ export function HomeRoute() {
         </form>
       </SidebarInset>
     </SidebarProvider>
+  );
+}
+
+function TopbarSidebarTrigger() {
+  const { open } = useSidebar();
+
+  if (open) {
+    return null;
+  }
+
+  return (
+    <>
+      <SidebarTrigger
+        aria-label="Open sidebar"
+        className="-ml-1"
+        title="Open sidebar"
+      />
+      <div className="h-5 w-px bg-[var(--border-divider)]" />
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary

- Replace the sidebar header logo mark with the sidebar close trigger.
- Hide the main topbar sidebar trigger while the sidebar is open, and show it only when the sidebar is closed so users can reopen it.
- Allow `SidebarTrigger` to expose context-specific accessible labels and titles for open/close states.

## Why

The sidebar close affordance was separated from the sidebar header logo. Moving the control into the logo position removes duplicate chrome while keeping the reopen action available after the sidebar is closed.

## Impact

Users now close the sidebar from the header logo position. When the sidebar is closed, the topbar shows an `Open sidebar` trigger so navigation remains recoverable.

## Validation

- `pnpm ready`

Note: the first `pnpm ready` attempt failed because this worktree was missing package links; after running `pnpm install`, `pnpm ready` passed.