### PR TITLE
[codex] Fix duplicate chat history

### DIFF
--- a/packages/server/src/services.test.ts
+++ b/packages/server/src/services.test.ts
@@ -1850,6 +1850,766 @@ describe("ServeServices", () => {
     );
   });
 
+  it("uses the persisted local timeline when Codex history repeats it", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "idle", activeTurnId: null })],
+      messages: [
+        {
+          id: "msg_user_1",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "initial request",
+          createdAt: "2026-05-08T00:45:00.000Z",
+        },
+        {
+          id: "msg_event",
+          chatId: "chat_1",
+          role: "event" as const,
+          text: "item/started: agentMessage",
+          eventType: "item/started",
+          createdAt: "2026-05-08T00:45:01.000Z",
+        },
+        {
+          id: "msg_assistant_1",
+          chatId: "chat_1",
+          role: "assistant" as const,
+          text: "first update",
+          eventType: "item/agentMessage/delta",
+          itemId: "local_agent_1",
+          createdAt: "2026-05-08T00:45:02.000Z",
+        },
+        {
+          id: "msg_user_2",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "follow up",
+          itemId: "turn_1",
+          createdAt: "2026-05-08T00:46:00.000Z",
+        },
+        {
+          id: "msg_assistant_2",
+          chatId: "chat_1",
+          role: "assistant" as const,
+          text: "second update",
+          eventType: "item/agentMessage/delta",
+          itemId: "local_agent_2",
+          createdAt: "2026-05-08T00:46:02.000Z",
+        },
+      ],
+    };
+    const { codex, services } = await createHarness(state);
+    codex.readThread.mockResolvedValueOnce({
+      thread: {
+        turns: [
+          {
+            id: "turn_1",
+            items: [
+              { id: "item-1", type: "userMessage", text: "initial request" },
+              { id: "item-2", type: "agentMessage", text: "first update" },
+              { id: "item-3", type: "userMessage", text: "follow up" },
+              { id: "item-4", type: "agentMessage", text: "second update" },
+            ],
+          },
+        ],
+      },
+    });
+
+    const messages = await services.getMessages("chat_1");
+
+    deepStrictEqual(
+      messages.map((message) => [
+        message.id,
+        message.role,
+        message.text,
+        message.eventType,
+      ]),
+      [
+        ["msg_user_1", "user", "initial request", undefined],
+        ["msg_event", "event", "item/started: agentMessage", "item/started"],
+        [
+          "msg_assistant_1",
+          "assistant",
+          "first update",
+          "item/agentMessage/delta",
+        ],
+        ["msg_user_2", "user", "follow up", undefined],
+        [
+          "msg_assistant_2",
+          "assistant",
+          "second update",
+          "item/agentMessage/delta",
+        ],
+      ],
+    );
+  });
+
+  it("drops repeated Codex history before merging newer Codex messages", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "idle", activeTurnId: null })],
+      messages: [
+        {
+          id: "msg_user_1",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "initial request",
+          createdAt: "2026-05-08T00:45:00.000Z",
+        },
+        {
+          id: "msg_assistant_1",
+          chatId: "chat_1",
+          role: "assistant" as const,
+          text: "first update",
+          eventType: "item/agentMessage/delta",
+          itemId: "local_agent_1",
+          createdAt: "2026-05-08T00:45:02.000Z",
+        },
+        {
+          id: "msg_user_2",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "follow up",
+          itemId: "turn_1",
+          createdAt: "2026-05-08T00:46:00.000Z",
+        },
+        {
+          id: "msg_assistant_2",
+          chatId: "chat_1",
+          role: "assistant" as const,
+          text: "second update",
+          eventType: "item/agentMessage/delta",
+          itemId: "local_agent_2",
+          createdAt: "2026-05-08T00:46:02.000Z",
+        },
+        {
+          id: "msg_queued",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "queued next",
+          eventType: "chat.message.queued",
+          createdAt: "2026-05-08T00:47:00.000Z",
+        },
+      ],
+    };
+    const { codex, services } = await createHarness(state);
+    codex.readThread.mockResolvedValueOnce({
+      thread: {
+        turns: [
+          {
+            id: "turn_1",
+            items: [
+              { id: "item-1", type: "userMessage", text: "initial request" },
+              { id: "item-2", type: "agentMessage", text: "first update" },
+              { id: "item-3", type: "userMessage", text: "follow up" },
+              { id: "item-4", type: "agentMessage", text: "second update" },
+              { id: "item-5", type: "agentMessage", text: "newer update" },
+            ],
+          },
+        ],
+      },
+    });
+
+    const messages = await services.getMessages("chat_1");
+
+    deepStrictEqual(
+      messages.map((message) => [
+        message.role,
+        message.text,
+        message.eventType,
+      ]),
+      [
+        ["user", "initial request", undefined],
+        ["assistant", "first update", "item/agentMessage/delta"],
+        ["user", "follow up", undefined],
+        ["assistant", "second update", "item/agentMessage/delta"],
+        ["assistant", "newer update", undefined],
+        ["user", "queued next", "chat.message.queued"],
+      ],
+    );
+  });
+
+  it("drops a single completed exchange before a newer fallback Codex message", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "idle", activeTurnId: null })],
+      messages: [
+        {
+          id: "msg_user_1",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "initial request",
+          createdAt: "2026-05-08T00:45:00.000Z",
+        },
+        {
+          id: "msg_assistant_1",
+          chatId: "chat_1",
+          role: "assistant" as const,
+          text: "first update",
+          eventType: "item/agentMessage/delta",
+          itemId: "local_agent_1",
+          createdAt: "2026-05-08T00:45:02.000Z",
+        },
+      ],
+    };
+    const { codex, services } = await createHarness(state);
+    codex.readThread.mockResolvedValueOnce({
+      thread: {
+        turns: [
+          {
+            id: "turn_1",
+            items: [
+              { id: "item-1", type: "userMessage", text: "initial request" },
+              { id: "item-2", type: "agentMessage", text: "first update" },
+              { id: "item-3", type: "agentMessage", text: "newer update" },
+            ],
+          },
+        ],
+      },
+    });
+
+    const messages = await services.getMessages("chat_1");
+
+    deepStrictEqual(
+      messages.map((message) => [
+        message.id,
+        message.role,
+        message.text,
+        message.eventType,
+      ]),
+      [
+        ["msg_user_1", "user", "initial request", undefined],
+        [
+          "msg_assistant_1",
+          "assistant",
+          "first update",
+          "item/agentMessage/delta",
+        ],
+        ["chat_1_codex_turn_1_2", "assistant", "newer update", undefined],
+      ],
+    );
+  });
+
+  it("does not skip intervening local transcript messages when dropping fallback prefixes", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "idle", activeTurnId: null })],
+      messages: [
+        {
+          id: "msg_user_1",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "initial request",
+          createdAt: "2026-05-08T00:45:00.000Z",
+        },
+        {
+          id: "msg_local_only",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "local-only follow up",
+          createdAt: "2026-05-08T00:45:01.000Z",
+        },
+        {
+          id: "msg_assistant_1",
+          chatId: "chat_1",
+          role: "assistant" as const,
+          text: "first update",
+          eventType: "item/agentMessage/delta",
+          itemId: "local_agent_1",
+          createdAt: "2026-05-08T00:45:02.000Z",
+        },
+      ],
+    };
+    const { codex, services } = await createHarness(state);
+    codex.readThread.mockResolvedValueOnce({
+      thread: {
+        turns: [
+          {
+            id: "turn_1",
+            items: [
+              { id: "item-1", type: "userMessage", text: "initial request" },
+              { id: "item-2", type: "agentMessage", text: "first update" },
+              { id: "item-3", type: "agentMessage", text: "newer update" },
+            ],
+          },
+        ],
+      },
+    });
+
+    const messages = await services.getMessages("chat_1");
+
+    deepStrictEqual(
+      messages.map((message) => [message.id, message.role, message.text]),
+      [
+        ["chat_1_codex_turn_1_0", "user", "initial request"],
+        ["chat_1_codex_turn_1_1", "assistant", "first update"],
+        ["chat_1_codex_turn_1_2", "assistant", "newer update"],
+        ["msg_user_1", "user", "initial request"],
+        ["msg_local_only", "user", "local-only follow up"],
+        ["msg_assistant_1", "assistant", "first update"],
+      ],
+    );
+  });
+
+  it("drops shorter repeated Codex prefixes before newer fallback Codex messages", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "idle", activeTurnId: null })],
+      messages: [
+        {
+          id: "msg_user_1",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "initial request",
+          createdAt: "2026-05-08T00:45:00.000Z",
+        },
+        {
+          id: "msg_assistant_1",
+          chatId: "chat_1",
+          role: "assistant" as const,
+          text: "first update",
+          eventType: "item/agentMessage/delta",
+          itemId: "local_agent_1",
+          createdAt: "2026-05-08T00:45:02.000Z",
+        },
+        {
+          id: "msg_user_2",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "follow up",
+          itemId: "turn_1",
+          createdAt: "2026-05-08T00:46:00.000Z",
+        },
+        {
+          id: "msg_queued",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "queued next",
+          eventType: "chat.message.queued",
+          createdAt: "2026-05-08T00:47:00.000Z",
+        },
+      ],
+    };
+    const { codex, services } = await createHarness(state);
+    codex.readThread.mockResolvedValueOnce({
+      thread: {
+        turns: [
+          {
+            id: "turn_1",
+            items: [
+              { id: "item-1", type: "userMessage", text: "initial request" },
+              { id: "item-2", type: "agentMessage", text: "first update" },
+            ],
+          },
+          {
+            id: "turn_2",
+            items: [
+              { id: "item-3", type: "userMessage", text: "follow up" },
+              { id: "item-4", type: "agentMessage", text: "newer update" },
+            ],
+          },
+        ],
+      },
+    });
+
+    const messages = await services.getMessages("chat_1");
+
+    deepStrictEqual(
+      messages.map((message) => [
+        message.id,
+        message.role,
+        message.text,
+        message.eventType,
+      ]),
+      [
+        ["msg_user_1", "user", "initial request", undefined],
+        [
+          "msg_assistant_1",
+          "assistant",
+          "first update",
+          "item/agentMessage/delta",
+        ],
+        ["msg_user_2", "user", "follow up", undefined],
+        ["chat_1_codex_turn_2_1", "assistant", "newer update", undefined],
+        ["msg_queued", "user", "queued next", "chat.message.queued"],
+      ],
+    );
+  });
+
+  it("drops repeated Codex prefixes across stale steered local users", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "idle", activeTurnId: null })],
+      messages: [
+        {
+          id: "msg_user_1",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "initial request",
+          createdAt: "2026-05-08T00:45:00.000Z",
+        },
+        {
+          id: "msg_assistant_1",
+          chatId: "chat_1",
+          role: "assistant" as const,
+          text: "first update",
+          eventType: "item/agentMessage/delta",
+          itemId: "local_agent_1",
+          createdAt: "2026-05-08T00:45:02.000Z",
+        },
+        {
+          id: "msg_steered",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "adjust course",
+          eventType: "chat.message.steered",
+          itemId: "turn_1",
+          createdAt: "2026-05-08T00:46:00.000Z",
+        },
+        {
+          id: "msg_assistant_2",
+          chatId: "chat_1",
+          role: "assistant" as const,
+          text: "adjusted update",
+          eventType: "item/agentMessage/delta",
+          itemId: "local_agent_2",
+          createdAt: "2026-05-08T00:46:02.000Z",
+        },
+      ],
+    };
+    const { codex, services } = await createHarness(state);
+    codex.readThread.mockResolvedValueOnce({
+      thread: {
+        turns: [
+          {
+            id: "turn_1",
+            items: [
+              { id: "item-1", type: "userMessage", text: "initial request" },
+              { id: "item-2", type: "agentMessage", text: "first update" },
+              { id: "item-3", type: "userMessage", text: "adjust course" },
+              { id: "item-4", type: "agentMessage", text: "adjusted update" },
+              { id: "item-5", type: "agentMessage", text: "newer update" },
+            ],
+          },
+        ],
+      },
+    });
+
+    const messages = await services.getMessages("chat_1");
+
+    deepStrictEqual(
+      messages.map((message) => [
+        message.id,
+        message.role,
+        message.text,
+        message.eventType,
+      ]),
+      [
+        ["msg_user_1", "user", "initial request", undefined],
+        [
+          "msg_assistant_1",
+          "assistant",
+          "first update",
+          "item/agentMessage/delta",
+        ],
+        ["msg_steered", "user", "adjust course", undefined],
+        [
+          "msg_assistant_2",
+          "assistant",
+          "adjusted update",
+          "item/agentMessage/delta",
+        ],
+        ["chat_1_codex_turn_1_4", "assistant", "newer update", undefined],
+      ],
+    );
+  });
+
+  it("keeps local repeated transcript messages before newer same-text Codex messages", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "idle", activeTurnId: null })],
+      messages: [
+        {
+          id: "msg_user_1",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "initial request",
+          createdAt: "2026-05-08T00:45:00.000Z",
+        },
+        {
+          id: "msg_assistant_1",
+          chatId: "chat_1",
+          role: "assistant" as const,
+          text: "repeated update",
+          eventType: "item/agentMessage/delta",
+          itemId: "local_agent_1",
+          createdAt: "2026-05-08T00:45:02.000Z",
+        },
+        {
+          id: "msg_user_2",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "follow up",
+          itemId: "turn_1",
+          createdAt: "2026-05-08T00:46:00.000Z",
+        },
+        {
+          id: "msg_assistant_2",
+          chatId: "chat_1",
+          role: "assistant" as const,
+          text: "second update",
+          eventType: "item/agentMessage/delta",
+          itemId: "local_agent_2",
+          createdAt: "2026-05-08T00:46:02.000Z",
+        },
+      ],
+    };
+    const { codex, services } = await createHarness(state);
+    codex.readThread.mockResolvedValueOnce({
+      thread: {
+        turns: [
+          {
+            id: "turn_1",
+            items: [
+              { id: "item-1", type: "userMessage", text: "initial request" },
+              { id: "item-2", type: "agentMessage", text: "repeated update" },
+              { id: "item-3", type: "userMessage", text: "follow up" },
+              { id: "item-4", type: "agentMessage", text: "second update" },
+              { id: "item-5", type: "agentMessage", text: "repeated update" },
+            ],
+          },
+        ],
+      },
+    });
+
+    const messages = await services.getMessages("chat_1");
+
+    deepStrictEqual(
+      messages.map((message) => [message.id, message.role, message.text]),
+      [
+        ["msg_user_1", "user", "initial request"],
+        ["msg_assistant_1", "assistant", "repeated update"],
+        ["msg_user_2", "user", "follow up"],
+        ["msg_assistant_2", "assistant", "second update"],
+        ["chat_1_codex_turn_1_4", "assistant", "repeated update"],
+      ],
+    );
+  });
+
+  it("places retained local messages between remaining Codex messages after dropping repeated history", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "idle", activeTurnId: null })],
+      messages: [
+        {
+          id: "msg_user_1",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "initial request",
+          createdAt: "2026-05-08T00:45:00.000Z",
+        },
+        {
+          id: "msg_assistant_1",
+          chatId: "chat_1",
+          role: "assistant" as const,
+          text: "first update",
+          eventType: "item/agentMessage/delta",
+          itemId: "local_agent_1",
+          createdAt: "2026-05-08T00:45:02.000Z",
+        },
+        {
+          id: "msg_user_2",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "follow up",
+          itemId: "turn_1",
+          createdAt: "2026-05-08T00:46:00.000Z",
+        },
+        {
+          id: "msg_assistant_2",
+          chatId: "chat_1",
+          role: "assistant" as const,
+          text: "second update",
+          eventType: "item/agentMessage/delta",
+          itemId: "local_agent_2",
+          createdAt: "2026-05-08T00:46:02.000Z",
+        },
+        {
+          id: "msg_local_between_codex",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "local note",
+          createdAt: "2026-05-08T00:47:00.000Z",
+        },
+      ],
+    };
+    const { codex, services } = await createHarness(state);
+    codex.readThread.mockResolvedValueOnce({
+      thread: {
+        turns: [
+          {
+            id: "turn_1",
+            items: [
+              {
+                createdAt: "2026-05-08T00:45:10.000Z",
+                type: "userMessage",
+                text: "initial request",
+              },
+              {
+                createdAt: "2026-05-08T00:45:20.000Z",
+                type: "agentMessage",
+                text: "first update",
+              },
+              {
+                createdAt: "2026-05-08T00:46:10.000Z",
+                type: "userMessage",
+                text: "follow up",
+              },
+              {
+                createdAt: "2026-05-08T00:46:20.000Z",
+                type: "agentMessage",
+                text: "second update",
+              },
+              {
+                createdAt: "2026-05-08T00:46:50.000Z",
+                type: "agentMessage",
+                text: "newer update before local",
+              },
+              {
+                createdAt: "2026-05-08T00:47:10.000Z",
+                type: "agentMessage",
+                text: "newer update after local",
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const messages = await services.getMessages("chat_1");
+
+    deepStrictEqual(
+      messages.map((message) => [message.role, message.text]),
+      [
+        ["user", "initial request"],
+        ["assistant", "first update"],
+        ["user", "follow up"],
+        ["assistant", "second update"],
+        ["assistant", "newer update before local"],
+        ["user", "local note"],
+        ["assistant", "newer update after local"],
+      ],
+    );
+  });
+
+  it("keeps repeated active local turns separate from older Codex history", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "running", activeTurnId: "turn_current" })],
+      messages: [
+        {
+          id: "msg_current_user_1",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "repeat request",
+          createdAt: "2026-05-08T00:45:00.000Z",
+        },
+        {
+          id: "msg_current_assistant_1",
+          chatId: "chat_1",
+          role: "assistant" as const,
+          text: "first repeat response",
+          eventType: "item/agentMessage/delta",
+          itemId: "current_agent_1",
+          createdAt: "2026-05-08T00:45:02.000Z",
+        },
+        {
+          id: "msg_current_user_2",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "repeat follow up",
+          createdAt: "2026-05-08T00:46:00.000Z",
+        },
+        {
+          id: "msg_current_assistant_2",
+          chatId: "chat_1",
+          role: "assistant" as const,
+          text: "second repeat response",
+          eventType: "item/agentMessage/delta",
+          itemId: "current_agent_2",
+          createdAt: "2026-05-08T00:46:02.000Z",
+        },
+      ],
+    };
+    const { codex, services } = await createHarness(state);
+    markChatActiveInCurrentProcess(services, "chat_1");
+    codex.readThread.mockResolvedValueOnce({
+      thread: {
+        turns: [
+          {
+            id: "turn_old",
+            items: [
+              { type: "userMessage", text: "repeat request" },
+              { type: "agentMessage", text: "first repeat response" },
+              { type: "userMessage", text: "repeat follow up" },
+              { type: "agentMessage", text: "second repeat response" },
+            ],
+          },
+        ],
+      },
+    });
+
+    const messages = await services.getMessages("chat_1");
+
+    deepStrictEqual(
+      messages.map((message) => [
+        message.id,
+        message.role,
+        message.text,
+        message.eventType,
+      ]),
+      [
+        ["chat_1_codex_turn_old_0", "user", "repeat request", undefined],
+        [
+          "chat_1_codex_turn_old_1",
+          "assistant",
+          "first repeat response",
+          undefined,
+        ],
+        ["chat_1_codex_turn_old_2", "user", "repeat follow up", undefined],
+        [
+          "chat_1_codex_turn_old_3",
+          "assistant",
+          "second repeat response",
+          undefined,
+        ],
+        ["msg_current_user_1", "user", "repeat request", undefined],
+        [
+          "msg_current_assistant_1",
+          "assistant",
+          "first repeat response",
+          "item/agentMessage/delta",
+        ],
+        ["msg_current_user_2", "user", "repeat follow up", undefined],
+        [
+          "msg_current_assistant_2",
+          "assistant",
+          "second repeat response",
+          "item/agentMessage/delta",
+        ],
+      ],
+    );
+  });
+
   it("preserves local attachment metadata when Codex thread history matches a sent user message", async () => {
     const attachment = {
       name: "screenshot.png",

--- a/packages/server/src/services.ts
+++ b/packages/server/src/services.ts
@@ -1235,15 +1235,12 @@ export class ServeServices {
         includeTurns: true,
       });
       const codexMessages = normalizeCodexThreadMessages(result, chat.id);
-      if (codexMessages.length === 0) {
-        return localMessagesWithoutStaleSteeredState(chat, localMessages);
-      }
-      return mergeCodexAndLocalMessages(
+      return resolveChatMessageTimeline({
+        activeTurnId,
+        chat,
         codexMessages,
         localMessages,
-        activeTurnId,
-        chat.activeTurnId != null,
-      );
+      });
     } catch {
       return localMessagesWithoutStaleSteeredState(chat, localMessages);
     }
@@ -3898,18 +3895,72 @@ function extractCodexText(value: unknown): string {
   return extractCodexText(value.content);
 }
 
+interface ResolveChatMessageTimelineInput {
+  activeTurnId: string | null;
+  chat: ChatRecord;
+  codexMessages: InternalChatMessageRecord[];
+  localMessages: ChatMessageRecord[];
+}
+
+function resolveChatMessageTimeline({
+  activeTurnId,
+  chat,
+  codexMessages,
+  localMessages,
+}: ResolveChatMessageTimelineInput): ChatMessageRecord[] {
+  if (codexMessages.length === 0) {
+    return localMessagesWithoutStaleSteeredState(chat, localMessages);
+  }
+  const localMessagesForCanonicalTranscript = isChatInActiveTurn(chat)
+    ? localMessages
+    : localMessagesWithoutStaleSteeredState(chat, localMessages);
+  const canonicalLocalTranscriptMatch = isChatInActiveTurn(chat)
+    ? emptyCanonicalLocalTranscriptMatch()
+    : findCanonicalLocalTranscriptMatch(
+        codexMessages,
+        localMessagesForCanonicalTranscript,
+      );
+  const deduplicatedCodexMessages =
+    codexMessagesWithoutCanonicalLocalTranscript(
+      codexMessages,
+      canonicalLocalTranscriptMatch.codexMessageIndexes,
+    );
+  if (deduplicatedCodexMessages.length === 0) {
+    return localMessagesWithoutStaleSteeredState(chat, localMessages);
+  }
+  const localMessagesForMerge =
+    localMessagesWithCanonicalStaleSteeredStateCleared(
+      chat,
+      localMessages,
+      canonicalLocalTranscriptMatch,
+    );
+  return mergeCodexAndLocalMessages(
+    deduplicatedCodexMessages,
+    localMessagesForMerge,
+    activeTurnId,
+    chat.activeTurnId != null,
+    canonicalLocalTranscriptMatch.localMessageCodexOrderMatches,
+  );
+}
+
 function mergeCodexAndLocalMessages(
   codexMessages: InternalChatMessageRecord[],
   localMessages: ChatMessageRecord[],
   activeTurnId: string | null,
   protectActiveLocalTurn: boolean,
+  protectedLocalMessageCodexOrderMatches: ReadonlyMap<
+    string,
+    number
+  > = new Map(),
 ): ChatMessageRecord[] {
   if (codexMessages.length === 0) {
     return localMessages;
   }
   const mergedCodexMessages = [...codexMessages];
   const unmatchedCodexMessageIndexes = codexMessages.map((_, index) => index);
-  const localMessageCodexOrderMatches = new Map<string, number>();
+  const localMessageCodexOrderMatches = new Map(
+    protectedLocalMessageCodexOrderMatches,
+  );
   const steeredLocalMessageCounts = countSteeredLocalMessages(localMessages);
   const activeLocalTurnStartIndex = protectActiveLocalTurn
     ? findActiveLocalTurnStartIndex(localMessages)
@@ -3933,6 +3984,9 @@ function mergeCodexAndLocalMessages(
       return true;
     }
     if (message.eventType === "chat.message.queued") {
+      return true;
+    }
+    if (protectedLocalMessageCodexOrderMatches.has(message.id)) {
       return true;
     }
     const fallbackTranscriptCodexIndex =
@@ -4047,10 +4101,256 @@ function localMessagesWithoutStaleSteeredState(
     return localMessages;
   }
   return localMessages.map((message) =>
-    message.eventType === "chat.message.steered"
-      ? { ...message, eventType: undefined }
+    localMessageWithoutStaleSteeredState(chat, message),
+  );
+}
+
+function localMessagesWithCanonicalStaleSteeredStateCleared(
+  chat: ChatRecord,
+  localMessages: ChatMessageRecord[],
+  canonicalLocalTranscriptMatch: CanonicalLocalTranscriptMatch,
+): ChatMessageRecord[] {
+  if (
+    isChatInActiveTurn(chat) ||
+    canonicalLocalTranscriptMatch.localMessageCodexOrderMatches.size === 0
+  ) {
+    return localMessages;
+  }
+  return localMessages.map((message) =>
+    canonicalLocalTranscriptMatch.localMessageCodexOrderMatches.has(message.id)
+      ? localMessageWithoutStaleSteeredState(chat, message)
       : message,
   );
+}
+
+function localMessageWithoutStaleSteeredState(
+  chat: ChatRecord,
+  message: ChatMessageRecord,
+): ChatMessageRecord {
+  if (
+    isChatInActiveTurn(chat) ||
+    message.eventType !== "chat.message.steered"
+  ) {
+    return message;
+  }
+  return { ...message, eventType: undefined };
+}
+
+interface CanonicalLocalTranscriptMatch {
+  codexMessageIndexes: ReadonlySet<number>;
+  localMessageCodexOrderMatches: ReadonlyMap<string, number>;
+}
+
+function emptyCanonicalLocalTranscriptMatch(): CanonicalLocalTranscriptMatch {
+  return {
+    codexMessageIndexes: new Set(),
+    localMessageCodexOrderMatches: new Map(),
+  };
+}
+
+function codexMessagesWithoutCanonicalLocalTranscript(
+  codexMessages: InternalChatMessageRecord[],
+  duplicateCodexMessageIndexes: ReadonlySet<number>,
+): InternalChatMessageRecord[] {
+  if (duplicateCodexMessageIndexes.size === 0) {
+    return codexMessages;
+  }
+  const filteredMessages = codexMessages.filter(
+    (_, index) => !duplicateCodexMessageIndexes.has(index),
+  );
+  return filteredMessages;
+}
+
+function findCanonicalLocalTranscriptMatch(
+  codexMessages: InternalChatMessageRecord[],
+  localMessages: ChatMessageRecord[],
+): CanonicalLocalTranscriptMatch {
+  const matchedEntries = findCanonicalLocalTranscriptEntries(
+    codexMessages,
+    localMessages,
+  );
+  if (matchedEntries.length === 0) {
+    return emptyCanonicalLocalTranscriptMatch();
+  }
+  return {
+    codexMessageIndexes: new Set(
+      matchedEntries.map((entry) => entry.codexIndex),
+    ),
+    localMessageCodexOrderMatches: new Map(
+      matchedEntries.map((entry) => [
+        entry.localId,
+        entry.message.codexOrder ?? entry.codexIndex,
+      ]),
+    ),
+  };
+}
+
+function findCanonicalLocalTranscriptEntries(
+  codexMessages: InternalChatMessageRecord[],
+  localMessages: ChatMessageRecord[],
+): Array<{
+  codexIndex: number;
+  localId: string;
+  message: InternalChatMessageRecord;
+}> {
+  const minimumCanonicalTranscriptLength = 4;
+  const matchedCodexEntries: Array<{
+    codexIndex: number;
+    localId: string;
+    message: InternalChatMessageRecord;
+  }> = [];
+  let nextLocalIndex = 0;
+  for (const [codexIndex, codexMessage] of codexMessages.entries()) {
+    if (!isTranscriptMessage(codexMessage)) {
+      continue;
+    }
+    const matchedLocalIndex = findNextCanonicalLocalTranscriptIndex(
+      localMessages,
+      nextLocalIndex,
+      codexMessage,
+    );
+    if (matchedLocalIndex === -1) {
+      break;
+    }
+    const matchedLocalMessage = localMessages[matchedLocalIndex];
+    if (!matchedLocalMessage) {
+      break;
+    }
+    matchedCodexEntries.push({
+      codexIndex,
+      localId: matchedLocalMessage.id,
+      message: codexMessage,
+    });
+    nextLocalIndex = matchedLocalIndex + 1;
+  }
+  const matchedMessages = matchedCodexEntries.map((entry) => entry.message);
+  const hasNewerCodexTranscriptMessage =
+    hasCodexTranscriptMessageAfterMatchedPrefix(
+      codexMessages,
+      matchedCodexEntries,
+    );
+  const hasSubstantialCanonicalTranscript =
+    matchedMessages.length >= minimumCanonicalTranscriptLength &&
+    matchedMessages.some((message) => message.role === "user") &&
+    matchedMessages.filter((message) => message.role === "assistant").length >=
+      2;
+  const hasOpenUserBoundaryBeforeNewerCodexTranscript =
+    hasNewerCodexTranscriptMessage &&
+    matchedMessages[0]?.role === "user" &&
+    matchedMessages.some((message) => message.role === "assistant") &&
+    matchedMessages[matchedMessages.length - 1]?.role === "user";
+  const hasCompletedExchangeBeforeSameTurnCodexAssistant =
+    matchedMessages[0]?.role === "user" &&
+    matchedMessages.some((message) => message.role === "assistant") &&
+    matchedMessages[matchedMessages.length - 1]?.role === "assistant" &&
+    hasSameTurnAssistantMessageAfterMatchedPrefix(
+      codexMessages,
+      matchedCodexEntries,
+    );
+  if (
+    !hasSubstantialCanonicalTranscript &&
+    !hasOpenUserBoundaryBeforeNewerCodexTranscript &&
+    !hasCompletedExchangeBeforeSameTurnCodexAssistant
+  ) {
+    return [];
+  }
+  const codexTurnIds = new Set(
+    matchedMessages.map((message) => message.codexTurnId).filter(Boolean),
+  );
+  if (codexTurnIds.size > 1 && !hasOpenUserBoundaryBeforeNewerCodexTranscript) {
+    return [];
+  }
+  return matchedCodexEntries;
+}
+
+function findNextCanonicalLocalTranscriptIndex(
+  localMessages: ChatMessageRecord[],
+  startIndex: number,
+  codexMessage: InternalChatMessageRecord,
+): number {
+  for (
+    let localIndex = startIndex;
+    localIndex < localMessages.length;
+    localIndex += 1
+  ) {
+    const localMessage = localMessages[localIndex]!;
+    if (!isTranscriptMessage(localMessage)) {
+      if (isSkippableCanonicalLocalTimelineMessage(localMessage)) {
+        continue;
+      }
+      return -1;
+    }
+    return messageFingerprint(localMessage) ===
+      messageFingerprint(codexMessage) &&
+      isLocalMessageAtOrBeforeCodexMessage(localMessage, codexMessage)
+      ? localIndex
+      : -1;
+  }
+  return -1;
+}
+
+function isSkippableCanonicalLocalTimelineMessage(
+  message: ChatMessageRecord,
+): boolean {
+  return message.role === "event" || message.role === "error";
+}
+
+function hasCodexTranscriptMessageAfterMatchedPrefix(
+  codexMessages: InternalChatMessageRecord[],
+  matchedEntries: Array<{ codexIndex: number }>,
+): boolean {
+  const lastMatchedEntry = matchedEntries[matchedEntries.length - 1];
+  if (!lastMatchedEntry) {
+    return false;
+  }
+  return codexMessages.some(
+    (message, index) =>
+      index > lastMatchedEntry.codexIndex && isTranscriptMessage(message),
+  );
+}
+
+function hasSameTurnAssistantMessageAfterMatchedPrefix(
+  codexMessages: InternalChatMessageRecord[],
+  matchedEntries: Array<{ codexIndex: number }>,
+): boolean {
+  const lastMatchedEntry = matchedEntries[matchedEntries.length - 1];
+  if (!lastMatchedEntry) {
+    return false;
+  }
+  const lastMatchedMessage = codexMessages[lastMatchedEntry.codexIndex];
+  if (!lastMatchedMessage?.codexTurnId) {
+    return false;
+  }
+  return codexMessages.some(
+    (message, index) =>
+      index > lastMatchedEntry.codexIndex &&
+      message.codexTurnId === lastMatchedMessage.codexTurnId &&
+      message.role === "assistant" &&
+      isTranscriptMessage(message),
+  );
+}
+
+function isTranscriptMessage(message: ChatMessageRecord): boolean {
+  return (
+    (message.role === "assistant" || message.role === "user") &&
+    !isQueuedMessage(message) &&
+    !isPendingSteeredMessage(message)
+  );
+}
+
+function isLocalMessageAtOrBeforeCodexMessage(
+  localMessage: ChatMessageRecord,
+  codexMessage: InternalChatMessageRecord,
+): boolean {
+  if (codexMessage.hasFallbackTimestamp) {
+    return true;
+  }
+  const codexTime = Date.parse(codexMessage.createdAt);
+  const localTime = Date.parse(localMessage.createdAt);
+  if (Number.isFinite(codexTime) && Number.isFinite(localTime)) {
+    return localTime <= codexTime;
+  }
+  return localMessage.createdAt <= codexMessage.createdAt;
 }
 
 function insertRecordAtIndex<TRecord>(
@@ -4117,10 +4417,14 @@ function getLocalMessageMergeSortBucket(
   activeTurnId: string | null,
 ): number {
   if (isPendingSteeredMessage(message)) {
-    return orderedCodexMessages.length * 2 + 2;
+    return getAfterCodexMessagesMergeSortBucket(orderedCodexMessages, 2);
   }
   if (isQueuedMessage(message)) {
-    return orderedCodexMessages.length * 2 + 3;
+    return getAfterCodexMessagesMergeSortBucket(orderedCodexMessages, 3);
+  }
+  const matchedCodexOrder = localMessageCodexOrderMatches.get(message.id);
+  if (matchedCodexOrder !== undefined && isTranscriptMessage(message)) {
+    return matchedCodexOrder * 2;
   }
   if (isLocalTimelineEvent(message)) {
     return getLocalTimelineEventMergeSortBucket(
@@ -4152,6 +4456,29 @@ function getLocalMessageMergeSortBucket(
     localMessages,
     localMessageCodexOrderMatches,
   );
+}
+
+function getAfterCodexMessagesMergeSortBucket(
+  orderedCodexMessages: InternalChatMessageRecord[],
+  offset: number,
+): number {
+  const maxCodexOrder = orderedCodexMessages.reduce(
+    (maxOrder, message, index) =>
+      Math.max(maxOrder, message.codexOrder ?? index),
+    -1,
+  );
+  return (maxCodexOrder + 1) * 2 + offset;
+}
+
+function getBeforeCodexMessageMergeSortBucket(
+  orderedCodexMessages: InternalChatMessageRecord[],
+  insertionIndex: number,
+): number {
+  const codexMessage = orderedCodexMessages[insertionIndex];
+  if (!codexMessage) {
+    return getAfterCodexMessagesMergeSortBucket(orderedCodexMessages, 1);
+  }
+  return (codexMessage.codexOrder ?? insertionIndex) * 2 - 1;
 }
 
 function getLocalTimelineEventMergeSortBucket(
@@ -4216,7 +4543,7 @@ function getLocalTimelineEventMergeSortBucket(
     return earlierLocalBoundaryBucket + 0.5;
   }
   if (laterLocalBoundaryBucket === undefined) {
-    return orderedCodexMessages.length * 2 + 1;
+    return getAfterCodexMessagesMergeSortBucket(orderedCodexMessages, 1);
   }
   return laterLocalBoundaryBucket - 0.5;
 }
@@ -4247,10 +4574,10 @@ function getLocalTimelineEventBoundaryMergeSortBucket(
     }
   }
   if (isPendingSteeredMessage(message)) {
-    return orderedCodexMessages.length * 2 + 2;
+    return getAfterCodexMessagesMergeSortBucket(orderedCodexMessages, 2);
   }
   if (isQueuedMessage(message)) {
-    return orderedCodexMessages.length * 2 + 3;
+    return getAfterCodexMessagesMergeSortBucket(orderedCodexMessages, 3);
   }
   if (!isLiveAssistantDeltaMessage(message)) {
     return null;
@@ -4296,8 +4623,11 @@ function getStandardLocalMessageMergeSortBucket(
     );
     return applyEarlierLocalCodexBoundary(
       nextTrustedInsertionIndex === -1
-        ? orderedCodexMessages.length * 2 + 1
-        : nextTrustedInsertionIndex * 2 - 1,
+        ? getAfterCodexMessagesMergeSortBucket(orderedCodexMessages, 1)
+        : getBeforeCodexMessageMergeSortBucket(
+            orderedCodexMessages,
+            nextTrustedInsertionIndex,
+          ),
       index,
       localMessages,
       localMessageCodexOrderMatches,
@@ -4305,8 +4635,11 @@ function getStandardLocalMessageMergeSortBucket(
   }
   const bucket =
     insertionIndex === -1
-      ? orderedCodexMessages.length * 2 + 1
-      : insertionIndex * 2 - 1;
+      ? getAfterCodexMessagesMergeSortBucket(orderedCodexMessages, 1)
+      : getBeforeCodexMessageMergeSortBucket(
+          orderedCodexMessages,
+          insertionIndex,
+        );
   return applyEarlierLocalCodexBoundary(
     bucket,
     index,
@@ -4424,10 +4757,13 @@ function getLiveAssistantDeltaMergeSortBucket(
       localMessageCodexOrderMatches,
     );
     return earlierMatchedCodexOrder === undefined
-      ? orderedCodexMessages.length * 2 + 1
+      ? getAfterCodexMessagesMergeSortBucket(orderedCodexMessages, 1)
       : earlierMatchedCodexOrder * 2 + 0.5;
   }
-  const bucket = boundaryInsertionIndex * 2 - 1;
+  const bucket = getBeforeCodexMessageMergeSortBucket(
+    orderedCodexMessages,
+    boundaryInsertionIndex,
+  );
   return applyEarlierLocalCodexBoundary(
     bucket,
     index,


### PR DESCRIPTION
## Summary

Fixes duplicate and out-of-order chat messages by simplifying the server-side timeline resolution path for chat history.

## Root Cause

`getMessages()` merged Codex thread history with locally persisted live messages on every request. When Codex returned a transcript that was already present locally, especially with fallback timestamps, the merge could keep the Codex copy at the front and then render the same local transcript later.

## Changes

- Route Codex/local timeline resolution through a dedicated `resolveChatMessageTimeline()` helper.
- Detect Codex transcript entries that are already represented in the local timeline.
- Remove only the repeated Codex prefix before falling back to the existing merge logic for newer Codex messages.
- Preserve canonical local transcript messages through later merge passes so newer same-text Codex messages do not consume older local messages.
- Base local tail and insertion buckets on remaining Codex `codexOrder` values rather than filtered array positions.
- Keep active turns on the existing protected merge path.
- Add regression coverage for fully repeated history, repeated history with newer Codex output, queued messages, same-text repeats, retained local messages between remaining Codex messages, and active-turn repeats.

## Validation

- `pnpm --filter @phantompane/server test`
- `pnpm ready`
- Independent review loop with subagents; final re-review reported no actionable findings.
- Manual dev verification before commit: direct API and Vite proxy returned zero transcript duplicate groups; DOM article duplicate groups were zero for the reproduced chat.
