### PR TITLE
[codex] align e2e package version

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -8,5 +8,5 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },
-  "version": "0.2.0-1"
+  "version": "6.3.0-1"
 }


### PR DESCRIPTION
## Summary

- Align `@phantompane/e2e` package version with the rest of the monorepo at `6.3.0-1`.

## Validation

- `pnpm ready`

## Notes

- The first `pnpm ready` attempt failed because `node_modules` was missing in this worktree. I ran `pnpm install` with the existing lockfile, then reran `pnpm ready` successfully.