### PR TITLE
fix: archive empty chats without rollout files

### DIFF
--- a/packages/server/src/services.test.ts
+++ b/packages/server/src/services.test.ts
@@ -1738,13 +1738,71 @@ describe("ServeServices", () => {
     const restoredChat = await services.setChatArchived("chat_1", false);
 
     strictEqual(archivedChat.status, "archived");
-    strictEqual(archivedChat.codexThreadId, null);
+    strictEqual(archivedChat.codexThreadId, threadId);
+    strictEqual(archivedChat.codexArchiveUnavailable, true);
     strictEqual(restoredChat.status, "idle");
-    strictEqual(restoredChat.codexThreadId, null);
+    strictEqual(restoredChat.codexThreadId, threadId);
+    strictEqual(restoredChat.codexArchiveUnavailable, undefined);
     strictEqual((await store.load()).chats[0]?.status, "idle");
-    strictEqual((await store.load()).chats[0]?.codexThreadId, null);
+    strictEqual((await store.load()).chats[0]?.codexThreadId, threadId);
     deepStrictEqual(codex.archiveThread.mock.calls, [[threadId]]);
     strictEqual(codex.unarchiveThread.mock.calls.length, 0);
+  });
+
+  it("keeps empty chats with unavailable Codex archives matched during sync", async () => {
+    const threadId = "019e2ee9-8e0e-7722-9fa1-86230697e3c9";
+    const worktreePath = "/repo/.git/phantom/worktrees/feature/list";
+    const { codex, services, store } = await createHarness({
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [
+        createChat({
+          codexArchiveUnavailable: true,
+          codexThreadId: threadId,
+          status: "archived",
+          worktreeName: "feature/list",
+          worktreePath,
+        }),
+      ],
+    });
+    coreMocks.listWorktrees.mockResolvedValue({
+      ok: true,
+      value: {
+        worktrees: [
+          {
+            name: "feature/list",
+            path: worktreePath,
+            pathToDisplay: ".git/phantom/worktrees/feature/list",
+            branch: "feature/list",
+            isClean: true,
+          },
+        ],
+      },
+    });
+    codex.listThreads.mockResolvedValueOnce({
+      threads: [
+        {
+          id: threadId,
+          cwd: worktreePath,
+          title: "Existing work",
+          createdAt: "2026-04-25T00:00:00.000Z",
+          updatedAt: "2026-04-25T00:03:00.000Z",
+        },
+      ],
+    });
+    codex.listThreads.mockResolvedValueOnce({ threads: [] });
+
+    const chats = await services.listChats("proj_1");
+
+    strictEqual(chats.length, 1);
+    strictEqual(chats[0]?.id, "chat_1");
+    strictEqual(chats[0]?.status, "archived");
+    strictEqual(chats[0]?.codexThreadId, threadId);
+    strictEqual(chats[0]?.codexArchiveUnavailable, true);
+    const savedState = await store.load();
+    strictEqual(savedState.chats.length, 1);
+    strictEqual(savedState.chats[0]?.id, "chat_1");
+    strictEqual(savedState.chats[0]?.status, "archived");
   });
 
   it("does not archive non-empty chats with missing Codex rollouts locally", async () => {

--- a/packages/server/src/services.test.ts
+++ b/packages/server/src/services.test.ts
@@ -1723,6 +1723,56 @@ describe("ServeServices", () => {
     strictEqual(codex.unarchiveThread.mock.calls.length, 0);
   });
 
+  it("archives empty chats with missing Codex rollouts locally", async () => {
+    const threadId = "019e2ee9-8e0e-7722-9fa1-86230697e3c9";
+    const { codex, services, store } = await createHarness({
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ codexThreadId: threadId })],
+    });
+    codex.archiveThread.mockRejectedValueOnce(
+      new Error(`no rollout found for thread id ${threadId}`),
+    );
+
+    const archivedChat = await services.setChatArchived("chat_1", true);
+    const restoredChat = await services.setChatArchived("chat_1", false);
+
+    strictEqual(archivedChat.status, "archived");
+    strictEqual(archivedChat.codexThreadId, null);
+    strictEqual(restoredChat.status, "idle");
+    strictEqual(restoredChat.codexThreadId, null);
+    strictEqual((await store.load()).chats[0]?.status, "idle");
+    strictEqual((await store.load()).chats[0]?.codexThreadId, null);
+    deepStrictEqual(codex.archiveThread.mock.calls, [[threadId]]);
+    strictEqual(codex.unarchiveThread.mock.calls.length, 0);
+  });
+
+  it("does not archive non-empty chats with missing Codex rollouts locally", async () => {
+    const threadId = "019e2ee9-8e0e-7722-9fa1-86230697e3c9";
+    const { codex, services, store } = await createHarness({
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ codexThreadId: threadId })],
+      messages: [
+        {
+          id: "msg_1",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "existing message",
+          createdAt: timestamp,
+        },
+      ],
+    });
+    codex.archiveThread.mockRejectedValueOnce(
+      new Error(`no rollout found for thread id ${threadId}`),
+    );
+
+    await rejects(services.setChatArchived("chat_1", true), /no rollout found/);
+
+    strictEqual((await store.load()).chats[0]?.status, "idle");
+    strictEqual((await store.load()).chats[0]?.codexThreadId, threadId);
+  });
+
   it("does not update local archive state when Codex archive fails", async () => {
     const { codex, services, store } = await createHarness({
       ...createTestState(),

--- a/packages/server/src/services.ts
+++ b/packages/server/src/services.ts
@@ -553,10 +553,26 @@ export class ServeServices {
           .filter((chat) => chat.codexThreadId)
           .map((chat) => [chat.codexThreadId, chat]),
       );
-      const nextProjectChats = threadChats.map((chat) => {
+      const nextProjectChats = threadChats.map((chat): ChatRecord => {
         const existingChat = existingChatsByThreadId.get(chat.codexThreadId);
         if (!existingChat) {
           return chat;
+        }
+        if (
+          chat.status !== "archived" &&
+          existingChat.status === "archived" &&
+          existingChat.codexArchiveUnavailable &&
+          isLocallyEmptyChat(nextState, existingChat)
+        ) {
+          return {
+            ...chat,
+            id: existingChat.id,
+            status: "archived",
+            activeTurnId: null,
+            codexArchiveUnavailable: true,
+            createdAt: existingChat.createdAt,
+            updatedAt: existingChat.updatedAt,
+          };
         }
         const archiveBlockMessage =
           chat.status === "archived"
@@ -1229,13 +1245,13 @@ export class ServeServices {
     }
     this.assertCanSetChatArchived(initialState, initialChat, archived);
     this.archiveOperationChatIds.add(chatId);
-    let clearUnavailableCodexThread = false;
+    let codexArchiveUnavailable = false;
     try {
       if (initialChat.codexThreadId) {
         try {
           if (archived) {
             await this.codex.archiveThread(initialChat.codexThreadId);
-          } else {
+          } else if (!initialChat.codexArchiveUnavailable) {
             await this.codex.unarchiveThread(initialChat.codexThreadId);
           }
         } catch (error) {
@@ -1244,7 +1260,7 @@ export class ServeServices {
             isMissingCodexRolloutError(error, initialChat.codexThreadId) &&
             isLocallyEmptyChat(initialState, initialChat)
           ) {
-            clearUnavailableCodexThread = true;
+            codexArchiveUnavailable = true;
           } else {
             throw error;
           }
@@ -1263,11 +1279,13 @@ export class ServeServices {
 
         const nextChat: ChatRecord = {
           ...chat,
-          codexThreadId: clearUnavailableCodexThread
-            ? null
-            : chat.codexThreadId,
           status: archived ? "archived" : "idle",
           activeTurnId: null,
+          codexArchiveUnavailable:
+            archived &&
+            (codexArchiveUnavailable || chat.codexArchiveUnavailable)
+              ? true
+              : undefined,
           updatedAt: createTimestamp(),
         };
         updatedChat = nextChat;

--- a/packages/server/src/services.ts
+++ b/packages/server/src/services.ts
@@ -1229,12 +1229,25 @@ export class ServeServices {
     }
     this.assertCanSetChatArchived(initialState, initialChat, archived);
     this.archiveOperationChatIds.add(chatId);
+    let clearUnavailableCodexThread = false;
     try {
       if (initialChat.codexThreadId) {
-        if (archived) {
-          await this.codex.archiveThread(initialChat.codexThreadId);
-        } else {
-          await this.codex.unarchiveThread(initialChat.codexThreadId);
+        try {
+          if (archived) {
+            await this.codex.archiveThread(initialChat.codexThreadId);
+          } else {
+            await this.codex.unarchiveThread(initialChat.codexThreadId);
+          }
+        } catch (error) {
+          if (
+            archived &&
+            isMissingCodexRolloutError(error, initialChat.codexThreadId) &&
+            isLocallyEmptyChat(initialState, initialChat)
+          ) {
+            clearUnavailableCodexThread = true;
+          } else {
+            throw error;
+          }
         }
       }
 
@@ -1250,6 +1263,9 @@ export class ServeServices {
 
         const nextChat: ChatRecord = {
           ...chat,
+          codexThreadId: clearUnavailableCodexThread
+            ? null
+            : chat.codexThreadId,
           status: archived ? "archived" : "idle",
           activeTurnId: null,
           updatedAt: createTimestamp(),
@@ -6679,6 +6695,21 @@ function getStringArray(value: unknown): string[] {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function isLocallyEmptyChat(state: ServeState, chat: ChatRecord): boolean {
+  return (
+    !state.messages.some((message) => message.chatId === chat.id) &&
+    !state.queuedMessages.some((message) => message.chatId === chat.id)
+  );
+}
+
+function isMissingCodexRolloutError(error: unknown, threadId: string): boolean {
+  const message = toErrorMessage(error);
+  return (
+    message.includes("no rollout found for thread id") &&
+    message.includes(threadId)
+  );
 }
 
 function toErrorMessage(error: unknown): string {

--- a/packages/state/src/types.ts
+++ b/packages/state/src/types.ts
@@ -74,6 +74,7 @@ const chatRecordBaseSchema = z.object({
   title: z.string(),
   status: chatStatusSchema,
   activeTurnId: z.string().nullable().optional(),
+  codexArchiveUnavailable: z.boolean().optional(),
   hasQueuedMessages: z.boolean().optional(),
   isDrainingQueuedMessages: z.boolean().optional(),
   createdAt: z.string(),


### PR DESCRIPTION
## Summary

- Allow empty Phantom chats to archive locally when Codex reports the thread has no rollout file.
- Clear the unavailable Codex thread id for that empty-chat case so restore can also complete locally.
- Keep non-empty chats failing on missing rollouts to avoid disconnecting chats that may have real history.

## Testing

- `pnpm --filter @phantompane/server test -- services.test.ts`
- `pnpm ready`