### PR TITLE
feat: add web slash command suggestions

### DIFF
--- a/packages/web/src/lib/slash-commands.test.ts
+++ b/packages/web/src/lib/slash-commands.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   completeSlashCommand,
   filterSlashCommands,
+  filterSlashCommandsForState,
   getSlashCommandKeyAction,
   getSlashCommandQuery,
   shouldOpenSlashCommandMenu,
@@ -46,6 +47,29 @@ describe("filterSlashCommands", () => {
     expect(slashCommandOptions.map((command) => command.command)).not.toContain(
       "/clear",
     );
+  });
+
+  it("keeps only active-turn-safe commands while a chat is running", () => {
+    expect(
+      filterSlashCommandsForState(slashCommandOptions, {
+        isChatRunning: true,
+      }).map((command) => command.command),
+    ).toEqual([
+      "/status",
+      "/diff",
+      "/skills",
+      "/rename",
+      "/statusline",
+      "/feedback",
+    ]);
+  });
+
+  it("keeps the full command list while a chat is idle", () => {
+    expect(
+      filterSlashCommandsForState(slashCommandOptions, {
+        isChatRunning: false,
+      }),
+    ).toEqual(slashCommandOptions);
   });
 });
 

--- a/packages/web/src/lib/slash-commands.test.ts
+++ b/packages/web/src/lib/slash-commands.test.ts
@@ -4,6 +4,7 @@ import {
   filterSlashCommands,
   getSlashCommandKeyAction,
   getSlashCommandQuery,
+  shouldOpenSlashCommandMenu,
   slashCommandOptions,
 } from "./slash-commands";
 
@@ -39,6 +40,12 @@ describe("filterSlashCommands", () => {
         (command) => command.command,
       ),
     ).toContain("/status");
+  });
+
+  it("does not advertise commands that require unimplemented web handling", () => {
+    expect(slashCommandOptions.map((command) => command.command)).not.toContain(
+      "/clear",
+    );
   });
 });
 
@@ -83,5 +90,38 @@ describe("getSlashCommandKeyAction", () => {
     expect(getSlashCommandKeyAction({ key: "ArrowDown" }, false)).toBeNull();
     expect(getSlashCommandKeyAction({ key: "Enter" }, false)).toBeNull();
     expect(getSlashCommandKeyAction({ key: "Escape" }, false)).toBe("dismiss");
+  });
+});
+
+describe("shouldOpenSlashCommandMenu", () => {
+  const baseState = {
+    composerText: "/",
+    dismissedText: null,
+    hasSelectedChat: true,
+    hasSelectedProject: true,
+    isComposerBlocked: false,
+    query: "",
+  };
+
+  it("opens for slash input in an existing chat", () => {
+    expect(shouldOpenSlashCommandMenu(baseState)).toBe(true);
+  });
+
+  it("stays closed before a chat exists", () => {
+    expect(
+      shouldOpenSlashCommandMenu({
+        ...baseState,
+        hasSelectedChat: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("stays closed when dismissed for the current text", () => {
+    expect(
+      shouldOpenSlashCommandMenu({
+        ...baseState,
+        dismissedText: "/",
+      }),
+    ).toBe(false);
   });
 });

--- a/packages/web/src/lib/slash-commands.test.ts
+++ b/packages/web/src/lib/slash-commands.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+  completeSlashCommand,
+  filterSlashCommands,
+  getSlashCommandQuery,
+  slashCommandOptions,
+} from "./slash-commands";
+
+describe("getSlashCommandQuery", () => {
+  it("detects command text at the start of the composer", () => {
+    expect(getSlashCommandQuery("/")).toBe("");
+    expect(getSlashCommandQuery("/pla")).toBe("pla");
+  });
+
+  it("closes command search after whitespace or non-command text", () => {
+    expect(getSlashCommandQuery(" /plan")).toBeNull();
+    expect(getSlashCommandQuery("/plan ")).toBeNull();
+    expect(getSlashCommandQuery("/plan\nnext")).toBeNull();
+    expect(getSlashCommandQuery("please /plan")).toBeNull();
+  });
+});
+
+describe("filterSlashCommands", () => {
+  it("returns all commands for an empty query", () => {
+    expect(filterSlashCommands(slashCommandOptions, "")).toEqual(
+      slashCommandOptions,
+    );
+  });
+
+  it("matches command names and keywords case-insensitively", () => {
+    expect(
+      filterSlashCommands(slashCommandOptions, "PLA").map(
+        (command) => command.command,
+      ),
+    ).toContain("/plan");
+    expect(
+      filterSlashCommands(slashCommandOptions, "tokens").map(
+        (command) => command.command,
+      ),
+    ).toContain("/status");
+  });
+});
+
+describe("completeSlashCommand", () => {
+  it("adds a trailing space so the user can continue typing", () => {
+    expect(completeSlashCommand(slashCommandOptions[0])).toBe("/plan ");
+  });
+});

--- a/packages/web/src/lib/slash-commands.test.ts
+++ b/packages/web/src/lib/slash-commands.test.ts
@@ -44,9 +44,9 @@ describe("filterSlashCommands", () => {
   });
 
   it("does not advertise commands that require unimplemented web handling", () => {
-    expect(slashCommandOptions.map((command) => command.command)).not.toContain(
-      "/clear",
-    );
+    const commandNames = slashCommandOptions.map((command) => command.command);
+    expect(commandNames).not.toContain("/clear");
+    expect(commandNames).not.toContain("/review");
   });
 
   it("keeps only active-turn-safe commands while a chat is running", () => {

--- a/packages/web/src/lib/slash-commands.test.ts
+++ b/packages/web/src/lib/slash-commands.test.ts
@@ -52,7 +52,7 @@ describe("filterSlashCommands", () => {
   it("keeps only active-turn-safe commands while a chat is running", () => {
     expect(
       filterSlashCommandsForState(slashCommandOptions, {
-        isChatRunning: true,
+        hasActiveTurn: true,
       }).map((command) => command.command),
     ).toEqual([
       "/status",
@@ -67,7 +67,7 @@ describe("filterSlashCommands", () => {
   it("keeps the full command list while a chat is idle", () => {
     expect(
       filterSlashCommandsForState(slashCommandOptions, {
-        isChatRunning: false,
+        hasActiveTurn: false,
       }),
     ).toEqual(slashCommandOptions);
   });
@@ -107,6 +107,9 @@ describe("getSlashCommandKeyAction", () => {
     ).toBeNull();
     expect(
       getSlashCommandKeyAction({ key: "ArrowDown", shiftKey: true }, true),
+    ).toBeNull();
+    expect(
+      getSlashCommandKeyAction({ key: "Escape", altKey: true }, true),
     ).toBeNull();
   });
 

--- a/packages/web/src/lib/slash-commands.test.ts
+++ b/packages/web/src/lib/slash-commands.test.ts
@@ -3,6 +3,7 @@ import {
   completeSlashCommand,
   filterSlashCommands,
   filterSlashCommandsForState,
+  getSlashCommandSubmitMode,
   getSlashCommandKeyAction,
   getSlashCommandQuery,
   shouldOpenSlashCommandMenu,
@@ -49,9 +50,19 @@ describe("filterSlashCommands", () => {
     expect(commandNames).not.toContain("/review");
   });
 
-  it("keeps only active-turn-safe commands while a chat is running", () => {
+  it("keeps all commands during an active turn when queueing is available", () => {
     expect(
       filterSlashCommandsForState(slashCommandOptions, {
+        canQueueCommands: true,
+        hasActiveTurn: true,
+      }),
+    ).toEqual(slashCommandOptions);
+  });
+
+  it("keeps only active-turn-safe commands when active commands cannot be queued", () => {
+    expect(
+      filterSlashCommandsForState(slashCommandOptions, {
+        canQueueCommands: false,
         hasActiveTurn: true,
       }).map((command) => command.command),
     ).toEqual([
@@ -67,9 +78,39 @@ describe("filterSlashCommands", () => {
   it("keeps the full command list while a chat is idle", () => {
     expect(
       filterSlashCommandsForState(slashCommandOptions, {
+        canQueueCommands: false,
         hasActiveTurn: false,
       }),
     ).toEqual(slashCommandOptions);
+  });
+});
+
+describe("getSlashCommandSubmitMode", () => {
+  it("queues active-turn-unsafe commands instead of steering them", () => {
+    expect(
+      getSlashCommandSubmitMode(slashCommandOptions, {
+        composerText: "/model ",
+        submitMode: "steer",
+      }),
+    ).toBe("queue");
+  });
+
+  it("keeps active-turn-safe commands in the current turn", () => {
+    expect(
+      getSlashCommandSubmitMode(slashCommandOptions, {
+        composerText: "/status ",
+        submitMode: "steer",
+      }),
+    ).toBe("steer");
+  });
+
+  it("leaves non-steer submit modes unchanged", () => {
+    expect(
+      getSlashCommandSubmitMode(slashCommandOptions, {
+        composerText: "/model ",
+        submitMode: "send",
+      }),
+    ).toBe("send");
   });
 });
 

--- a/packages/web/src/lib/slash-commands.test.ts
+++ b/packages/web/src/lib/slash-commands.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   completeSlashCommand,
   filterSlashCommands,
+  getSlashCommandKeyAction,
   getSlashCommandQuery,
   slashCommandOptions,
 } from "./slash-commands";
@@ -44,5 +45,43 @@ describe("filterSlashCommands", () => {
 describe("completeSlashCommand", () => {
   it("adds a trailing space so the user can continue typing", () => {
     expect(completeSlashCommand(slashCommandOptions[0])).toBe("/plan ");
+  });
+});
+
+describe("getSlashCommandKeyAction", () => {
+  it("maps plain navigation and completion keys when options are available", () => {
+    expect(getSlashCommandKeyAction({ key: "ArrowDown" }, true)).toBe("next");
+    expect(getSlashCommandKeyAction({ key: "ArrowUp" }, true)).toBe("previous");
+    expect(getSlashCommandKeyAction({ key: "Home" }, true)).toBe("first");
+    expect(getSlashCommandKeyAction({ key: "End" }, true)).toBe("last");
+    expect(getSlashCommandKeyAction({ key: "Enter" }, true)).toBe("complete");
+    expect(getSlashCommandKeyAction({ key: "Tab" }, true)).toBe("complete");
+  });
+
+  it("does not intercept IME composition keys", () => {
+    expect(
+      getSlashCommandKeyAction({ isComposing: true, key: "Enter" }, true),
+    ).toBeNull();
+    expect(
+      getSlashCommandKeyAction({ key: "Enter", keyCode: 229 }, true),
+    ).toBeNull();
+  });
+
+  it("does not trap modified keys that should keep native textarea behavior", () => {
+    expect(
+      getSlashCommandKeyAction({ key: "Tab", shiftKey: true }, true),
+    ).toBeNull();
+    expect(
+      getSlashCommandKeyAction({ key: "Enter", metaKey: true }, true),
+    ).toBeNull();
+    expect(
+      getSlashCommandKeyAction({ key: "ArrowDown", shiftKey: true }, true),
+    ).toBeNull();
+  });
+
+  it("only dismisses the menu when there are no options", () => {
+    expect(getSlashCommandKeyAction({ key: "ArrowDown" }, false)).toBeNull();
+    expect(getSlashCommandKeyAction({ key: "Enter" }, false)).toBeNull();
+    expect(getSlashCommandKeyAction({ key: "Escape" }, false)).toBe("dismiss");
   });
 });

--- a/packages/web/src/lib/slash-commands.ts
+++ b/packages/web/src/lib/slash-commands.ts
@@ -5,6 +5,24 @@ export interface SlashCommandOption {
   label: string;
 }
 
+export type SlashCommandKeyAction =
+  | "complete"
+  | "dismiss"
+  | "first"
+  | "last"
+  | "next"
+  | "previous";
+
+export interface SlashCommandKeyEvent {
+  altKey?: boolean;
+  ctrlKey?: boolean;
+  isComposing?: boolean;
+  key: string;
+  keyCode?: number;
+  metaKey?: boolean;
+  shiftKey?: boolean;
+}
+
 export const slashCommandOptions: SlashCommandOption[] = [
   {
     command: "/plan",
@@ -141,4 +159,45 @@ export function filterSlashCommands(
 
 export function completeSlashCommand(command: SlashCommandOption): string {
   return `${command.command} `;
+}
+
+export function getSlashCommandKeyAction(
+  event: SlashCommandKeyEvent,
+  hasOptions: boolean,
+): SlashCommandKeyAction | null {
+  if (event.isComposing || event.keyCode === 229) {
+    return null;
+  }
+
+  if (event.key === "Escape") {
+    return "dismiss";
+  }
+
+  if (!hasOptions || hasSlashCommandKeyModifier(event)) {
+    return null;
+  }
+
+  if (event.key === "ArrowDown") {
+    return "next";
+  }
+  if (event.key === "ArrowUp") {
+    return "previous";
+  }
+  if (event.key === "Home") {
+    return "first";
+  }
+  if (event.key === "End") {
+    return "last";
+  }
+  if (event.key === "Enter" || event.key === "Tab") {
+    return "complete";
+  }
+
+  return null;
+}
+
+function hasSlashCommandKeyModifier(event: SlashCommandKeyEvent): boolean {
+  return Boolean(
+    event.altKey || event.ctrlKey || event.metaKey || event.shiftKey,
+  );
 }

--- a/packages/web/src/lib/slash-commands.ts
+++ b/packages/web/src/lib/slash-commands.ts
@@ -66,12 +66,6 @@ export const slashCommandOptions: SlashCommandOption[] = [
     keywords: ["reasoning", "effort"],
   },
   {
-    command: "/review",
-    label: "Review",
-    description: "Review current changes and find issues.",
-    keywords: ["code review", "diff"],
-  },
-  {
     command: "/compact",
     label: "Compact",
     description: "Summarize history and free up context.",

--- a/packages/web/src/lib/slash-commands.ts
+++ b/packages/web/src/lib/slash-commands.ts
@@ -14,6 +14,8 @@ export type SlashCommandKeyAction =
   | "next"
   | "previous";
 
+export type SlashCommandSubmitMode = "queue" | "send" | "steer";
+
 export interface SlashCommandKeyEvent {
   altKey?: boolean;
   ctrlKey?: boolean;
@@ -164,14 +166,47 @@ export function filterSlashCommands(
 export function filterSlashCommandsForState(
   commands: SlashCommandOption[],
   options: {
+    canQueueCommands: boolean;
     hasActiveTurn: boolean;
   },
 ): SlashCommandOption[] {
-  if (!options.hasActiveTurn) {
+  if (!options.hasActiveTurn || options.canQueueCommands) {
     return commands;
   }
 
   return commands.filter((command) => command.availableDuringActiveTurn);
+}
+
+export function getSlashCommandForText(
+  commands: SlashCommandOption[],
+  text: string,
+): SlashCommandOption | null {
+  const commandTokenMatch = text.match(/^\/[^\s\r\n]*/);
+  const commandToken = commandTokenMatch?.[0];
+  if (!commandToken) {
+    return null;
+  }
+
+  return commands.find((command) => command.command === commandToken) ?? null;
+}
+
+export function getSlashCommandSubmitMode(
+  commands: SlashCommandOption[],
+  options: {
+    composerText: string;
+    submitMode: SlashCommandSubmitMode;
+  },
+): SlashCommandSubmitMode {
+  if (options.submitMode !== "steer") {
+    return options.submitMode;
+  }
+
+  const command = getSlashCommandForText(commands, options.composerText);
+  if (!command || command.availableDuringActiveTurn) {
+    return options.submitMode;
+  }
+
+  return "queue";
 }
 
 export function completeSlashCommand(command: SlashCommandOption): string {

--- a/packages/web/src/lib/slash-commands.ts
+++ b/packages/web/src/lib/slash-commands.ts
@@ -23,6 +23,15 @@ export interface SlashCommandKeyEvent {
   shiftKey?: boolean;
 }
 
+export interface SlashCommandMenuState {
+  composerText: string;
+  dismissedText: string | null;
+  hasSelectedChat: boolean;
+  hasSelectedProject: boolean;
+  isComposerBlocked: boolean;
+  query: string | null;
+}
+
 export const slashCommandOptions: SlashCommandOption[] = [
   {
     command: "/plan",
@@ -65,12 +74,6 @@ export const slashCommandOptions: SlashCommandOption[] = [
     label: "Compact",
     description: "Summarize history and free up context.",
     keywords: ["context", "summary"],
-  },
-  {
-    command: "/clear",
-    label: "Clear",
-    description: "Clear the current conversation view.",
-    keywords: ["reset"],
   },
   {
     command: "/diff",
@@ -159,6 +162,18 @@ export function filterSlashCommands(
 
 export function completeSlashCommand(command: SlashCommandOption): string {
   return `${command.command} `;
+}
+
+export function shouldOpenSlashCommandMenu(
+  state: SlashCommandMenuState,
+): boolean {
+  return (
+    state.hasSelectedProject &&
+    state.hasSelectedChat &&
+    !state.isComposerBlocked &&
+    state.query !== null &&
+    state.dismissedText !== state.composerText
+  );
 }
 
 export function getSlashCommandKeyAction(

--- a/packages/web/src/lib/slash-commands.ts
+++ b/packages/web/src/lib/slash-commands.ts
@@ -164,10 +164,10 @@ export function filterSlashCommands(
 export function filterSlashCommandsForState(
   commands: SlashCommandOption[],
   options: {
-    isChatRunning: boolean;
+    hasActiveTurn: boolean;
   },
 ): SlashCommandOption[] {
-  if (!options.isChatRunning) {
+  if (!options.hasActiveTurn) {
     return commands;
   }
 
@@ -198,11 +198,15 @@ export function getSlashCommandKeyAction(
     return null;
   }
 
+  if (hasSlashCommandKeyModifier(event)) {
+    return null;
+  }
+
   if (event.key === "Escape") {
     return "dismiss";
   }
 
-  if (!hasOptions || hasSlashCommandKeyModifier(event)) {
+  if (!hasOptions) {
     return null;
   }
 

--- a/packages/web/src/lib/slash-commands.ts
+++ b/packages/web/src/lib/slash-commands.ts
@@ -1,0 +1,144 @@
+export interface SlashCommandOption {
+  command: `/${string}`;
+  description: string;
+  keywords?: string[];
+  label: string;
+}
+
+export const slashCommandOptions: SlashCommandOption[] = [
+  {
+    command: "/plan",
+    label: "Plan",
+    description: "Ask Codex to plan before making changes.",
+    keywords: ["planning", "steps"],
+  },
+  {
+    command: "/init",
+    label: "Init",
+    description: "Create an AGENTS.md guide for this project.",
+    keywords: ["agents", "instructions"],
+  },
+  {
+    command: "/status",
+    label: "Status",
+    description: "Show the current session, model, and usage state.",
+    keywords: ["usage", "tokens", "limits"],
+  },
+  {
+    command: "/permissions",
+    label: "Permissions",
+    description: "Choose what Codex is allowed to do.",
+    keywords: ["approval", "sandbox"],
+  },
+  {
+    command: "/model",
+    label: "Model",
+    description: "Choose the model and reasoning effort.",
+    keywords: ["reasoning", "effort"],
+  },
+  {
+    command: "/review",
+    label: "Review",
+    description: "Review current changes and find issues.",
+    keywords: ["code review", "diff"],
+  },
+  {
+    command: "/compact",
+    label: "Compact",
+    description: "Summarize history and free up context.",
+    keywords: ["context", "summary"],
+  },
+  {
+    command: "/clear",
+    label: "Clear",
+    description: "Clear the current conversation view.",
+    keywords: ["reset"],
+  },
+  {
+    command: "/diff",
+    label: "Diff",
+    description: "View current file changes.",
+    keywords: ["changes", "patch"],
+  },
+  {
+    command: "/skills",
+    label: "Skills",
+    description: "List available Codex skills.",
+    keywords: ["skill"],
+  },
+  {
+    command: "/fast",
+    label: "Fast",
+    description: "Use faster inference for upcoming turns.",
+    keywords: ["speed", "tier"],
+  },
+  {
+    command: "/rename",
+    label: "Rename",
+    description: "Rename the current thread.",
+    keywords: ["thread", "title"],
+  },
+  {
+    command: "/approvals",
+    label: "Approvals",
+    description: "Adjust approval behavior for commands.",
+    keywords: ["permission", "reviewer"],
+  },
+  {
+    command: "/statusline",
+    label: "Status Line",
+    description: "Configure status line items.",
+    keywords: ["status", "display"],
+  },
+  {
+    command: "/sandbox-add-read-dir",
+    label: "Add Read Directory",
+    description: "Allow Codex to read an extra absolute directory.",
+    keywords: ["sandbox", "directory", "read"],
+  },
+  {
+    command: "/feedback",
+    label: "Feedback",
+    description: "Report a problem with Codex.",
+    keywords: ["issue", "bug"],
+  },
+];
+
+export function getSlashCommandQuery(text: string): string | null {
+  if (!text.startsWith("/")) {
+    return null;
+  }
+
+  const commandTokenMatch = text.match(/^\/[^\s\r\n]*/);
+  if (!commandTokenMatch || commandTokenMatch[0].length !== text.length) {
+    return null;
+  }
+
+  return commandTokenMatch[0].slice(1);
+}
+
+export function filterSlashCommands(
+  commands: SlashCommandOption[],
+  query: string,
+): SlashCommandOption[] {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) {
+    return commands;
+  }
+
+  return commands.filter((command) => {
+    const searchableText = [
+      command.command,
+      command.label,
+      command.description,
+      ...(command.keywords ?? []),
+    ]
+      .join(" ")
+      .toLowerCase();
+    return searchableText.includes(normalizedQuery);
+  });
+}
+
+export function completeSlashCommand(command: SlashCommandOption): string {
+  return `${command.command} `;
+}

--- a/packages/web/src/lib/slash-commands.ts
+++ b/packages/web/src/lib/slash-commands.ts
@@ -1,4 +1,5 @@
 export interface SlashCommandOption {
+  availableDuringActiveTurn?: boolean;
   command: `/${string}`;
   description: string;
   keywords?: string[];
@@ -50,6 +51,7 @@ export const slashCommandOptions: SlashCommandOption[] = [
     label: "Status",
     description: "Show the current session, model, and usage state.",
     keywords: ["usage", "tokens", "limits"],
+    availableDuringActiveTurn: true,
   },
   {
     command: "/permissions",
@@ -80,12 +82,14 @@ export const slashCommandOptions: SlashCommandOption[] = [
     label: "Diff",
     description: "View current file changes.",
     keywords: ["changes", "patch"],
+    availableDuringActiveTurn: true,
   },
   {
     command: "/skills",
     label: "Skills",
     description: "List available Codex skills.",
     keywords: ["skill"],
+    availableDuringActiveTurn: true,
   },
   {
     command: "/fast",
@@ -98,6 +102,7 @@ export const slashCommandOptions: SlashCommandOption[] = [
     label: "Rename",
     description: "Rename the current thread.",
     keywords: ["thread", "title"],
+    availableDuringActiveTurn: true,
   },
   {
     command: "/approvals",
@@ -110,6 +115,7 @@ export const slashCommandOptions: SlashCommandOption[] = [
     label: "Status Line",
     description: "Configure status line items.",
     keywords: ["status", "display"],
+    availableDuringActiveTurn: true,
   },
   {
     command: "/sandbox-add-read-dir",
@@ -122,6 +128,7 @@ export const slashCommandOptions: SlashCommandOption[] = [
     label: "Feedback",
     description: "Report a problem with Codex.",
     keywords: ["issue", "bug"],
+    availableDuringActiveTurn: true,
   },
 ];
 
@@ -158,6 +165,19 @@ export function filterSlashCommands(
       .toLowerCase();
     return searchableText.includes(normalizedQuery);
   });
+}
+
+export function filterSlashCommandsForState(
+  commands: SlashCommandOption[],
+  options: {
+    isChatRunning: boolean;
+  },
+): SlashCommandOption[] {
+  if (!options.isChatRunning) {
+    return commands;
+  }
+
+  return commands.filter((command) => command.availableDuringActiveTurn);
 }
 
 export function completeSlashCommand(command: SlashCommandOption): string {

--- a/packages/web/src/routes/home.tsx
+++ b/packages/web/src/routes/home.tsx
@@ -143,6 +143,7 @@ import {
   filterSlashCommandsForState,
   getSlashCommandKeyAction,
   getSlashCommandQuery,
+  getSlashCommandSubmitMode,
   shouldOpenSlashCommandMenu,
   slashCommandOptions,
   type SlashCommandOption,
@@ -1124,33 +1125,42 @@ export function HomeRoute() {
     Boolean(
       selectedChatId && pendingSendChatIdsRef.current.has(selectedChatId),
     );
-  const canSubmitPrimaryComposerAction =
-    canSendMessage &&
-    !isComposerBlocked &&
-    (primaryComposerMode !== "steer" || isChatRunning);
   const canQueueComposerMessage =
     hasSelectedChat &&
     !isSelectedChatArchived &&
     canSendMessage &&
     !isComposerBlocked;
+  const effectivePrimaryComposerMode = getSlashCommandSubmitMode(
+    slashCommandOptions,
+    {
+      composerText,
+      submitMode: primaryComposerMode,
+    },
+  );
+  const canSubmitPrimaryComposerAction =
+    canSendMessage &&
+    !isComposerBlocked &&
+    (effectivePrimaryComposerMode !== "steer" || isChatRunning);
   const canInterruptActiveTurn =
     hasActiveTurn && !isInterrupting && Boolean(selectedChat?.activeTurnId);
   const areComposerOptionsDisabled = !hasSelectedChat || isComposerBlocked;
   const canSelectProjectComposerContext =
     Boolean(selectedProject) && !isComposerBlocked;
-  const primaryComposerActionLabel =
-    formatComposerModeAction(primaryComposerMode);
+  const primaryComposerActionLabel = formatComposerModeAction(
+    effectivePrimaryComposerMode,
+  );
   const primaryComposerButtonLabel =
-    pendingComposerMode === primaryComposerMode
-      ? formatComposerModeBusy(pendingComposerMode)
+    pendingComposerMode === effectivePrimaryComposerMode
+      ? formatComposerModeBusy(effectivePrimaryComposerMode)
       : primaryComposerActionLabel;
   const slashCommandQuery = getSlashCommandQuery(composerText);
   const availableSlashCommandOptions = useMemo(
     () =>
       filterSlashCommandsForState(slashCommandOptions, {
+        canQueueCommands: canQueueComposerMessage,
         hasActiveTurn,
       }),
-    [hasActiveTurn],
+    [canQueueComposerMessage, hasActiveTurn],
   );
   const filteredSlashCommandOptions = useMemo(
     () =>
@@ -3275,15 +3285,24 @@ export function HomeRoute() {
       return;
     }
     const submitMode = getComposerSubmitModeForEnter(action, selectedChat);
-    if (!submitMode || (!validatedSelectedChatId && submitMode !== "send")) {
+    const effectiveSubmitMode = submitMode
+      ? getSlashCommandSubmitMode(slashCommandOptions, {
+          composerText,
+          submitMode,
+        })
+      : null;
+    if (
+      !effectiveSubmitMode ||
+      (!validatedSelectedChatId && effectiveSubmitMode !== "send")
+    ) {
       return;
     }
     event.preventDefault();
-    if (submitMode === "send") {
+    if (effectiveSubmitMode === "send") {
       event.currentTarget.form?.requestSubmit();
       return;
     }
-    void submitComposer(submitMode);
+    void submitComposer(effectiveSubmitMode);
   }
 
   async function interruptChat() {
@@ -4563,44 +4582,46 @@ export function HomeRoute() {
                     >
                       <Paperclip />
                     </Button>
-                    {hasSelectedChat && primaryComposerMode !== "queue" && (
-                      <Button
-                        aria-label={
-                          pendingComposerMode === "queue"
-                            ? "Queueing message"
-                            : "Queue message"
-                        }
-                        className="size-10"
-                        disabled={!canQueueComposerMessage}
-                        onClick={() => void submitComposer("queue")}
-                        size="icon"
-                        title="Queue message"
-                        type="button"
-                        variant="outline"
-                      >
-                        {pendingComposerMode === "queue" ? (
-                          <LoadingSpinner />
-                        ) : (
-                          <Clock3 />
-                        )}
-                      </Button>
-                    )}
+                    {hasSelectedChat &&
+                      effectivePrimaryComposerMode !== "queue" && (
+                        <Button
+                          aria-label={
+                            pendingComposerMode === "queue"
+                              ? "Queueing message"
+                              : "Queue message"
+                          }
+                          className="size-10"
+                          disabled={!canQueueComposerMessage}
+                          onClick={() => void submitComposer("queue")}
+                          size="icon"
+                          title="Queue message"
+                          type="button"
+                          variant="outline"
+                        >
+                          {pendingComposerMode === "queue" ? (
+                            <LoadingSpinner />
+                          ) : (
+                            <Clock3 />
+                          )}
+                        </Button>
+                      )}
                     <Button
                       aria-label={primaryComposerButtonLabel}
                       className="size-10"
                       disabled={!canSubmitPrimaryComposerAction}
                       onClick={
                         hasActiveTurn
-                          ? () => void submitComposer(primaryComposerMode)
+                          ? () =>
+                              void submitComposer(effectivePrimaryComposerMode)
                           : undefined
                       }
                       size="icon"
                       title={primaryComposerActionLabel}
                       type={hasActiveTurn ? "button" : "submit"}
                     >
-                      {pendingComposerMode === primaryComposerMode ? (
+                      {pendingComposerMode === effectivePrimaryComposerMode ? (
                         <LoadingSpinner />
-                      ) : primaryComposerMode === "queue" ? (
+                      ) : effectivePrimaryComposerMode === "queue" ? (
                         <Clock3 />
                       ) : (
                         <Send />

--- a/packages/web/src/routes/home.tsx
+++ b/packages/web/src/routes/home.tsx
@@ -36,6 +36,7 @@ import {
   FormEvent,
   KeyboardEvent,
   useEffect,
+  useId,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -136,6 +137,13 @@ import {
   type ComposerSubmitMode,
 } from "../lib/composer-keyboard";
 import { getProjectSkillPathIdentity } from "../lib/project-skill-path";
+import {
+  completeSlashCommand,
+  filterSlashCommands,
+  getSlashCommandQuery,
+  slashCommandOptions,
+  type SlashCommandOption,
+} from "../lib/slash-commands";
 import { cn } from "../lib/utils";
 import {
   dedupeChatThreads,
@@ -206,6 +214,7 @@ const chatEventNames = [
 const chatScrollStorageKeyPrefix = "phantom.chatScroll:v1:";
 const chatScrollBottomThreshold = 4;
 const maxVisibleRecentSkillSuggestions = 5;
+const maxVisibleSlashCommands = 8;
 const searchParamKeys = {
   chat: "chat",
   effort: "effort",
@@ -621,6 +630,10 @@ export function HomeRoute() {
     useState<DeleteWorktreeBranchMode>("default");
   const [deleteWorktreeForce, setDeleteWorktreeForce] = useState(false);
   const [composerText, setComposerText] = useState("");
+  const [dismissedSlashCommandText, setDismissedSlashCommandText] = useState<
+    string | null
+  >(null);
+  const [activeSlashCommandIndex, setActiveSlashCommandIndex] = useState(0);
   const [models, setModels] = useState<CodexModelRecord[]>([]);
   const [skills, setSkills] = useState<CodexSkillRecord[]>([]);
   const [selectedSkillPaths, setSelectedSkillPaths] = useState<Set<string>>(
@@ -716,6 +729,7 @@ export function HomeRoute() {
   const attachmentInputRef = useRef<HTMLInputElement | null>(null);
   const composerTextareaRef = useRef<HTMLTextAreaElement | null>(null);
   const composerTextRef = useRef(composerText);
+  const slashCommandListboxId = useId();
   const hasSelectedContextRef = useRef(false);
   const restoredPendingComposerContextRef =
     useRef<RestoredPendingComposerContext | null>(null);
@@ -1127,6 +1141,50 @@ export function HomeRoute() {
     pendingComposerMode === primaryComposerMode
       ? formatComposerModeBusy(pendingComposerMode)
       : primaryComposerActionLabel;
+  const slashCommandQuery = getSlashCommandQuery(composerText);
+  const filteredSlashCommandOptions = useMemo(
+    () =>
+      slashCommandQuery === null
+        ? []
+        : filterSlashCommands(slashCommandOptions, slashCommandQuery).slice(
+            0,
+            maxVisibleSlashCommands,
+          ),
+    [slashCommandQuery],
+  );
+  const isSlashCommandMenuOpen =
+    Boolean(selectedProject) &&
+    !isComposerBlocked &&
+    slashCommandQuery !== null &&
+    dismissedSlashCommandText !== composerText;
+  const safeActiveSlashCommandIndex =
+    isSlashCommandMenuOpen && filteredSlashCommandOptions.length > 0
+      ? Math.min(
+          activeSlashCommandIndex,
+          filteredSlashCommandOptions.length - 1,
+        )
+      : -1;
+  const activeSlashCommandOption =
+    safeActiveSlashCommandIndex >= 0
+      ? filteredSlashCommandOptions[safeActiveSlashCommandIndex]
+      : null;
+  const activeSlashCommandOptionId =
+    safeActiveSlashCommandIndex >= 0
+      ? `${slashCommandListboxId}-option-${safeActiveSlashCommandIndex}`
+      : undefined;
+
+  useEffect(() => {
+    setActiveSlashCommandIndex(0);
+  }, [slashCommandQuery]);
+
+  useEffect(() => {
+    if (!isSlashCommandMenuOpen || filteredSlashCommandOptions.length === 0) {
+      return;
+    }
+    setActiveSlashCommandIndex((current) =>
+      Math.min(current, filteredSlashCommandOptions.length - 1),
+    );
+  }, [filteredSlashCommandOptions.length, isSlashCommandMenuOpen]);
 
   const modelOptions = useMemo<ComboboxOption[]>(
     () =>
@@ -3099,7 +3157,81 @@ export function HomeRoute() {
     });
   }
 
+  function selectSlashCommand(command: SlashCommandOption) {
+    const completedCommand = completeSlashCommand(command);
+    setComposerText(completedCommand);
+    setDismissedSlashCommandText(null);
+    if (composerError) {
+      setComposerError(null);
+    }
+    requestAnimationFrame(() => {
+      const textarea = composerTextareaRef.current;
+      if (!textarea) {
+        return;
+      }
+      textarea.focus();
+      textarea.setSelectionRange(
+        completedCommand.length,
+        completedCommand.length,
+      );
+    });
+  }
+
+  function moveActiveSlashCommand(delta: number) {
+    const commandCount = filteredSlashCommandOptions.length;
+    if (commandCount === 0) {
+      return;
+    }
+    setActiveSlashCommandIndex(
+      (current) => (current + delta + commandCount) % commandCount,
+    );
+  }
+
+  function selectActiveSlashCommand(): boolean {
+    if (!activeSlashCommandOption) {
+      return false;
+    }
+    selectSlashCommand(activeSlashCommandOption);
+    return true;
+  }
+
   function handleComposerKeyDown(event: KeyboardEvent<HTMLTextAreaElement>) {
+    if (isSlashCommandMenuOpen) {
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        moveActiveSlashCommand(1);
+        return;
+      }
+      if (event.key === "ArrowUp") {
+        event.preventDefault();
+        moveActiveSlashCommand(-1);
+        return;
+      }
+      if (event.key === "Home") {
+        event.preventDefault();
+        setActiveSlashCommandIndex(0);
+        return;
+      }
+      if (event.key === "End") {
+        event.preventDefault();
+        setActiveSlashCommandIndex(
+          Math.max(0, filteredSlashCommandOptions.length - 1),
+        );
+        return;
+      }
+      if (event.key === "Escape") {
+        event.preventDefault();
+        setDismissedSlashCommandText(composerText);
+        return;
+      }
+      if (event.key === "Enter" || event.key === "Tab") {
+        if (selectActiveSlashCommand()) {
+          event.preventDefault();
+          return;
+        }
+      }
+    }
+
     const action = getComposerEnterAction({
       altKey: event.altKey,
       code: event.code,
@@ -4332,11 +4464,30 @@ export function HomeRoute() {
                   </div>
                 )}
                 <div className="flex items-end gap-2">
-                  <div className="min-w-0 flex-1">
+                  <div className="relative min-w-0 flex-1">
                     <Label className="sr-only" htmlFor="composer">
                       Message
                     </Label>
+                    <SlashCommandMenu
+                      activeOptionId={activeSlashCommandOptionId}
+                      activeOptionIndex={safeActiveSlashCommandIndex}
+                      commands={filteredSlashCommandOptions}
+                      isOpen={isSlashCommandMenuOpen}
+                      listboxId={slashCommandListboxId}
+                      query={slashCommandQuery ?? ""}
+                      onActiveOptionChange={setActiveSlashCommandIndex}
+                      onSelectCommand={selectSlashCommand}
+                    />
                     <Textarea
+                      aria-activedescendant={activeSlashCommandOptionId}
+                      aria-autocomplete="list"
+                      aria-controls={
+                        isSlashCommandMenuOpen
+                          ? slashCommandListboxId
+                          : undefined
+                      }
+                      aria-expanded={isSlashCommandMenuOpen}
+                      aria-haspopup="listbox"
                       className="min-h-12 border-0 bg-transparent px-2 py-2 shadow-none focus-visible:shadow-none"
                       disabled={!selectedProject || isComposerBlocked}
                       enterKeyHint="enter"
@@ -4354,7 +4505,11 @@ export function HomeRoute() {
                       ref={composerTextareaRef}
                       value={composerText}
                       onChange={(event) => {
-                        setComposerText(event.target.value);
+                        const nextComposerText = event.target.value;
+                        setComposerText(nextComposerText);
+                        if (dismissedSlashCommandText !== null) {
+                          setDismissedSlashCommandText(null);
+                        }
                         if (composerError) {
                           setComposerError(null);
                         }
@@ -4873,6 +5028,92 @@ function InlineNotice({
           <X className="size-3.5" />
         </button>
       )}
+    </div>
+  );
+}
+
+function SlashCommandMenu({
+  activeOptionId,
+  activeOptionIndex,
+  commands,
+  isOpen,
+  listboxId,
+  onActiveOptionChange,
+  onSelectCommand,
+  query,
+}: {
+  activeOptionId?: string;
+  activeOptionIndex: number;
+  commands: SlashCommandOption[];
+  isOpen: boolean;
+  listboxId: string;
+  onActiveOptionChange: (index: number) => void;
+  onSelectCommand: (command: SlashCommandOption) => void;
+  query: string;
+}) {
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div
+      aria-label="Codex commands"
+      className="absolute bottom-full left-0 right-0 z-40 mb-2 overflow-hidden rounded-[var(--radius-md)] border border-border bg-popover text-popover-foreground shadow-[var(--shadow-md)]"
+    >
+      <div className="flex items-center gap-2 border-b border-[var(--border-divider)] px-3 py-2">
+        <Terminal className="size-3.5 shrink-0 text-[var(--icon-color-muted)]" />
+        <span className="min-w-0 flex-1 truncate text-[length:var(--font-size-xs)] font-medium uppercase text-[var(--text-tertiary)]">
+          Codex commands
+        </span>
+        {query && (
+          <span className="max-w-36 truncate font-mono text-[length:var(--font-size-xs)] text-[var(--text-tertiary)]">
+            /{query}
+          </span>
+        )}
+      </div>
+      <div
+        aria-activedescendant={activeOptionId}
+        className="max-h-72 overflow-y-auto p-1"
+        id={listboxId}
+        role="listbox"
+      >
+        {commands.length === 0 ? (
+          <div className="px-3 py-3 text-[length:var(--font-size-sm)] text-[var(--text-tertiary)]">
+            No matching commands
+          </div>
+        ) : (
+          commands.map((command, index) => {
+            const isActive = index === activeOptionIndex;
+            return (
+              <button
+                aria-selected={isActive}
+                className={cn(
+                  "flex w-full min-w-0 items-start gap-2 rounded-[var(--radius-sm)] px-2.5 py-2 text-left outline-none transition-colors hover:bg-[var(--state-hover-bg)] focus-visible:shadow-[var(--state-focus-ring)]",
+                  isActive && "bg-[var(--state-selected-bg)]",
+                )}
+                id={`${listboxId}-option-${index}`}
+                key={command.command}
+                onClick={() => onSelectCommand(command)}
+                onMouseEnter={() => onActiveOptionChange(index)}
+                role="option"
+                type="button"
+              >
+                <span className="mt-0.5 shrink-0 rounded-[var(--radius-xs)] bg-[var(--surface-code)] px-1.5 py-0.5 font-mono text-[length:var(--font-size-xs)] text-[var(--text-secondary)]">
+                  {command.command}
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate text-[length:var(--font-size-sm)] font-medium text-[var(--text-primary)]">
+                    {command.label}
+                  </span>
+                  <span className="mt-0.5 block truncate text-[length:var(--font-size-xs)] text-[var(--text-tertiary)]">
+                    {command.description}
+                  </span>
+                </span>
+              </button>
+            );
+          })
+        )}
+      </div>
     </div>
   );
 }

--- a/packages/web/src/routes/home.tsx
+++ b/packages/web/src/routes/home.tsx
@@ -140,6 +140,7 @@ import { getProjectSkillPathIdentity } from "../lib/project-skill-path";
 import {
   completeSlashCommand,
   filterSlashCommands,
+  getSlashCommandKeyAction,
   getSlashCommandQuery,
   slashCommandOptions,
   type SlashCommandOption,
@@ -3197,36 +3198,45 @@ export function HomeRoute() {
 
   function handleComposerKeyDown(event: KeyboardEvent<HTMLTextAreaElement>) {
     if (isSlashCommandMenuOpen) {
-      if (event.key === "ArrowDown") {
+      const slashCommandKeyAction = getSlashCommandKeyAction(
+        {
+          altKey: event.altKey,
+          ctrlKey: event.ctrlKey,
+          isComposing: event.nativeEvent.isComposing,
+          key: event.key,
+          keyCode: event.keyCode,
+          metaKey: event.metaKey,
+          shiftKey: event.shiftKey,
+        },
+        filteredSlashCommandOptions.length > 0,
+      );
+
+      if (slashCommandKeyAction) {
         event.preventDefault();
-        moveActiveSlashCommand(1);
-        return;
-      }
-      if (event.key === "ArrowUp") {
-        event.preventDefault();
-        moveActiveSlashCommand(-1);
-        return;
-      }
-      if (event.key === "Home") {
-        event.preventDefault();
-        setActiveSlashCommandIndex(0);
-        return;
-      }
-      if (event.key === "End") {
-        event.preventDefault();
-        setActiveSlashCommandIndex(
-          Math.max(0, filteredSlashCommandOptions.length - 1),
-        );
-        return;
-      }
-      if (event.key === "Escape") {
-        event.preventDefault();
-        setDismissedSlashCommandText(composerText);
-        return;
-      }
-      if (event.key === "Enter" || event.key === "Tab") {
-        if (selectActiveSlashCommand()) {
-          event.preventDefault();
+        if (slashCommandKeyAction === "next") {
+          moveActiveSlashCommand(1);
+          return;
+        }
+        if (slashCommandKeyAction === "previous") {
+          moveActiveSlashCommand(-1);
+          return;
+        }
+        if (slashCommandKeyAction === "first") {
+          setActiveSlashCommandIndex(0);
+          return;
+        }
+        if (slashCommandKeyAction === "last") {
+          setActiveSlashCommandIndex(
+            Math.max(0, filteredSlashCommandOptions.length - 1),
+          );
+          return;
+        }
+        if (slashCommandKeyAction === "dismiss") {
+          setDismissedSlashCommandText(composerText);
+          return;
+        }
+        if (slashCommandKeyAction === "complete") {
+          selectActiveSlashCommand();
           return;
         }
       }

--- a/packages/web/src/routes/home.tsx
+++ b/packages/web/src/routes/home.tsx
@@ -140,6 +140,7 @@ import { getProjectSkillPathIdentity } from "../lib/project-skill-path";
 import {
   completeSlashCommand,
   filterSlashCommands,
+  filterSlashCommandsForState,
   getSlashCommandKeyAction,
   getSlashCommandQuery,
   shouldOpenSlashCommandMenu,
@@ -1144,15 +1145,22 @@ export function HomeRoute() {
       ? formatComposerModeBusy(pendingComposerMode)
       : primaryComposerActionLabel;
   const slashCommandQuery = getSlashCommandQuery(composerText);
+  const availableSlashCommandOptions = useMemo(
+    () =>
+      filterSlashCommandsForState(slashCommandOptions, {
+        isChatRunning,
+      }),
+    [isChatRunning],
+  );
   const filteredSlashCommandOptions = useMemo(
     () =>
       slashCommandQuery === null
         ? []
-        : filterSlashCommands(slashCommandOptions, slashCommandQuery).slice(
-            0,
-            maxVisibleSlashCommands,
-          ),
-    [slashCommandQuery],
+        : filterSlashCommands(
+            availableSlashCommandOptions,
+            slashCommandQuery,
+          ).slice(0, maxVisibleSlashCommands),
+    [availableSlashCommandOptions, slashCommandQuery],
   );
   const isSlashCommandMenuOpen = shouldOpenSlashCommandMenu({
     composerText,

--- a/packages/web/src/routes/home.tsx
+++ b/packages/web/src/routes/home.tsx
@@ -1148,9 +1148,9 @@ export function HomeRoute() {
   const availableSlashCommandOptions = useMemo(
     () =>
       filterSlashCommandsForState(slashCommandOptions, {
-        isChatRunning,
+        hasActiveTurn,
       }),
-    [isChatRunning],
+    [hasActiveTurn],
   );
   const filteredSlashCommandOptions = useMemo(
     () =>
@@ -5073,6 +5073,21 @@ function SlashCommandMenu({
   onSelectCommand: (command: SlashCommandOption) => void;
   query: string;
 }) {
+  const listboxRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isOpen || !activeOptionId) {
+      return;
+    }
+
+    const activeOption = document.getElementById(activeOptionId);
+    if (!activeOption || !listboxRef.current?.contains(activeOption)) {
+      return;
+    }
+
+    activeOption.scrollIntoView({ block: "nearest" });
+  }, [activeOptionId, isOpen]);
+
   if (!isOpen) {
     return null;
   }
@@ -5097,6 +5112,7 @@ function SlashCommandMenu({
         aria-activedescendant={activeOptionId}
         className="max-h-72 overflow-y-auto p-1"
         id={listboxId}
+        ref={listboxRef}
         role="listbox"
       >
         {commands.length === 0 ? (

--- a/packages/web/src/routes/home.tsx
+++ b/packages/web/src/routes/home.tsx
@@ -142,6 +142,7 @@ import {
   filterSlashCommands,
   getSlashCommandKeyAction,
   getSlashCommandQuery,
+  shouldOpenSlashCommandMenu,
   slashCommandOptions,
   type SlashCommandOption,
 } from "../lib/slash-commands";
@@ -1153,11 +1154,14 @@ export function HomeRoute() {
           ),
     [slashCommandQuery],
   );
-  const isSlashCommandMenuOpen =
-    Boolean(selectedProject) &&
-    !isComposerBlocked &&
-    slashCommandQuery !== null &&
-    dismissedSlashCommandText !== composerText;
+  const isSlashCommandMenuOpen = shouldOpenSlashCommandMenu({
+    composerText,
+    dismissedText: dismissedSlashCommandText,
+    hasSelectedChat,
+    hasSelectedProject: Boolean(selectedProject),
+    isComposerBlocked,
+    query: slashCommandQuery,
+  });
   const safeActiveSlashCommandIndex =
     isSlashCommandMenuOpen && filteredSlashCommandOptions.length > 0
       ? Math.min(


### PR DESCRIPTION
Summary:
- Add a Codex slash command suggestion popup to the web chat composer.
- Support filtering, keyboard navigation, Enter/Tab completion, and Escape dismissal.
- Add slash command helper tests and keep selected commands flowing through the existing text input protocol.

Verification:
- pnpm --filter @phantompane/web test
- pnpm --filter @phantompane/web typecheck
- pnpm ready