### PR TITLE
fix: preserve local chat message order

### DIFF
--- a/packages/server/src/services.test.ts
+++ b/packages/server/src/services.test.ts
@@ -3100,6 +3100,99 @@ describe("ServeServices", () => {
     );
   });
 
+  it("keeps unmatched local transcript messages between fallback Codex anchors", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "idle", activeTurnId: null })],
+      messages: [
+        {
+          id: "msg_user_1",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "install skills",
+          createdAt: "2026-04-25T00:01:00.000Z",
+        },
+        {
+          id: "msg_assistant_1",
+          chatId: "chat_1",
+          role: "assistant" as const,
+          text: "already installed",
+          eventType: "item/agentMessage/delta",
+          itemId: "agent_msg_1",
+          createdAt: "2026-04-25T00:02:00.000Z",
+        },
+        {
+          id: "msg_interrupted",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "use npx",
+          createdAt: "2026-04-25T00:03:00.000Z",
+        },
+        {
+          id: "msg_user_2",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "use npx skills\ncheck README",
+          createdAt: "2026-04-25T00:04:00.000Z",
+        },
+        {
+          id: "msg_assistant_2",
+          chatId: "chat_1",
+          role: "assistant" as const,
+          text: "using npx",
+          eventType: "item/agentMessage/delta",
+          itemId: "agent_msg_2",
+          createdAt: "2026-04-25T00:05:00.000Z",
+        },
+      ],
+    };
+    const { codex, services } = await createHarness(state);
+    codex.readThread.mockResolvedValueOnce({
+      thread: {
+        turns: [
+          {
+            id: "turn_1",
+            items: [
+              { type: "userMessage", text: "install skills" },
+              { type: "agentMessage", text: "already installed" },
+            ],
+          },
+          {
+            id: "turn_2",
+            items: [
+              { type: "userMessage", text: "use npx skills\ncheck README" },
+              { type: "agentMessage", text: "using npx" },
+            ],
+          },
+        ],
+      },
+    });
+
+    const messages = await services.getMessages("chat_1");
+
+    deepStrictEqual(
+      messages.map((message) => [
+        message.id,
+        message.role,
+        message.text,
+        message.eventType,
+      ]),
+      [
+        ["chat_1_codex_turn_1_0", "user", "install skills", undefined],
+        ["chat_1_codex_turn_1_1", "assistant", "already installed", undefined],
+        ["msg_interrupted", "user", "use npx", undefined],
+        [
+          "chat_1_codex_turn_2_0",
+          "user",
+          "use npx skills\ncheck README",
+          undefined,
+        ],
+        ["chat_1_codex_turn_2_1", "assistant", "using npx", undefined],
+      ],
+    );
+  });
+
   it("treats missing active turn id as inactive for fallback transcript deduplication", async () => {
     const chatWithoutActiveTurnId = createChat({ status: "idle" });
     delete (chatWithoutActiveTurnId as Partial<typeof chatWithoutActiveTurnId>)

--- a/packages/server/src/services.ts
+++ b/packages/server/src/services.ts
@@ -4744,7 +4744,7 @@ function getStandardLocalMessageMergeSortBucket(
         !codexMessage.hasFallbackTimestamp &&
         codexMessage.createdAt > message.createdAt,
     );
-    return applyEarlierLocalCodexBoundary(
+    return applyLocalCodexBoundaries(
       nextTrustedInsertionIndex === -1
         ? getAfterCodexMessagesMergeSortBucket(orderedCodexMessages, 1)
         : getBeforeCodexMessageMergeSortBucket(
@@ -4763,7 +4763,7 @@ function getStandardLocalMessageMergeSortBucket(
           orderedCodexMessages,
           insertionIndex,
         );
-  return applyEarlierLocalCodexBoundary(
+  return applyLocalCodexBoundaries(
     bucket,
     index,
     localMessages,
@@ -4771,7 +4771,7 @@ function getStandardLocalMessageMergeSortBucket(
   );
 }
 
-function applyEarlierLocalCodexBoundary(
+function applyLocalCodexBoundaries(
   bucket: number,
   index: number | undefined,
   localMessages: ChatMessageRecord[] | undefined,
@@ -4787,10 +4787,21 @@ function applyEarlierLocalCodexBoundary(
         localMessageCodexOrderMatches,
       )
     : undefined;
-  if (earlierMatchedCodexOrder === undefined) {
-    return bucket;
+  const laterMatchedCodexOrder = localMessages
+    ? getLaterLocalCodexOrder(
+        index,
+        localMessages,
+        localMessageCodexOrderMatches,
+      )
+    : undefined;
+  let boundedBucket = bucket;
+  if (earlierMatchedCodexOrder !== undefined) {
+    boundedBucket = Math.max(boundedBucket, earlierMatchedCodexOrder * 2 + 0.5);
   }
-  return Math.max(bucket, earlierMatchedCodexOrder * 2 + 0.5);
+  if (laterMatchedCodexOrder !== undefined) {
+    boundedBucket = Math.min(boundedBucket, laterMatchedCodexOrder * 2 - 0.5);
+  }
+  return boundedBucket;
 }
 
 function getEarlierLocalCodexOrder(
@@ -4801,6 +4812,17 @@ function getEarlierLocalCodexOrder(
   return localMessages
     .slice(0, index)
     .reverse()
+    .map((message) => localMessageCodexOrderMatches.get(message.id))
+    .find((codexOrder): codexOrder is number => codexOrder !== undefined);
+}
+
+function getLaterLocalCodexOrder(
+  index: number,
+  localMessages: ChatMessageRecord[],
+  localMessageCodexOrderMatches: ReadonlyMap<string, number>,
+): number | undefined {
+  return localMessages
+    .slice(index + 1)
     .map((message) => localMessageCodexOrderMatches.get(message.id))
     .find((codexOrder): codexOrder is number => codexOrder !== undefined);
 }
@@ -4887,7 +4909,7 @@ function getLiveAssistantDeltaMergeSortBucket(
     orderedCodexMessages,
     boundaryInsertionIndex,
   );
-  return applyEarlierLocalCodexBoundary(
+  return applyLocalCodexBoundaries(
     bucket,
     index,
     localMessages,


### PR DESCRIPTION
## Summary

- Preserve local-only chat messages between their surrounding Codex transcript anchors when Codex thread history only has fallback timestamps.
- Add regression coverage for an interrupted `use npx` style message so it stays in chronological chat order instead of drifting to the bottom.

## Testing

- `pnpm --filter @phantompane/server test -- services.test.ts`
- `pnpm ready`