### PR TITLE
[codex] Remember recent project skills

### DIFF
--- a/packages/server/src/rpc.test.ts
+++ b/packages/server/src/rpc.test.ts
@@ -6,7 +6,10 @@ const services = vi.hoisted(() => ({
   createChat: vi.fn(),
   getMessages: vi.fn(),
   listProjectGitHubCheckoutTargets: vi.fn(),
+  listProjectSkills: vi.fn(),
   listProjects: vi.fn(),
+  listRecentProjectSkills: vi.fn(),
+  rememberRecentProjectSkill: vi.fn(),
   uploadAttachment: vi.fn(),
 }));
 
@@ -206,6 +209,89 @@ describe("rpcRoutes", () => {
           },
         ],
       },
+    });
+  });
+
+  it("lists recent project skills through Hono RPC", async () => {
+    services.listRecentProjectSkills.mockResolvedValueOnce([
+      {
+        path: "/skills/review/SKILL.md",
+        lastUsedAt: "2026-05-08T00:00:00.000Z",
+      },
+    ]);
+
+    const response = await rpcRoutes.request("/projects/proj_1/recent-skills");
+
+    strictEqual(response.status, 200);
+    deepStrictEqual(services.listRecentProjectSkills.mock.calls[0], ["proj_1"]);
+    deepStrictEqual(await response.json(), {
+      recentSkills: [
+        {
+          path: "/skills/review/SKILL.md",
+          lastUsedAt: "2026-05-08T00:00:00.000Z",
+        },
+      ],
+    });
+  });
+
+  it("lists project skills through Hono RPC", async () => {
+    services.listProjectSkills.mockResolvedValueOnce([
+      {
+        name: "review",
+        path: "/skills/review/SKILL.md",
+        displayName: "Review",
+        description: "Review code",
+        shortDescription: null,
+        enabled: true,
+      },
+    ]);
+
+    const response = await rpcRoutes.request("/projects/proj_1/skills");
+
+    strictEqual(response.status, 200);
+    deepStrictEqual(services.listProjectSkills.mock.calls[0], ["proj_1"]);
+    deepStrictEqual(await response.json(), {
+      skills: [
+        {
+          name: "review",
+          path: "/skills/review/SKILL.md",
+          displayName: "Review",
+          description: "Review code",
+          shortDescription: null,
+          enabled: true,
+        },
+      ],
+    });
+  });
+
+  it("remembers recent project skills through Hono RPC", async () => {
+    services.rememberRecentProjectSkill.mockResolvedValueOnce([
+      {
+        path: "/skills/review/SKILL.md",
+        lastUsedAt: "2026-05-08T00:00:00.000Z",
+      },
+    ]);
+
+    const response = await rpcRoutes.request("/projects/proj_1/recent-skills", {
+      body: JSON.stringify({ path: "/skills/review/SKILL.md" }),
+      headers: {
+        "Content-Type": "application/json",
+      },
+      method: "POST",
+    });
+
+    strictEqual(response.status, 200);
+    deepStrictEqual(services.rememberRecentProjectSkill.mock.calls[0], [
+      "proj_1",
+      "/skills/review/SKILL.md",
+    ]);
+    deepStrictEqual(await response.json(), {
+      recentSkills: [
+        {
+          path: "/skills/review/SKILL.md",
+          lastUsedAt: "2026-05-08T00:00:00.000Z",
+        },
+      ],
     });
   });
 

--- a/packages/server/src/rpc.ts
+++ b/packages/server/src/rpc.ts
@@ -74,6 +74,10 @@ const deleteWorktreeSchema = worktreeSchema.extend({
   keepBranch: z.boolean().optional(),
 });
 
+const recentProjectSkillSchema = z.object({
+  path: z.string().min(1, "Skill path is required"),
+});
+
 const sendMessageSchema = z.object({
   text: z.string().min(1, "Message text is required"),
   attachments: z.array(attachmentSchema).optional(),
@@ -341,6 +345,43 @@ export const rpcRoutes = new Hono()
       return handleApiError(c, error);
     }
   })
+  .get("/projects/:projectId/skills", async (c) => {
+    try {
+      const skills = await getServeServices().listProjectSkills(
+        c.req.param("projectId"),
+      );
+      return c.json({ skills }, 200);
+    } catch (error) {
+      return handleApiError(c, error);
+    }
+  })
+  .get("/projects/:projectId/recent-skills", async (c) => {
+    try {
+      const recentSkills = await getServeServices().listRecentProjectSkills(
+        c.req.param("projectId"),
+      );
+      return c.json({ recentSkills }, 200);
+    } catch (error) {
+      return handleApiError(c, error);
+    }
+  })
+  .post(
+    "/projects/:projectId/recent-skills",
+    jsonBody(recentProjectSkillSchema),
+    async (c) => {
+      try {
+        const body = c.req.valid("json");
+        const recentSkills =
+          await getServeServices().rememberRecentProjectSkill(
+            c.req.param("projectId"),
+            body.path,
+          );
+        return c.json({ recentSkills }, 200);
+      } catch (error) {
+        return handleApiError(c, error);
+      }
+    },
+  )
   .get("/projects/:projectId/github/checkout-targets", async (c) => {
     try {
       const github = await getServeServices().listProjectGitHubCheckoutTargets(

--- a/packages/server/src/services.test.ts
+++ b/packages/server/src/services.test.ts
@@ -158,6 +158,7 @@ function createTestState(overrides: Partial<ServeState> = {}): ServeState {
     chats: [],
     messages: [],
     queuedMessages: [],
+    recentProjectSkills: {},
     selectedProjectId: null,
     selectedChatId: null,
     ...overrides,
@@ -576,6 +577,171 @@ describe("ServeServices", () => {
     deepStrictEqual(savedState.messages, []);
     strictEqual(savedState.selectedProjectId, null);
     strictEqual(savedState.selectedChatId, null);
+  });
+
+  it("removes recent skill suggestions when removing a project", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      recentProjectSkills: {
+        proj_1: [
+          {
+            path: "/skills/review/SKILL.md",
+            lastUsedAt: "2026-05-08T00:00:00.000Z",
+          },
+        ],
+        proj_2: [
+          {
+            path: "/skills/other/SKILL.md",
+            lastUsedAt: "2026-05-08T00:00:00.000Z",
+          },
+        ],
+      },
+    };
+    const { services, store } = await createHarness(state);
+
+    await services.removeProject("proj_1");
+
+    const savedState = await store.load();
+    deepStrictEqual(savedState.recentProjectSkills, {
+      proj_2: [
+        {
+          path: "/skills/other/SKILL.md",
+          lastUsedAt: "2026-05-08T00:00:00.000Z",
+        },
+      ],
+    });
+  });
+
+  it("lists skills from the project root", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject({ rootPath: "/repo" })],
+    };
+    const { codex, services } = await createHarness(state);
+    codex.listSkills.mockResolvedValueOnce({
+      skills: [
+        {
+          name: "review",
+          path: "/repo/.codex/skills/review/SKILL.md",
+          description: "Review code",
+          interface: {
+            displayName: "Review",
+          },
+        },
+      ],
+    });
+
+    const skills = await services.listProjectSkills("proj_1");
+
+    deepStrictEqual(codex.listSkills.mock.calls[0], [["/repo"]]);
+    deepStrictEqual(skills, [
+      {
+        name: "review",
+        path: "/repo/.codex/skills/review/SKILL.md",
+        displayName: "Review",
+        description: "Review code",
+        shortDescription: null,
+        enabled: true,
+      },
+    ]);
+  });
+
+  it("normalizes recent project-local skill paths across project roots and worktrees", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject({ rootPath: "/repo" })],
+      chats: [
+        createChat({
+          worktreePath: "/repo/.git/phantom/worktrees/feature",
+        }),
+      ],
+      recentProjectSkills: {
+        proj_1: [
+          {
+            path: "/repo/.codex/skills/review/SKILL.md",
+            lastUsedAt: "2026-05-08T00:00:00.000Z",
+          },
+        ],
+      },
+    };
+    const { services, store } = await createHarness(state);
+
+    const recentSkills = await services.rememberRecentProjectSkill(
+      "proj_1",
+      "/repo/.git/phantom/worktrees/feature/.codex/skills/review/SKILL.md",
+    );
+
+    deepStrictEqual(
+      recentSkills.map((skill) => skill.path),
+      [".codex/skills/review/SKILL.md"],
+    );
+    deepStrictEqual(
+      (await store.load()).recentProjectSkills.proj_1?.map(
+        (skill) => skill.path,
+      ),
+      [".codex/skills/review/SKILL.md"],
+    );
+  });
+
+  it("remembers recent skill selections per project", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      recentProjectSkills: {
+        proj_1: [
+          {
+            path: "/skills/review/SKILL.md",
+            lastUsedAt: "2026-05-08T00:00:00.000Z",
+          },
+        ],
+      },
+    };
+    const { services, store } = await createHarness(state);
+
+    const recentSkills = await services.rememberRecentProjectSkill(
+      "proj_1",
+      "/skills/test/SKILL.md",
+    );
+
+    strictEqual(recentSkills[0]?.path, "/skills/test/SKILL.md");
+    strictEqual(recentSkills[1]?.path, "/skills/review/SKILL.md");
+    deepStrictEqual(await services.listRecentProjectSkills("proj_1"), [
+      ...recentSkills,
+    ]);
+    deepStrictEqual((await store.load()).recentProjectSkills.proj_1, [
+      ...recentSkills,
+    ]);
+  });
+
+  it("updates an existing recent skill selection instead of duplicating it", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      recentProjectSkills: {
+        proj_1: [
+          {
+            path: "/skills/review/SKILL.md",
+            lastUsedAt: "2026-05-08T00:00:00.000Z",
+          },
+          {
+            path: "/skills/test/SKILL.md",
+            lastUsedAt: "2026-05-08T00:30:00.000Z",
+          },
+        ],
+      },
+    };
+    const { services } = await createHarness(state);
+
+    const recentSkills = await services.rememberRecentProjectSkill(
+      "proj_1",
+      "/skills/review/SKILL.md",
+    );
+
+    deepStrictEqual(
+      recentSkills.map((skill) => skill.path),
+      ["/skills/review/SKILL.md", "/skills/test/SKILL.md"],
+    );
   });
 
   it("removes persisted chats for worktrees missing from a live sync", async () => {
@@ -7073,6 +7239,68 @@ describe("ServeServices", () => {
         skills: [{ name: "review", path: "/skills/review/SKILL.md" }],
       },
     ]);
+  });
+
+  it("remaps project-root skill context to the selected chat worktree", async () => {
+    const projectRoot = await createTemporaryDirectory();
+    const worktreePath = join(projectRoot, ".git/phantom/worktrees/feature");
+    const projectSkillPath = join(projectRoot, ".codex/skills/review/SKILL.md");
+    const worktreeSkillPath = join(
+      worktreePath,
+      ".codex/skills/review/SKILL.md",
+    );
+    const state = {
+      ...createTestState(),
+      projects: [createProject({ rootPath: projectRoot })],
+      chats: [createChat({ worktreePath })],
+    };
+    const { codex, services } = await createHarness(state);
+    codex.resumeThread.mockResolvedValueOnce({});
+    codex.listSkills.mockResolvedValueOnce({
+      skills: [
+        { name: "review", path: projectSkillPath },
+        { name: "review", path: worktreeSkillPath },
+      ],
+    });
+    codex.startTurn.mockResolvedValueOnce({ turn: { id: "turn_1" } });
+
+    await services.sendMessage("chat_1", {
+      skills: [{ name: "review", path: projectSkillPath }],
+      text: "please review",
+    });
+
+    deepStrictEqual(codex.startTurn.mock.calls[0]?.[3], {
+      skills: [{ name: "review", path: worktreeSkillPath }],
+    });
+  });
+
+  it("allows root-only project skill context for a new worktree chat", async () => {
+    const projectRoot = await createTemporaryDirectory();
+    const worktreePath = join(projectRoot, ".git/phantom/worktrees/feature");
+    const projectSkillPath = join(projectRoot, ".codex/skills/review/SKILL.md");
+    const state = {
+      ...createTestState(),
+      projects: [createProject({ rootPath: projectRoot })],
+      chats: [createChat({ worktreePath })],
+    };
+    const { codex, services } = await createHarness(state);
+    codex.resumeThread.mockResolvedValueOnce({});
+    codex.listSkills.mockResolvedValueOnce({
+      skills: [{ name: "review", path: projectSkillPath }],
+    });
+    codex.startTurn.mockResolvedValueOnce({ turn: { id: "turn_1" } });
+
+    await services.sendMessage("chat_1", {
+      skills: [{ name: "review", path: projectSkillPath }],
+      text: "please review",
+    });
+
+    deepStrictEqual(codex.listSkills.mock.calls[0], [
+      [worktreePath, projectRoot],
+    ]);
+    deepStrictEqual(codex.startTurn.mock.calls[0]?.[3], {
+      skills: [{ name: "review", path: projectSkillPath }],
+    });
   });
 
   it("uploads image attachments and passes them to Codex turns", async () => {

--- a/packages/server/src/services.ts
+++ b/packages/server/src/services.ts
@@ -46,7 +46,9 @@ import {
 import {
   createRecordId,
   createTimestamp,
+  getRecentProjectSkillRecords,
   getServeDataDir,
+  rememberRecentProjectSkillSelection,
   ServeStateStore,
   touchProject,
 } from "@phantompane/state";
@@ -66,6 +68,7 @@ import type {
   ProjectWorktreeRecord,
   ProjectRecord,
   QueuedMessageRecord,
+  RecentProjectSkillRecord,
   ServeState,
 } from "./types.ts";
 
@@ -420,6 +423,11 @@ export class ServeServices {
         queuedMessages: state.queuedMessages.filter(
           (message) => !removedChatIds.has(message.chatId),
         ),
+        recentProjectSkills: Object.fromEntries(
+          Object.entries(state.recentProjectSkills).filter(
+            ([storedProjectId]) => storedProjectId !== projectId,
+          ),
+        ),
         selectedProjectId:
           state.selectedProjectId === projectId
             ? null
@@ -430,6 +438,60 @@ export class ServeServices {
       };
     });
     this.eventHub.emit("project.removed", { projectId });
+  }
+
+  async listRecentProjectSkills(
+    projectId: string,
+  ): Promise<RecentProjectSkillRecord[]> {
+    const state = await this.store.load();
+    const project = this.requireProject(state, projectId);
+    return normalizeRecentProjectSkillRecordPaths(
+      getRecentProjectSkillRecords(state.recentProjectSkills, projectId),
+      getProjectSkillRoots(state, project),
+    );
+  }
+
+  async rememberRecentProjectSkill(
+    projectId: string,
+    skillPath: string,
+  ): Promise<RecentProjectSkillRecord[]> {
+    if (!skillPath.trim()) {
+      throw new Error("Skill path is required");
+    }
+
+    let recentSkills: RecentProjectSkillRecord[] = [];
+    const lastUsedAt = createTimestamp();
+    await this.store.update((state) => {
+      const project = this.requireProject(state, projectId);
+      const projectSkillRoots = getProjectSkillRoots(state, project);
+      const normalizedSkillPath = normalizeProjectSkillPath(
+        skillPath,
+        projectSkillRoots,
+      );
+      const normalizedRecordsByProject = {
+        ...state.recentProjectSkills,
+        [projectId]: normalizeRecentProjectSkillRecordPaths(
+          getRecentProjectSkillRecords(state.recentProjectSkills, projectId),
+          projectSkillRoots,
+        ),
+      };
+      const recentProjectSkills = rememberRecentProjectSkillSelection(
+        normalizedRecordsByProject,
+        projectId,
+        normalizedSkillPath,
+        lastUsedAt,
+      );
+      recentSkills = getRecentProjectSkillRecords(
+        recentProjectSkills,
+        projectId,
+      );
+      return {
+        ...state,
+        recentProjectSkills,
+      };
+    });
+
+    return recentSkills;
   }
 
   async listChats(projectId: string): Promise<ChatRecord[]> {
@@ -1824,6 +1886,14 @@ export class ServeServices {
     return normalizeModelRecords(await this.codex.listModels());
   }
 
+  async listProjectSkills(projectId: string): Promise<CodexSkillRecord[]> {
+    const state = await this.store.load();
+    const project = this.requireProject(state, projectId);
+    return normalizeSkillRecords(
+      await this.codex.listSkills([project.rootPath]),
+    );
+  }
+
   async listSkills(chatId: string): Promise<CodexSkillRecord[]> {
     const chat = await this.getChat(chatId);
     return normalizeSkillRecords(
@@ -1865,10 +1935,7 @@ export class ServeServices {
       input.files,
       chat.worktreePath,
     );
-    const skills = await this.normalizeSkillContextItems(
-      input.skills,
-      chat.worktreePath,
-    );
+    const skills = await this.normalizeSkillContextItems(input.skills, chat);
     if (
       !input.effort &&
       !input.model &&
@@ -1976,23 +2043,39 @@ export class ServeServices {
 
   private async normalizeSkillContextItems(
     items: CodexTurnContextItem[] | undefined,
-    worktreePath: string,
+    chat: ChatRecord,
   ): Promise<CodexTurnContextItem[]> {
     const normalized = normalizeTurnContextItems(items);
     if (normalized.length === 0) {
       return [];
     }
 
+    const state = await this.store.load();
+    const project = this.requireProject(state, chat.projectId);
+    const projectSkillRoots = getProjectSkillRoots(state, project);
+    const skillListRoots = getSkillListRoots(chat, project);
     const availableSkills = normalizeSkillRecords(
-      await this.codex.listSkills([worktreePath]),
+      await this.codex.listSkills(skillListRoots),
     );
-    const skillsByPath = new Map(
-      availableSkills
-        .filter((skill) => skill.enabled)
-        .map((skill) => [skill.path, skill]),
-    );
+    const skillsByPath = new Map<string, CodexSkillRecord>();
+    for (const skill of sortSkillsByRootPreference(
+      availableSkills.filter((candidate) => candidate.enabled),
+      skillListRoots,
+    )) {
+      skillsByPath.set(skill.path, skill);
+      const skillIdentity = normalizeProjectSkillPath(
+        skill.path,
+        projectSkillRoots,
+      );
+      if (!skillsByPath.has(skillIdentity)) {
+        skillsByPath.set(skillIdentity, skill);
+      }
+    }
     return normalized.map((item) => {
-      const skill = skillsByPath.get(item.path);
+      const skill =
+        skillsByPath.get(
+          normalizeProjectSkillPath(item.path, projectSkillRoots),
+        ) ?? skillsByPath.get(item.path);
       if (!skill) {
         throw new Error(`Skill context path is not available: ${item.path}`);
       }
@@ -5577,6 +5660,85 @@ function normalizeSkillRecords(value: unknown): CodexSkillRecord[] {
       } satisfies CodexSkillRecord;
     })
     .filter((skill): skill is CodexSkillRecord => Boolean(skill));
+}
+
+function getProjectSkillRoots(
+  state: ServeState,
+  project: ProjectRecord,
+): string[] {
+  return Array.from(
+    new Set([
+      project.rootPath,
+      ...state.chats
+        .filter((chat) => chat.projectId === project.id)
+        .map((chat) => chat.worktreePath),
+    ]),
+  ).sort((left, right) => right.length - left.length);
+}
+
+function getSkillListRoots(chat: ChatRecord, project: ProjectRecord): string[] {
+  return Array.from(new Set([chat.worktreePath, project.rootPath]));
+}
+
+function sortSkillsByRootPreference(
+  skills: CodexSkillRecord[],
+  roots: string[],
+): CodexSkillRecord[] {
+  return [...skills].sort(
+    (left, right) =>
+      getPathRootIndex(left.path, roots) - getPathRootIndex(right.path, roots),
+  );
+}
+
+function getPathRootIndex(path: string, roots: string[]): number {
+  if (!isAbsolute(path)) {
+    return roots.length;
+  }
+  const rootIndex = roots.findIndex((root) => isPathInside(root, path));
+  return rootIndex === -1 ? roots.length : rootIndex;
+}
+
+function normalizeRecentProjectSkillRecordPaths(
+  records: RecentProjectSkillRecord[],
+  projectSkillRoots: string[],
+): RecentProjectSkillRecord[] {
+  const seenSkillPaths = new Set<string>();
+  return records
+    .map((record) => ({
+      ...record,
+      path: normalizeProjectSkillPath(record.path, projectSkillRoots),
+    }))
+    .filter((record) => {
+      if (seenSkillPaths.has(record.path)) {
+        return false;
+      }
+      seenSkillPaths.add(record.path);
+      return true;
+    });
+}
+
+function normalizeProjectSkillPath(
+  skillPath: string,
+  projectSkillRoots: string[],
+): string {
+  const trimmedSkillPath = skillPath.trim();
+  if (!isAbsolute(trimmedSkillPath)) {
+    return trimmedSkillPath;
+  }
+
+  for (const root of projectSkillRoots) {
+    const relativeSkillPath = relative(root, trimmedSkillPath);
+    if (
+      relativeSkillPath &&
+      !relativeSkillPath.startsWith(`..${sep}`) &&
+      relativeSkillPath !== ".." &&
+      !isAbsolute(relativeSkillPath)
+    ) {
+      return relativeSkillPath.split(sep).join("/");
+    }
+  }
+
+  return trimmedSkillPath;
 }
 
 function normalizeFileRecords(value: unknown): CodexFileRecord[] {

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -7,6 +7,7 @@ export type {
   ChatStatus,
   ProjectRecord,
   QueuedMessageRecord,
+  RecentProjectSkillRecord,
   ServeState,
 } from "@phantompane/state";
 

--- a/packages/state/src/index.ts
+++ b/packages/state/src/index.ts
@@ -1,2 +1,3 @@
+export * from "./recent-project-skills.ts";
 export * from "./store.ts";
 export * from "./types.ts";

--- a/packages/state/src/recent-project-skills.test.ts
+++ b/packages/state/src/recent-project-skills.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import {
+  getRecentProjectSkillRecords,
+  rememberRecentProjectSkillSelection,
+} from "./recent-project-skills.ts";
+
+describe("rememberRecentProjectSkillSelection", () => {
+  it("keeps the most recently selected skill first for a project", () => {
+    expect(
+      rememberRecentProjectSkillSelection(
+        {
+          "project-1": [
+            {
+              path: "/skills/review/SKILL.md",
+              lastUsedAt: "2026-05-08T00:00:00.000Z",
+            },
+          ],
+        },
+        "project-1",
+        "/skills/test/SKILL.md",
+        "2026-05-08T01:00:00.000Z",
+      ),
+    ).toEqual({
+      "project-1": [
+        {
+          path: "/skills/test/SKILL.md",
+          lastUsedAt: "2026-05-08T01:00:00.000Z",
+        },
+        {
+          path: "/skills/review/SKILL.md",
+          lastUsedAt: "2026-05-08T00:00:00.000Z",
+        },
+      ],
+    });
+  });
+
+  it("updates an existing skill instead of duplicating it", () => {
+    expect(
+      rememberRecentProjectSkillSelection(
+        {
+          "project-1": [
+            {
+              path: "/skills/review/SKILL.md",
+              lastUsedAt: "2026-05-08T00:00:00.000Z",
+            },
+            {
+              path: "/skills/test/SKILL.md",
+              lastUsedAt: "2026-05-08T00:30:00.000Z",
+            },
+          ],
+        },
+        "project-1",
+        "/skills/review/SKILL.md",
+        "2026-05-08T01:00:00.000Z",
+      ),
+    ).toEqual({
+      "project-1": [
+        {
+          path: "/skills/review/SKILL.md",
+          lastUsedAt: "2026-05-08T01:00:00.000Z",
+        },
+        {
+          path: "/skills/test/SKILL.md",
+          lastUsedAt: "2026-05-08T00:30:00.000Z",
+        },
+      ],
+    });
+  });
+
+  it("limits records per project without touching other projects", () => {
+    expect(
+      rememberRecentProjectSkillSelection(
+        {
+          "project-1": [
+            {
+              path: "/skills/a/SKILL.md",
+              lastUsedAt: "2026-05-08T00:04:00.000Z",
+            },
+            {
+              path: "/skills/b/SKILL.md",
+              lastUsedAt: "2026-05-08T00:03:00.000Z",
+            },
+          ],
+          "project-2": [
+            {
+              path: "/skills/other/SKILL.md",
+              lastUsedAt: "2026-05-08T00:00:00.000Z",
+            },
+          ],
+        },
+        "project-1",
+        "/skills/c/SKILL.md",
+        "2026-05-08T00:05:00.000Z",
+        2,
+      ),
+    ).toEqual({
+      "project-1": [
+        {
+          path: "/skills/c/SKILL.md",
+          lastUsedAt: "2026-05-08T00:05:00.000Z",
+        },
+        {
+          path: "/skills/a/SKILL.md",
+          lastUsedAt: "2026-05-08T00:04:00.000Z",
+        },
+      ],
+      "project-2": [
+        {
+          path: "/skills/other/SKILL.md",
+          lastUsedAt: "2026-05-08T00:00:00.000Z",
+        },
+      ],
+    });
+  });
+});
+
+describe("getRecentProjectSkillRecords", () => {
+  it("returns records for the selected project only", () => {
+    expect(
+      getRecentProjectSkillRecords(
+        {
+          "project-1": [
+            {
+              path: "/skills/review/SKILL.md",
+              lastUsedAt: "2026-05-08T00:00:00.000Z",
+            },
+          ],
+          "project-2": [
+            {
+              path: "/skills/test/SKILL.md",
+              lastUsedAt: "2026-05-08T01:00:00.000Z",
+            },
+          ],
+        },
+        "project-1",
+      ),
+    ).toEqual([
+      {
+        path: "/skills/review/SKILL.md",
+        lastUsedAt: "2026-05-08T00:00:00.000Z",
+      },
+    ]);
+  });
+});

--- a/packages/state/src/recent-project-skills.ts
+++ b/packages/state/src/recent-project-skills.ts
@@ -1,0 +1,35 @@
+import type {
+  RecentProjectSkillRecord,
+  RecentProjectSkillsByProject,
+} from "./types.ts";
+
+export const maxRecentProjectSkillsPerProject = 5;
+
+export function rememberRecentProjectSkillSelection(
+  recordsByProject: RecentProjectSkillsByProject,
+  projectId: string,
+  skillPath: string,
+  lastUsedAt = new Date().toISOString(),
+  limit = maxRecentProjectSkillsPerProject,
+): RecentProjectSkillsByProject {
+  const nextProjectRecords = [
+    { path: skillPath, lastUsedAt },
+    ...(recordsByProject[projectId] ?? []).filter(
+      (record) => record.path !== skillPath,
+    ),
+  ]
+    .sort((left, right) => right.lastUsedAt.localeCompare(left.lastUsedAt))
+    .slice(0, Math.max(0, limit));
+
+  return {
+    ...recordsByProject,
+    [projectId]: nextProjectRecords,
+  };
+}
+
+export function getRecentProjectSkillRecords(
+  recordsByProject: RecentProjectSkillsByProject,
+  projectId: string,
+): RecentProjectSkillRecord[] {
+  return recordsByProject[projectId] ?? [];
+}

--- a/packages/state/src/store.test.ts
+++ b/packages/state/src/store.test.ts
@@ -29,6 +29,7 @@ function createTestState(overrides: Partial<ServeState> = {}): ServeState {
     chats: [],
     messages: [],
     queuedMessages: [],
+    recentProjectSkills: {},
     selectedProjectId: null,
     selectedChatId: null,
     ...overrides,
@@ -231,6 +232,7 @@ describe("ServeStateStore", () => {
     strictEqual(savedState.projects[0]?.customProjectField, "project metadata");
     strictEqual(savedState.chats[0]?.customChatField, "chat metadata");
     strictEqual(savedState.messages[0]?.customMessageField, "message metadata");
+    deepStrictEqual(savedState.recentProjectSkills, {});
     strictEqual(savedState.customTopLevelField, "state metadata");
   });
 

--- a/packages/state/src/store.ts
+++ b/packages/state/src/store.ts
@@ -2,7 +2,11 @@ import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, isAbsolute, join } from "node:path";
 import { serveStateSchema } from "./types.ts";
-import type { ProjectRecord, ServeState } from "./types.ts";
+import type {
+  ProjectRecord,
+  RecentProjectSkillsByProject,
+  ServeState,
+} from "./types.ts";
 
 const STATE_FILE_NAME = "state.json";
 
@@ -17,6 +21,7 @@ function createEmptyState(): ServeState {
     chats: [],
     messages: [],
     queuedMessages: [],
+    recentProjectSkills: {},
     selectedProjectId: null,
     selectedChatId: null,
   };
@@ -119,6 +124,9 @@ export class ServeStateStore {
         chats: [...state.chats],
         messages: [...state.messages],
         queuedMessages: [...state.queuedMessages],
+        recentProjectSkills: cloneRecentProjectSkills(
+          state.recentProjectSkills,
+        ),
       });
       await this.save(nextState);
       return nextState;
@@ -126,6 +134,17 @@ export class ServeStateStore {
     this.updateChain = nextUpdate.catch(() => undefined);
     return nextUpdate;
   }
+}
+
+function cloneRecentProjectSkills(
+  recordsByProject: RecentProjectSkillsByProject,
+): RecentProjectSkillsByProject {
+  return Object.fromEntries(
+    Object.entries(recordsByProject).map(([projectId, records]) => [
+      projectId,
+      [...records],
+    ]),
+  );
 }
 
 export function touchProject(project: ProjectRecord): ProjectRecord {

--- a/packages/state/src/types.ts
+++ b/packages/state/src/types.ts
@@ -41,6 +41,15 @@ const turnContextItemBaseSchema = z.object({
   path: z.string(),
 });
 
+const recentProjectSkillRecordBaseSchema = z.object({
+  path: z.string(),
+  lastUsedAt: z.string(),
+});
+
+const recentProjectSkillsByProjectBaseSchema = z
+  .record(z.string(), z.array(recentProjectSkillRecordBaseSchema))
+  .default({});
+
 const queuedMessageRecordBaseSchema = z.object({
   id: z.string(),
   chatId: z.string(),
@@ -82,6 +91,7 @@ const serveStateBaseSchema = z.object({
   chats: z.array(chatRecordBaseSchema),
   messages: z.array(chatMessageRecordBaseSchema),
   queuedMessages: z.array(queuedMessageRecordBaseSchema).default([]),
+  recentProjectSkills: recentProjectSkillsByProjectBaseSchema,
   selectedProjectId: nullableStringFromUnknownSchema,
   selectedChatId: nullableStringFromUnknownSchema,
 });
@@ -93,6 +103,12 @@ export type ChatAttachmentRecord = z.infer<
 export type ProjectRecord = z.infer<typeof projectRecordBaseSchema>;
 export type ChatMessageRecord = z.infer<typeof chatMessageRecordBaseSchema>;
 export type QueuedMessageRecord = z.infer<typeof queuedMessageRecordBaseSchema>;
+export type RecentProjectSkillRecord = z.infer<
+  typeof recentProjectSkillRecordBaseSchema
+>;
+export type RecentProjectSkillsByProject = z.infer<
+  typeof recentProjectSkillsByProjectBaseSchema
+>;
 export type ChatRecord = z.infer<typeof chatRecordBaseSchema>;
 export type ServeState = z.infer<typeof serveStateBaseSchema>;
 
@@ -102,6 +118,8 @@ export const chatMessageRecordSchema: z.ZodType<ChatMessageRecord> =
   chatMessageRecordBaseSchema.passthrough();
 export const queuedMessageRecordSchema: z.ZodType<QueuedMessageRecord> =
   queuedMessageRecordBaseSchema.passthrough();
+export const recentProjectSkillRecordSchema: z.ZodType<RecentProjectSkillRecord> =
+  recentProjectSkillRecordBaseSchema.passthrough();
 export const chatRecordSchema: z.ZodType<ChatRecord> =
   chatRecordBaseSchema.passthrough();
 export const serveStateSchema: z.ZodType<ServeState> = z
@@ -111,6 +129,9 @@ export const serveStateSchema: z.ZodType<ServeState> = z
     chats: z.array(chatRecordSchema),
     messages: z.array(chatMessageRecordSchema),
     queuedMessages: z.array(queuedMessageRecordSchema).default([]),
+    recentProjectSkills: z
+      .record(z.string(), z.array(recentProjectSkillRecordSchema))
+      .default({}),
     selectedProjectId: nullableStringFromUnknownSchema,
     selectedChatId: nullableStringFromUnknownSchema,
   })

--- a/packages/web/src/api/mutations.test.ts
+++ b/packages/web/src/api/mutations.test.ts
@@ -7,6 +7,7 @@ import {
   deleteProjectMutation,
   deletePendingMessageMutation,
   queueMessageMutation,
+  rememberProjectSkillMutation,
   restorePendingMessageMutation,
   steerMessageMutation,
 } from "./mutations";
@@ -138,6 +139,42 @@ describe("deleteProjectMutation", () => {
 
     strictEqual(requestMethod, "DELETE");
     strictEqual(requestUrl, "/api/projects/proj%2Fwith%23hash");
+  });
+});
+
+describe("rememberProjectSkillMutation", () => {
+  it("encodes project route params and sends the skill path", async () => {
+    let requestBody: string | undefined;
+    let requestUrl: string | undefined;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        requestBody = init?.body?.toString();
+        requestUrl =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+        return new Response('{"recentSkills":[]}', {
+          headers: {
+            "Content-Type": "application/json",
+          },
+          status: 200,
+        });
+      }),
+    );
+
+    await rememberProjectSkillMutation(
+      "proj/with#hash",
+      "/skills/review/SKILL.md",
+    );
+
+    strictEqual(requestUrl, "/api/projects/proj%2Fwith%23hash/recent-skills");
+    strictEqual(
+      requestBody,
+      JSON.stringify({ path: "/skills/review/SKILL.md" }),
+    );
   });
 });
 

--- a/packages/web/src/api/mutations.ts
+++ b/packages/web/src/api/mutations.ts
@@ -7,6 +7,7 @@ import type {
   CodexTurnContextItem,
   ProjectRecord,
   QueuedMessageRecord,
+  RecentProjectSkillRecord,
 } from "@phantompane/server";
 
 export interface DeleteWorktreeInput {
@@ -112,6 +113,18 @@ export async function syncWorktreeMutation(
     await api.projects[":projectId"].worktrees.sync.$post({
       param: { projectId: routeParam(projectId) },
       json: input,
+    }),
+  );
+}
+
+export async function rememberProjectSkillMutation(
+  projectId: string,
+  path: string,
+) {
+  return readRpcJson<{ recentSkills: RecentProjectSkillRecord[] }>(
+    await api.projects[":projectId"]["recent-skills"].$post({
+      param: { projectId: routeParam(projectId) },
+      json: { path },
     }),
   );
 }

--- a/packages/web/src/api/queries.ts
+++ b/packages/web/src/api/queries.ts
@@ -10,6 +10,7 @@ import type {
   PendingApprovalRecord,
   ProjectRecord,
   ProjectWorktreeRecord,
+  RecentProjectSkillRecord,
   RenderedChatMessageRecord,
 } from "@phantompane/server";
 
@@ -68,6 +69,46 @@ export function projectGitHubCheckoutTargetsQueryOptions(projectId: string) {
         await api.projects[":projectId"].github["checkout-targets"].$get({
           param: { projectId: routeParam(projectId) },
         }),
+      ),
+  });
+}
+
+export function projectRecentSkillsQueryOptions(
+  projectId: string,
+  signal?: AbortSignal,
+) {
+  return queryOptions({
+    queryKey: queryKeys.projectRecentSkills(projectId),
+    queryFn: async () =>
+      readRpcJson<{ recentSkills: RecentProjectSkillRecord[] }>(
+        await api.projects[":projectId"]["recent-skills"].$get(
+          {
+            param: { projectId: routeParam(projectId) },
+          },
+          {
+            init: { signal },
+          },
+        ),
+      ),
+  });
+}
+
+export function projectSkillsQueryOptions(
+  projectId: string,
+  signal?: AbortSignal,
+) {
+  return queryOptions({
+    queryKey: queryKeys.projectSkills(projectId),
+    queryFn: async () =>
+      readRpcJson<{ skills: CodexSkillRecord[] }>(
+        await api.projects[":projectId"].skills.$get(
+          {
+            param: { projectId: routeParam(projectId) },
+          },
+          {
+            init: { signal },
+          },
+        ),
       ),
   });
 }

--- a/packages/web/src/api/query-keys.ts
+++ b/packages/web/src/api/query-keys.ts
@@ -6,6 +6,10 @@ export const queryKeys = {
     ["projects", projectId, "chats"] as const,
   projectGitHubCheckoutTargets: (projectId: string) =>
     ["projects", projectId, "github", "checkout-targets"] as const,
+  projectRecentSkills: (projectId: string) =>
+    ["projects", projectId, "recent-skills"] as const,
+  projectSkills: (projectId: string) =>
+    ["projects", projectId, "skills"] as const,
   projectWorktrees: (projectId: string) =>
     ["projects", projectId, "worktrees"] as const,
   chat: (chatId: string) => ["chats", chatId] as const,

--- a/packages/web/src/lib/project-skill-path.test.ts
+++ b/packages/web/src/lib/project-skill-path.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { getProjectSkillPathIdentity } from "./project-skill-path";
+
+describe("getProjectSkillPathIdentity", () => {
+  it("normalizes project-local skill paths relative to the active root", () => {
+    expect(
+      getProjectSkillPathIdentity(
+        "/repo/.git/phantom/worktrees/feature/.codex/skills/review/SKILL.md",
+        ["/repo", "/repo/.git/phantom/worktrees/feature"],
+      ),
+    ).toBe(".codex/skills/review/SKILL.md");
+  });
+
+  it("leaves external skill paths stable", () => {
+    expect(
+      getProjectSkillPathIdentity("/home/user/.codex/skills/review/SKILL.md", [
+        "/repo",
+      ]),
+    ).toBe("/home/user/.codex/skills/review/SKILL.md");
+  });
+});

--- a/packages/web/src/lib/project-skill-path.ts
+++ b/packages/web/src/lib/project-skill-path.ts
@@ -1,0 +1,22 @@
+export function getProjectSkillPathIdentity(
+  skillPath: string,
+  projectRoots: readonly string[],
+): string {
+  const normalizedSkillPath = normalizeSlashPath(skillPath.trim());
+  for (const root of [...projectRoots].sort(
+    (left, right) => right.length - left.length,
+  )) {
+    const normalizedRoot = normalizeSlashPath(root);
+    const rootPrefix = normalizedRoot.endsWith("/")
+      ? normalizedRoot
+      : `${normalizedRoot}/`;
+    if (normalizedSkillPath.startsWith(rootPrefix)) {
+      return normalizedSkillPath.slice(rootPrefix.length);
+    }
+  }
+  return normalizedSkillPath;
+}
+
+function normalizeSlashPath(path: string): string {
+  return path.replaceAll("\\", "/");
+}

--- a/packages/web/src/routes/home.tsx
+++ b/packages/web/src/routes/home.tsx
@@ -53,6 +53,7 @@ import {
   deleteWorktreeMutation,
   interruptChatMutation,
   queueMessageMutation,
+  rememberProjectSkillMutation,
   restorePendingMessageMutation,
   sendMessageMutation,
   steerMessageMutation,
@@ -70,6 +71,8 @@ import {
   modelsQueryOptions,
   projectChatsQueryOptions,
   projectGitHubCheckoutTargetsQueryOptions,
+  projectRecentSkillsQueryOptions,
+  projectSkillsQueryOptions,
   projectWorktreesQueryOptions,
   projectsQueryOptions,
 } from "../api/queries";
@@ -132,6 +135,7 @@ import {
   getComposerSubmitModeForEnter,
   type ComposerSubmitMode,
 } from "../lib/composer-keyboard";
+import { getProjectSkillPathIdentity } from "../lib/project-skill-path";
 import { cn } from "../lib/utils";
 import {
   dedupeChatThreads,
@@ -173,6 +177,7 @@ import type {
   PhantomEvent,
   ProjectWorktreeRecord,
   ProjectRecord,
+  RecentProjectSkillRecord,
   RenderedChatMessageRecord,
 } from "@phantompane/server";
 
@@ -200,6 +205,7 @@ const chatEventNames = [
 ];
 const chatScrollStorageKeyPrefix = "phantom.chatScroll:v1:";
 const chatScrollBottomThreshold = 4;
+const maxVisibleRecentSkillSuggestions = 5;
 const searchParamKeys = {
   chat: "chat",
   effort: "effort",
@@ -620,6 +626,9 @@ export function HomeRoute() {
   const [selectedSkillPaths, setSelectedSkillPaths] = useState<Set<string>>(
     () => new Set(),
   );
+  const [recentProjectSkills, setRecentProjectSkills] = useState<
+    RecentProjectSkillRecord[]
+  >([]);
   const [transientFileSearchQuery, setTransientFileSearchQuery] =
     useState<TransientFileSearchQuery | null>(null);
   const fileSearchQuery =
@@ -629,6 +638,12 @@ export function HomeRoute() {
       : "");
   const fileSearchQueryRef = useRef(fileSearchQuery);
   const fileSearchRequestIdRef = useRef(0);
+  const recentProjectSkillsRequestIdsRef = useRef<Map<string, number>>(
+    new Map(),
+  );
+  const recentProjectSkillRememberChainsRef = useRef<
+    Map<string, Promise<void>>
+  >(new Map());
   const approvalRefreshRequestIdRef = useRef(0);
   const approvalEventVersionRef = useRef(0);
   const [fileSearchResults, setFileSearchResults] = useState<CodexFileRecord[]>(
@@ -963,6 +978,23 @@ export function HomeRoute() {
     });
   }
 
+  function createRecentProjectSkillsRequestId(projectId: string): number {
+    const requestId =
+      (recentProjectSkillsRequestIdsRef.current.get(projectId) ?? 0) + 1;
+    recentProjectSkillsRequestIdsRef.current.set(projectId, requestId);
+    return requestId;
+  }
+
+  function isCurrentRecentProjectSkillsRequest(
+    projectId: string,
+    requestId: number,
+  ): boolean {
+    return (
+      selectedProjectIdRef.current === projectId &&
+      recentProjectSkillsRequestIdsRef.current.get(projectId) === requestId
+    );
+  }
+
   function getCurrentUrlWorkspaceSelectionKey(): string {
     const currentSearchParams = searchParamsRef.current;
     return getWorkspaceSelectionKey(
@@ -1090,6 +1122,8 @@ export function HomeRoute() {
   const canInterruptActiveTurn =
     hasActiveTurn && !isInterrupting && Boolean(selectedChat?.activeTurnId);
   const areComposerOptionsDisabled = !hasSelectedChat || isComposerBlocked;
+  const canSelectProjectComposerContext =
+    Boolean(selectedProject) && !isComposerBlocked;
   const primaryComposerActionLabel =
     formatComposerModeAction(primaryComposerMode);
   const primaryComposerButtonLabel =
@@ -1136,6 +1170,37 @@ export function HomeRoute() {
         })),
     [selectedSkillPaths, skills],
   );
+  const projectSkillRoots = useMemo(
+    () =>
+      [selectedProject?.rootPath ?? null, selectedChat?.worktreePath ?? null]
+        .filter((root): root is string => Boolean(root))
+        .sort((left, right) => right.length - left.length),
+    [selectedChat?.worktreePath, selectedProject?.rootPath],
+  );
+  const recentSkillSuggestions = useMemo(() => {
+    const enabledSkillsByPath = new Map<string, CodexSkillRecord>();
+    for (const skill of skills.filter(
+      (candidate) =>
+        candidate.enabled && !selectedSkillPaths.has(candidate.path),
+    )) {
+      enabledSkillsByPath.set(skill.path, skill);
+      enabledSkillsByPath.set(
+        getProjectSkillPathIdentity(skill.path, projectSkillRoots),
+        skill,
+      );
+    }
+    return recentProjectSkills
+      .map(
+        (recentSkill) =>
+          enabledSkillsByPath.get(recentSkill.path) ??
+          enabledSkillsByPath.get(
+            getProjectSkillPathIdentity(recentSkill.path, projectSkillRoots),
+          ) ??
+          null,
+      )
+      .filter((skill): skill is CodexSkillRecord => Boolean(skill))
+      .slice(0, maxVisibleRecentSkillSuggestions);
+  }, [projectSkillRoots, recentProjectSkills, selectedSkillPaths, skills]);
 
   const fileOptions = useMemo<ComboboxOption[]>(
     () =>
@@ -1325,14 +1390,24 @@ export function HomeRoute() {
 
   useEffect(() => {
     if (!selectedProjectId) {
+      setRecentProjectSkills([]);
       return;
     }
+    const recentSkillsController = new AbortController();
+    void refreshRecentProjectSkills(
+      selectedProjectId,
+      recentSkillsController.signal,
+    );
     void refreshWorktrees(selectedProjectId, {
       updateSelection: isSelectedChatValidated,
     });
     void refreshChats(selectedProjectId, {
       updateSelection: isSelectedChatValidated,
     });
+
+    return () => {
+      recentSkillsController.abort();
+    };
   }, [isSelectedChatValidated, selectedProjectId]);
 
   useEffect(() => {
@@ -1403,9 +1478,19 @@ export function HomeRoute() {
       setFileSearchResults([]);
       setSkills([]);
       setIsMessagesLoading(false);
-      setIsChatContextLoading(false);
       setIsFileSearchLoading(false);
-      return;
+      if (!selectedProjectId) {
+        setIsChatContextLoading(false);
+        return;
+      }
+      const projectSkillsController = new AbortController();
+      void refreshProjectSkills(
+        selectedProjectId,
+        projectSkillsController.signal,
+      );
+      return () => {
+        projectSkillsController.abort();
+      };
     }
 
     setSelectedFiles([]);
@@ -1831,6 +1916,75 @@ export function HomeRoute() {
     }
   }
 
+  async function refreshRecentProjectSkills(
+    projectId: string,
+    signal?: AbortSignal,
+  ) {
+    const requestId = createRecentProjectSkillsRequestId(projectId);
+    try {
+      const data = await queryClient.fetchQuery(
+        projectRecentSkillsQueryOptions(projectId, signal),
+      );
+      if (
+        signal?.aborted ||
+        !isCurrentRecentProjectSkillsRequest(projectId, requestId)
+      ) {
+        return;
+      }
+      setRecentProjectSkills(data.recentSkills);
+    } catch (err) {
+      if (
+        signal?.aborted ||
+        (err instanceof Error && err.name === "AbortError")
+      ) {
+        return;
+      }
+      if (!isCurrentRecentProjectSkillsRequest(projectId, requestId)) {
+        return;
+      }
+      setComposerError(formatErrorMessage("Could not load recent skills", err));
+    }
+  }
+
+  async function refreshProjectSkills(projectId: string, signal?: AbortSignal) {
+    setIsChatContextLoading(true);
+    try {
+      const data = await queryClient.fetchQuery(
+        projectSkillsQueryOptions(projectId, signal),
+      );
+      if (
+        signal?.aborted ||
+        selectedProjectIdRef.current !== projectId ||
+        selectedChatIdRef.current
+      ) {
+        return;
+      }
+      setSkills(data.skills);
+    } catch (err) {
+      if (
+        signal?.aborted ||
+        (err instanceof Error && err.name === "AbortError")
+      ) {
+        return;
+      }
+      if (
+        selectedProjectIdRef.current !== projectId ||
+        selectedChatIdRef.current
+      ) {
+        return;
+      }
+      setComposerError(formatErrorMessage("Could not load skills", err));
+    } finally {
+      if (
+        !signal?.aborted &&
+        selectedProjectIdRef.current === projectId &&
+        !selectedChatIdRef.current
+      ) {
+        setIsChatContextLoading(false);
+      }
+    }
+  }
+
   async function refreshChatContext(chatId: string, signal?: AbortSignal) {
     setIsChatContextLoading(true);
     try {
@@ -2246,6 +2400,8 @@ export function HomeRoute() {
         setTransientFileSearchQuery(null);
         setFileSearchResults([]);
         setSkills([]);
+        createRecentProjectSkillsRequestId(projectId);
+        setRecentProjectSkills([]);
         updatePendingApproval(null);
         restoredPendingComposerContextRef.current = null;
       }
@@ -2647,6 +2803,7 @@ export function HomeRoute() {
     input: SendMessageInput,
     composerInput: string,
     composerAttachments: SelectedAttachment[],
+    composerSkillPaths: Set<string>,
     requestWorkspaceSelectionKey: string,
     githubTargetNumber: number | null,
   ) {
@@ -2674,6 +2831,7 @@ export function HomeRoute() {
         if (isRequestWorkspaceSelected()) {
           setComposerText(composerInput);
           setSelectedAttachments(composerAttachments);
+          setSelectedSkillPaths(new Set(composerSkillPaths));
         }
         return;
       }
@@ -2711,6 +2869,7 @@ export function HomeRoute() {
       ) {
         setComposerText(composerInput);
         setSelectedAttachments(composerAttachments);
+        setSelectedSkillPaths(new Set(composerSkillPaths));
         setComposerError(formatErrorMessage("Could not send message", err));
       }
     } finally {
@@ -2748,6 +2907,7 @@ export function HomeRoute() {
       sendMessageRequestIdRef.current === requestId;
     const composerInput = composerText;
     const composerAttachments = selectedAttachments;
+    const composerSkillPaths = new Set(selectedSkillPaths);
     const text =
       composerInput.trim().length > 0
         ? composerInput
@@ -2777,6 +2937,7 @@ export function HomeRoute() {
         messageInput,
         composerInput,
         composerAttachments,
+        composerSkillPaths,
         workspaceSelectionKeyRef.current,
         selectedGitHubTarget?.number ?? null,
       );
@@ -3175,7 +3336,56 @@ export function HomeRoute() {
   }
 
   function selectSkill(path: string) {
+    const selectedSkill = skills.find(
+      (skill) => skill.enabled && skill.path === path,
+    );
+    if (!selectedSkill) {
+      return;
+    }
+
     setSelectedSkillPaths((current) => new Set(current).add(path));
+    if (!selectedProjectId) {
+      return;
+    }
+    void rememberSelectedProjectSkill(selectedProjectId, path);
+  }
+
+  function rememberSelectedProjectSkill(projectId: string, path: string) {
+    const previousRemember =
+      recentProjectSkillRememberChainsRef.current.get(projectId) ??
+      Promise.resolve();
+    const nextRemember = previousRemember
+      .catch(() => undefined)
+      .then(async () => {
+        createRecentProjectSkillsRequestId(projectId);
+        try {
+          const data = await rememberProjectSkillMutation(projectId, path);
+          queryClient.setQueryData(
+            queryKeys.projectRecentSkills(projectId),
+            data,
+          );
+          if (selectedProjectIdRef.current === projectId) {
+            createRecentProjectSkillsRequestId(projectId);
+            setRecentProjectSkills(data.recentSkills);
+          }
+        } catch (err) {
+          if (selectedProjectIdRef.current === projectId) {
+            setComposerError(
+              formatErrorMessage("Could not remember skill", err),
+            );
+          }
+        }
+      });
+
+    recentProjectSkillRememberChainsRef.current.set(projectId, nextRemember);
+    void nextRemember.finally(() => {
+      if (
+        recentProjectSkillRememberChainsRef.current.get(projectId) ===
+        nextRemember
+      ) {
+        recentProjectSkillRememberChainsRef.current.delete(projectId);
+      }
+    });
   }
 
   const visiblePendingApproval =
@@ -4082,6 +4292,30 @@ export function HomeRoute() {
                     onDismiss={() => setModelError(null)}
                   />
                 )}
+                {canSelectProjectComposerContext &&
+                  !isChatContextLoading &&
+                  recentSkillSuggestions.length > 0 && (
+                    <div className="flex min-h-8 flex-wrap items-center gap-2 px-1">
+                      <span className="text-[length:var(--font-size-xs)] font-medium text-[var(--text-tertiary)]">
+                        Recent skills
+                      </span>
+                      {recentSkillSuggestions.map((skill) => (
+                        <button
+                          aria-label={`Select ${skill.displayName}`}
+                          className="inline-flex h-8 max-w-48 items-center gap-1.5 rounded-[var(--radius-sm)] border border-[var(--border-divider)] bg-[var(--surface-input)] px-2 text-[length:var(--font-size-sm)] text-[var(--text-secondary)] outline-none transition-colors hover:bg-[var(--state-hover-bg)] hover:text-[var(--text-primary)] focus-visible:shadow-[var(--state-focus-ring)]"
+                          key={skill.path}
+                          onClick={() => selectSkill(skill.path)}
+                          title={skill.displayName}
+                          type="button"
+                        >
+                          <Sparkles className="size-3.5 shrink-0" />
+                          <span className="min-w-0 truncate">
+                            {skill.displayName}
+                          </span>
+                        </button>
+                      ))}
+                    </div>
+                  )}
                 {(selectedAttachments.length > 0 ||
                   selectedFiles.length > 0 ||
                   selectedSkills.length > 0) && (


### PR DESCRIPTION
## Summary

- Persist recently selected skills per project in Phantom Serve state instead of browser localStorage.
- Add project-level recent skill RPC endpoints and web API helpers.
- Show enabled recent skill suggestions above the chat composer and refresh them after explicit skill selection.

## Impact

Users can quickly reselect skills they explicitly chose before, with the history scoped to the current project and shared across browsers using the same serve data directory.

## Validation

- `pnpm ready`