### PR TITLE
fix: hide approved approval review warnings

### DIFF
--- a/packages/server/src/services.test.ts
+++ b/packages/server/src/services.test.ts
@@ -9473,14 +9473,15 @@ describe("ServeServices", () => {
       projects: [createProject()],
       chats: [createChat({ status: "running", activeTurnId: "turn_1" })],
     };
-    const { codex, store } = await createHarness(state);
+    const { codex, services, store } = await createHarness(state);
+    const emitSpy = vi.spyOn(services.eventHub, "emit");
 
     codex.emitNotification({
       method: "warning",
       params: {
         threadId: "thread_1",
         turnId: "turn_1",
-        message: "Automatic approval review approved",
+        message: " Automatic approval\nreview approved ",
       },
     });
     codex.emitNotification({
@@ -9504,6 +9505,18 @@ describe("ServeServices", () => {
         message.eventType,
       ]),
       [["event", "Review this warning", "warning"]],
+    );
+    deepStrictEqual(
+      emitSpy.mock.calls
+        .filter((call) => call[0] === "agent.warning")
+        .map((call) => (call[1] as CodexMessage).params),
+      [
+        {
+          threadId: "thread_1",
+          turnId: "turn_1",
+          message: "Review this warning",
+        },
+      ],
     );
   });
 

--- a/packages/server/src/services.ts
+++ b/packages/server/src/services.ts
@@ -2168,6 +2168,9 @@ export class ServeServices {
 
   private async processCodexNotification(message: CodexMessage): Promise<void> {
     const method = message.method ?? "unknown";
+    if (isHiddenCodexWarning(method, message.params)) {
+      return;
+    }
     const chat = await this.findChatByCodexParams(message.params);
     const eventType = mapCodexMethodToEvent(method);
 
@@ -6372,7 +6375,7 @@ function sanitizeCodexEventParams(method: string, params: unknown): unknown {
 }
 
 const hiddenCodexWarningMessages = new Set([
-  "Automatic approval review approved",
+  "automatic approval review approved",
 ]);
 
 function isHiddenCodexWarning(method: string, params: unknown): boolean {
@@ -6393,8 +6396,12 @@ function isHiddenCodexWarning(method: string, params: unknown): boolean {
   return candidates.some(
     (candidate) =>
       typeof candidate === "string" &&
-      hiddenCodexWarningMessages.has(candidate.trim()),
+      hiddenCodexWarningMessages.has(normalizeCodexWarningMessage(candidate)),
   );
+}
+
+function normalizeCodexWarningMessage(message: string): string {
+  return message.trim().replace(/\s+/g, " ").toLowerCase();
 }
 
 function sanitizeCodexEventItem(item: Record<string, unknown>): unknown {

--- a/packages/web/src/routes/home.tsx
+++ b/packages/web/src/routes/home.tsx
@@ -161,6 +161,7 @@ import {
   getRichEventText,
   getTextLineCount,
   getWarningEventText,
+  isHiddenRichEventMessage,
   isRichEventMessage,
 } from "./rich-events";
 import type {
@@ -1336,7 +1337,8 @@ export function HomeRoute() {
     () =>
       messages.filter(
         (message): message is VisibleMessageRecord =>
-          message.role !== "event" || isRichEventMessage(message),
+          message.role !== "event" ||
+          (isRichEventMessage(message) && !isHiddenRichEventMessage(message)),
       ),
     [messages],
   );

--- a/packages/web/src/routes/rich-events.test.ts
+++ b/packages/web/src/routes/rich-events.test.ts
@@ -10,6 +10,7 @@ import {
   getRichEventKind,
   getRichEventText,
   getTextLineCount,
+  isHiddenRichEventMessage,
   isRichEventMessage,
 } from "./rich-events";
 import type { ChatMessageRecord } from "@phantompane/server";
@@ -53,6 +54,29 @@ describe("rich event helpers", () => {
     );
     strictEqual(
       isRichEventMessage(createMessage({ eventType: "item/completed" })),
+      false,
+    );
+  });
+
+  it("hides approved automatic approval review warnings", () => {
+    strictEqual(
+      isHiddenRichEventMessage(
+        createMessage({
+          eventType: "warning",
+          eventData: { message: "Automatic approval review approved" },
+          text: "Automatic approval review approved",
+        }),
+      ),
+      true,
+    );
+    strictEqual(
+      isHiddenRichEventMessage(
+        createMessage({
+          eventType: "warning",
+          eventData: { message: "Review this warning" },
+          text: "Review this warning",
+        }),
+      ),
       false,
     );
   });

--- a/packages/web/src/routes/rich-events.ts
+++ b/packages/web/src/routes/rich-events.ts
@@ -68,6 +68,15 @@ export function isRichEventMessage(
   return getRichEventKind(message) !== null;
 }
 
+export function isHiddenRichEventMessage(message: ChatMessageRecord): boolean {
+  if (getRichEventKind(message) !== "warning") {
+    return false;
+  }
+
+  const warning = getWarningEventText(message);
+  return isHiddenWarningText(warning.summary);
+}
+
 export function getPlanEventData(message: ChatMessageRecord): {
   explanation: string | null;
   plan: RichPlanStep[];
@@ -142,6 +151,13 @@ export function getWarningEventText(message: ChatMessageRecord): {
     summary,
     details: getString(eventData, "details") ?? null,
   };
+}
+
+function isHiddenWarningText(value: string): boolean {
+  return (
+    value.trim().replace(/\s+/g, " ").toLowerCase() ===
+    "automatic approval review approved"
+  );
 }
 
 export function getCommandEventMeta(message: ChatMessageRecord): {


### PR DESCRIPTION
## Summary
- Hide automatic approval review approved warnings before server-side storage or SSE emission
- Filter any already-stored matching warning events from the chat UI
- Add server and web tests for the hidden warning behavior

## Verification
- pnpm --filter @phantompane/web test -- rich-events.test.ts
- pnpm --filter @phantompane/server test -- services.test.ts
- pnpm ready