### PR TITLE
[codex] Rename Phantom Serve to Phantom

### DIFF
--- a/packages/codex/src/bridge.ts
+++ b/packages/codex/src/bridge.ts
@@ -438,7 +438,7 @@ export class CodexBridge {
     await this.sendRequest("initialize", {
       clientInfo: {
         name: "phantom_serve",
-        title: "Phantom Serve",
+        title: "Phantom",
         version: "0.1.0",
       },
       capabilities: {

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -13,7 +13,7 @@
     <link rel="manifest" href="/manifest.webmanifest" />
     <link rel="icon" href="/icons/icon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="/icons/apple-touch-icon.png" />
-    <title>Phantom Serve</title>
+    <title>Phantom</title>
   </head>
   <body>
     <div id="root"></div>

--- a/packages/web/public/manifest.webmanifest
+++ b/packages/web/public/manifest.webmanifest
@@ -1,6 +1,6 @@
 {
   "id": "/",
-  "name": "Phantom Serve",
+  "name": "Phantom",
   "short_name": "Phantom",
   "description": "Phantom worktree and agent workspace.",
   "start_url": "/",


### PR DESCRIPTION
## Summary

- Rename the web document title from `Phantom Serve` to `Phantom`.
- Rename the PWA manifest `name` to `Phantom`.
- Update the Codex app client title sent during initialization to `Phantom`.

## Impact

Users now see the web app branded as `Phantom` in browser tabs, installed app metadata, and Codex app client metadata. Internal command names and identifiers such as `phantom serve` and `phantom_serve` are unchanged.

## Validation

- `pnpm ready`

Note: the first validation run failed because this worktree had no `node_modules`; after `pnpm install`, `pnpm ready` passed.