### PR TITLE
[codex] Show pull request metadata for worktrees

### DIFF
--- a/packages/github/src/api/checkout-target.test.ts
+++ b/packages/github/src/api/checkout-target.test.ts
@@ -7,6 +7,9 @@ interface MockCheckoutTargetOctokit {
   issues: {
     listForRepo: ReturnType<typeof vi.fn>;
   };
+  pulls: {
+    list: ReturnType<typeof vi.fn>;
+  };
 }
 
 let mockOctokit: MockCheckoutTargetOctokit | undefined;
@@ -47,6 +50,22 @@ describe("listGitHubCheckoutTargets", () => {
           ],
         })),
       },
+      pulls: {
+        list: vi.fn(async () => ({
+          data: [
+            {
+              number: 42,
+              head: {
+                ref: "fix/checkout",
+                repo: { full_name: "owner/repo" },
+              },
+              base: {
+                repo: { full_name: "owner/repo" },
+              },
+            },
+          ],
+        })),
+      },
     };
     createGitHubClientMock.mockImplementation(async () => mockOctokit!);
 
@@ -62,9 +81,20 @@ describe("listGitHubCheckoutTargets", () => {
       direction: "desc",
       per_page: 10,
     });
+    deepStrictEqual(mockOctokit!.pulls.list.mock.calls[0]?.[0], {
+      owner: "owner",
+      repo: "repo",
+      state: "open",
+      sort: "updated",
+      direction: "desc",
+      per_page: 10,
+    });
     deepStrictEqual(targets, [
       {
         author: "alice",
+        baseRepoFullName: "owner/repo",
+        headRef: "fix/checkout",
+        headRepoFullName: "owner/repo",
         htmlUrl: "https://github.com/owner/repo/pull/42",
         kind: "pullRequest",
         number: 42,
@@ -87,6 +117,11 @@ describe("listGitHubCheckoutTargets", () => {
     mockOctokit = {
       issues: {
         listForRepo: vi.fn(async () => ({
+          data: [],
+        })),
+      },
+      pulls: {
+        list: vi.fn(async () => ({
           data: [],
         })),
       },

--- a/packages/github/src/api/checkout-target.test.ts
+++ b/packages/github/src/api/checkout-target.test.ts
@@ -135,4 +135,58 @@ describe("listGitHubCheckoutTargets", () => {
       30,
     );
   });
+
+  it("keeps checkout targets when pull request metadata is unavailable", async () => {
+    resetMocks();
+    mockOctokit = {
+      issues: {
+        listForRepo: vi.fn(async () => ({
+          data: [
+            {
+              number: 42,
+              title: "Fix checkout",
+              html_url: "https://github.com/owner/repo/pull/42",
+              updated_at: "2026-05-04T00:00:00Z",
+              user: { login: "alice" },
+              pull_request: {},
+            },
+            {
+              number: 7,
+              title: "Support issue checkout",
+              html_url: "https://github.com/owner/repo/issues/7",
+              updated_at: "2026-05-03T00:00:00Z",
+              user: null,
+            },
+          ],
+        })),
+      },
+      pulls: {
+        list: vi.fn(async () => {
+          throw new Error("pull request metadata unavailable");
+        }),
+      },
+    };
+    createGitHubClientMock.mockImplementation(async () => mockOctokit!);
+
+    const targets = await listGitHubCheckoutTargets("owner", "repo");
+
+    deepStrictEqual(targets, [
+      {
+        author: "alice",
+        htmlUrl: "https://github.com/owner/repo/pull/42",
+        kind: "pullRequest",
+        number: 42,
+        title: "Fix checkout",
+        updatedAt: "2026-05-04T00:00:00Z",
+      },
+      {
+        author: null,
+        htmlUrl: "https://github.com/owner/repo/issues/7",
+        kind: "issue",
+        number: 7,
+        title: "Support issue checkout",
+        updatedAt: "2026-05-03T00:00:00Z",
+      },
+    ]);
+  });
 });

--- a/packages/github/src/api/checkout-target.ts
+++ b/packages/github/src/api/checkout-target.ts
@@ -11,21 +11,48 @@ export async function listGitHubCheckoutTargets(
   options: ListGitHubCheckoutTargetsOptions = {},
 ): Promise<GitHubCheckoutTarget[]> {
   const github = await createGitHubClient();
-  const { data } = await github.issues.listForRepo({
-    owner,
-    repo,
-    state: "open",
-    sort: "updated",
-    direction: "desc",
-    per_page: options.limit ?? 30,
-  });
+  const perPage = options.limit ?? 30;
+  const [{ data: issues }, { data: pullRequests }] = await Promise.all([
+    github.issues.listForRepo({
+      owner,
+      repo,
+      state: "open",
+      sort: "updated",
+      direction: "desc",
+      per_page: perPage,
+    }),
+    github.pulls.list({
+      owner,
+      repo,
+      state: "open",
+      sort: "updated",
+      direction: "desc",
+      per_page: perPage,
+    }),
+  ]);
+  const pullRequestByNumber = new Map(
+    pullRequests.map((pullRequest) => [pullRequest.number, pullRequest]),
+  );
 
-  return data.map((item) => ({
-    author: item.user?.login ?? null,
-    htmlUrl: item.html_url,
-    kind: item.pull_request ? "pullRequest" : "issue",
-    number: item.number,
-    title: item.title,
-    updatedAt: item.updated_at,
-  }));
+  return issues.map((item) => {
+    const pullRequest = item.pull_request
+      ? pullRequestByNumber.get(item.number)
+      : undefined;
+
+    return {
+      author: item.user?.login ?? null,
+      ...(pullRequest
+        ? {
+            baseRepoFullName: pullRequest.base.repo.full_name,
+            headRef: pullRequest.head.ref,
+            headRepoFullName: pullRequest.head.repo?.full_name,
+          }
+        : {}),
+      htmlUrl: item.html_url,
+      kind: item.pull_request ? "pullRequest" : "issue",
+      number: item.number,
+      title: item.title,
+      updatedAt: item.updated_at,
+    };
+  });
 }

--- a/packages/github/src/api/checkout-target.ts
+++ b/packages/github/src/api/checkout-target.ts
@@ -21,14 +21,16 @@ export async function listGitHubCheckoutTargets(
       direction: "desc",
       per_page: perPage,
     }),
-    github.pulls.list({
-      owner,
-      repo,
-      state: "open",
-      sort: "updated",
-      direction: "desc",
-      per_page: perPage,
-    }),
+    github.pulls
+      .list({
+        owner,
+        repo,
+        state: "open",
+        sort: "updated",
+        direction: "desc",
+        per_page: perPage,
+      })
+      .catch(() => ({ data: [] })),
   ]);
   const pullRequestByNumber = new Map(
     pullRequests.map((pullRequest) => [pullRequest.number, pullRequest]),

--- a/packages/github/src/api/types.ts
+++ b/packages/github/src/api/types.ts
@@ -21,6 +21,9 @@ export interface GitHubIssue {
 
 export interface GitHubCheckoutTarget {
   author: string | null;
+  baseRepoFullName?: string;
+  headRef?: string;
+  headRepoFullName?: string;
   htmlUrl: string;
   kind: "issue" | "pullRequest";
   number: number;

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -29,6 +29,9 @@ export interface ProjectWorktreeRecord {
 
 export interface GitHubCheckoutTargetRecord {
   author: string | null;
+  baseRepoFullName?: string;
+  headRef?: string;
+  headRepoFullName?: string;
   htmlUrl: string;
   kind: "issue" | "pullRequest";
   number: number;

--- a/packages/web/src/routes/home.tsx
+++ b/packages/web/src/routes/home.tsx
@@ -245,6 +245,57 @@ const statusMeta: Record<
   },
 };
 
+function getPullRequestBranchName(
+  target: GitHubCheckoutTargetRecord,
+): string | null {
+  if (target.kind !== "pullRequest" || !target.headRef) {
+    return null;
+  }
+  if (
+    target.headRepoFullName &&
+    target.baseRepoFullName &&
+    target.headRepoFullName !== target.baseRepoFullName
+  ) {
+    const [headOwner] = target.headRepoFullName.split("/");
+    return headOwner ? `${headOwner}/${target.headRef}` : target.headRef;
+  }
+  return target.headRef;
+}
+
+function getPullRequestTargetForWorktree(
+  worktree: ProjectWorktreeRecord | null,
+  githubTargets: GitHubCheckoutTargetsResult | null,
+): GitHubCheckoutTargetRecord | null {
+  if (!worktree || !githubTargets?.available) {
+    return null;
+  }
+  return (
+    githubTargets.targets.find(
+      (target) => getPullRequestBranchName(target) === worktree.branch,
+    ) ?? null
+  );
+}
+
+function getWorktreeDisplayName(
+  worktree: ProjectWorktreeRecord,
+  pullRequestTarget: GitHubCheckoutTargetRecord | null,
+): string {
+  return pullRequestTarget?.title ?? worktree.name;
+}
+
+function GitHubMark({ className }: { className?: string }) {
+  return (
+    <svg
+      aria-hidden="true"
+      className={className}
+      fill="currentColor"
+      viewBox="0 0 24 24"
+    >
+      <path d="M12 0.5C5.65 0.5 0.5 5.65 0.5 12c0 5.09 3.29 9.39 7.86 10.92 0.58 0.1 0.79-0.25 0.79-0.56 0-0.27-0.01-1.18-0.02-2.14-3.2 0.7-3.88-1.36-3.88-1.36-0.52-1.33-1.28-1.68-1.28-1.68-1.05-0.72 0.08-0.7 0.08-0.7 1.16 0.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36 0.96 0.1-0.75 0.4-1.25 0.73-1.54-2.55-0.29-5.24-1.28-5.24-5.68 0-1.25 0.45-2.28 1.19-3.08-0.12-0.29-0.52-1.46 0.11-3.04 0 0 0.97-0.31 3.17 1.18a11.02 11.02 0 0 1 5.77 0c2.2-1.49 3.17-1.18 3.17-1.18 0.63 1.58 0.23 2.75 0.11 3.04 0.74 0.8 1.19 1.83 1.19 3.08 0 4.42-2.69 5.39-5.25 5.68 0.41 0.35 0.78 1.05 0.78 2.12 0 1.53-0.01 2.76-0.01 3.14 0 0.31 0.21 0.67 0.79 0.56A11.51 11.51 0 0 0 23.5 12C23.5 5.65 18.35 0.5 12 0.5Z" />
+    </svg>
+  );
+}
+
 type PendingApproval = PendingApprovalRecord & { chatId: string };
 type PendingApprovalEventData = PendingApprovalRecord;
 
@@ -932,10 +983,9 @@ export function HomeRoute() {
     () => projects.find((project) => project.id === selectedProjectId) ?? null,
     [projects, selectedProjectId],
   );
-  const selectedProjectGitHubTargets =
-    selectedProjectId && !selectedChatId
-      ? (githubTargetsByProject[selectedProjectId] ?? null)
-      : null;
+  const selectedProjectGitHubTargets = selectedProjectId
+    ? (githubTargetsByProject[selectedProjectId] ?? null)
+    : null;
   const isSelectedProjectGitHubTargetsLoading = Boolean(
     selectedProjectId && loadingGitHubTargetProjectIds.has(selectedProjectId),
   );
@@ -1162,6 +1212,18 @@ export function HomeRoute() {
     }
     return null;
   }, [selectedChat, selectedProjectId, worktreesByProject]);
+  const selectedPullRequestTarget = useMemo(
+    () =>
+      getPullRequestTargetForWorktree(
+        selectedWorktree,
+        selectedProjectGitHubTargets,
+      ),
+    [selectedProjectGitHubTargets, selectedWorktree],
+  );
+  const selectedWorktreeDisplayName =
+    selectedWorktree && selectedPullRequestTarget
+      ? getWorktreeDisplayName(selectedWorktree, selectedPullRequestTarget)
+      : null;
 
   const chatsByWorktreeByProject = useMemo(() => {
     const nextChatsByWorktreeByProject: Record<
@@ -1260,7 +1322,7 @@ export function HomeRoute() {
 
   useEffect(() => {
     setSelectedGitHubTargetNumber(null);
-    if (!selectedProjectId || selectedChatId) {
+    if (!selectedProjectId) {
       return;
     }
     void refreshGitHubCheckoutTargets(selectedProjectId);
@@ -3161,6 +3223,8 @@ export function HomeRoute() {
                 projects.map((project) => {
                   const isProjectExpanded = expandedProjectIds.has(project.id);
                   const projectWorktrees = worktreesByProject[project.id] ?? [];
+                  const projectGitHubTargets =
+                    githubTargetsByProject[project.id] ?? null;
                   const isProjectDataLoading =
                     loadingProjectIds.has(project.id) &&
                     worktreesByProject[project.id] === undefined;
@@ -3260,6 +3324,16 @@ export function HomeRoute() {
                               const isSelectedWorktree =
                                 selectedProjectId === project.id &&
                                 selectedWorktree?.path === worktree.path;
+                              const pullRequestTarget =
+                                getPullRequestTargetForWorktree(
+                                  worktree,
+                                  projectGitHubTargets,
+                                );
+                              const worktreeDisplayName =
+                                getWorktreeDisplayName(
+                                  worktree,
+                                  pullRequestTarget,
+                                );
                               const worktreeChats =
                                 chatsByWorktreeByProject[project.id]?.get(
                                   worktree.path,
@@ -3292,8 +3366,10 @@ export function HomeRoute() {
                                 loadingChatProjectIds.has(project.id) &&
                                 worktreeChats.length === 0;
                               const title = `${worktree.name} (${worktree.path})${
-                                worktree.isClean ? "" : " [dirty]"
-                              }${
+                                pullRequestTarget
+                                  ? ` [PR #${pullRequestTarget.number}: ${pullRequestTarget.title}]`
+                                  : ""
+                              }${worktree.isClean ? "" : " [dirty]"}${
                                 worktree.isMainWorktree
                                   ? " [main worktree]"
                                   : ""
@@ -3311,7 +3387,7 @@ export function HomeRoute() {
                                   <div className="group/worktree flex items-center gap-0.5 rounded-[var(--radius-sm)]">
                                     <button
                                       aria-expanded={isWorktreeExpanded}
-                                      aria-label={`${isWorktreeExpanded ? "Collapse" : "Expand"} chats for ${worktree.name}`}
+                                      aria-label={`${isWorktreeExpanded ? "Collapse" : "Expand"} chats for ${worktreeDisplayName}`}
                                       className="inline-flex size-7 shrink-0 items-center justify-center rounded-[var(--radius-sm)] text-[var(--icon-color-default)] outline-none transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:shadow-[var(--state-focus-ring)]"
                                       onClick={() =>
                                         toggleWorktreeChats(
@@ -3345,13 +3421,15 @@ export function HomeRoute() {
                                     >
                                       {worktree.isMainWorktree ? (
                                         <FolderGit2 className="size-3.5 text-[var(--icon-color-default)]" />
+                                      ) : pullRequestTarget ? (
+                                        <GitHubMark className="size-3.5 text-[var(--icon-color-default)]" />
                                       ) : (
                                         <GitBranch className="size-3.5 text-[var(--icon-color-default)]" />
                                       )}
                                       <span className="min-w-0 flex-1">
                                         <span className="flex min-w-0 items-center gap-1.5">
                                           <span className="block min-w-0 truncate font-medium">
-                                            {worktree.name}
+                                            {worktreeDisplayName}
                                           </span>
                                         </span>
                                       </span>
@@ -3725,7 +3803,9 @@ export function HomeRoute() {
                 <div className="flex min-w-0 items-center gap-2">
                   <p className="truncate text-[length:var(--font-size-xl)] font-semibold leading-tight">
                     {selectedChat
-                      ? (selectedWorktree?.name ?? selectedChat.worktreeName)
+                      ? (selectedWorktreeDisplayName ??
+                        selectedWorktree?.name ??
+                        selectedChat.worktreeName)
                       : selectedProject
                         ? "New chat"
                         : "Workspace"}
@@ -3742,6 +3822,18 @@ export function HomeRoute() {
                   )}
                 </p>
               </div>
+              {selectedPullRequestTarget && (
+                <a
+                  aria-label={`Open PR #${selectedPullRequestTarget.number}`}
+                  className="inline-flex size-8 shrink-0 items-center justify-center rounded-[var(--radius-sm)] text-[var(--icon-color-default)] outline-none transition-colors duration-[var(--motion-duration-fast)] hover:bg-accent hover:text-accent-foreground focus-visible:border-ring focus-visible:shadow-[var(--state-focus-ring)]"
+                  href={selectedPullRequestTarget.htmlUrl}
+                  rel="noreferrer"
+                  target="_blank"
+                  title={`Open PR #${selectedPullRequestTarget.number}`}
+                >
+                  <GitHubMark className="size-4" />
+                </a>
+              )}
               {selectedChat && (
                 <Button
                   aria-label={


### PR DESCRIPTION
## Summary

- Match open GitHub pull requests to worktrees by PR head branch, including fork branch naming.
- Show the PR title in worktree display locations when a matching PR exists.
- Replace the sidebar branch icon with a GitHub mark for PR-linked worktrees and add a top-right PR link button in the chat view.

## Impact

Worktrees checked out from pull requests are easier to identify in the sidebar and chat header, and users can jump directly to the corresponding PR from the active chat view.

## Validation

- `pnpm --filter @phantompane/github test`
- `pnpm --filter @phantompane/web typecheck`
- `pnpm ready`