### PR TITLE
[codex] hide automatic approval review warning

### DIFF
--- a/packages/server/src/services.test.ts
+++ b/packages/server/src/services.test.ts
@@ -8479,6 +8479,46 @@ describe("ServeServices", () => {
     strictEqual(emittedFileCompletedChanges?.[0]?.diff, undefined);
   });
 
+  it("does not store automatic approval review warnings as chat messages", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "running", activeTurnId: "turn_1" })],
+    };
+    const { codex, store } = await createHarness(state);
+
+    codex.emitNotification({
+      method: "warning",
+      params: {
+        threadId: "thread_1",
+        turnId: "turn_1",
+        message: "Automatic approval review approved",
+      },
+    });
+    codex.emitNotification({
+      method: "warning",
+      params: {
+        threadId: "thread_1",
+        turnId: "turn_1",
+        message: "Review this warning",
+      },
+    });
+
+    await vi.waitFor(async () => {
+      strictEqual((await store.load()).messages.length, 1);
+    });
+
+    const savedState = await store.load();
+    deepStrictEqual(
+      savedState.messages.map((message) => [
+        message.role,
+        message.text,
+        message.eventType,
+      ]),
+      [["event", "Review this warning", "warning"]],
+    );
+  });
+
   it("preserves lightweight markers for repeated hidden diff and patch updates", async () => {
     const state = {
       ...createTestState(),

--- a/packages/server/src/services.ts
+++ b/packages/server/src/services.ts
@@ -3077,6 +3077,9 @@ export class ServeServices {
       method === "guardianWarning" ||
       method === "configWarning"
     ) {
+      if (isHiddenCodexWarning(method, params)) {
+        return;
+      }
       await this.addRichEventMessage({
         chatId,
         eventData: params,
@@ -5868,6 +5871,32 @@ function sanitizeCodexEventParams(method: string, params: unknown): unknown {
   }
 
   return params;
+}
+
+const hiddenCodexWarningMessages = new Set([
+  "Automatic approval review approved",
+]);
+
+function isHiddenCodexWarning(method: string, params: unknown): boolean {
+  if (
+    method !== "warning" &&
+    method !== "guardianWarning" &&
+    method !== "configWarning"
+  ) {
+    return false;
+  }
+
+  const object = getParamObject(params);
+  const candidates = [
+    summarizeCodexEvent(method, params),
+    typeof object?.message === "string" ? object.message : null,
+    typeof object?.summary === "string" ? object.summary : null,
+  ];
+  return candidates.some(
+    (candidate) =>
+      typeof candidate === "string" &&
+      hiddenCodexWarningMessages.has(candidate.trim()),
+  );
 }
 
 function sanitizeCodexEventItem(item: Record<string, unknown>): unknown {


### PR DESCRIPTION
## Summary

- Stop storing the Codex `Automatic approval review approved` warning as a chat timeline message.
- Keep other Codex warnings visible in chat.
- Add a server regression test covering the hidden warning and a normal warning.

## Why

Codex emits this automatic approval review warning as internal approval-flow noise. Showing it in the chat timeline adds clutter without requiring user action.

## Validation

- `pnpm --filter @phantompane/server test`
- `pnpm ready`