### PR TITLE
fix: defer post-create after worktree creation

### DIFF
--- a/packages/cli/src/handlers/create.test.ts
+++ b/packages/cli/src/handlers/create.test.ts
@@ -104,6 +104,10 @@ describe("createHandler", () => {
       "vertical",
     );
     strictEqual(runCreateWorktreeMock.mock.calls[0][0].logger, outputMock);
+    strictEqual(
+      runCreateWorktreeMock.mock.calls[0][0].postCreate,
+      "afterAction",
+    );
   });
 
   it("maps validation errors to validation exit codes", async () => {

--- a/packages/cli/src/handlers/create.test.ts
+++ b/packages/cli/src/handlers/create.test.ts
@@ -9,6 +9,7 @@ import { err, ok } from "@phantompane/utils";
 
 const exitMock = vi.fn();
 const runCreateWorktreeMock = vi.fn();
+const runPostCreateWorktreeMock = vi.fn();
 const exitWithErrorMock = vi.fn((message, code) => {
   throw new Error(`Exit with code ${code}: ${message}`);
 });
@@ -33,6 +34,7 @@ afterAll(() => {
 
 vi.doMock("@phantompane/core", () => ({
   runCreateWorktree: runCreateWorktreeMock,
+  runPostCreateWorktree: runPostCreateWorktreeMock,
   TmuxSessionRequiredError,
   WorktreeActionConflictError,
   WorktreeAlreadyExistsError,
@@ -65,6 +67,8 @@ describe("createHandler", () => {
   const resetMocks = () => {
     exitMock.mockReset();
     runCreateWorktreeMock.mockReset();
+    runPostCreateWorktreeMock.mockReset();
+    runPostCreateWorktreeMock.mockResolvedValue(ok({ executedCommands: [] }));
     exitWithErrorMock.mockReset();
     exitWithSuccessMock.mockReset();
     outputMock.log.mockReset();
@@ -104,10 +108,13 @@ describe("createHandler", () => {
       "vertical",
     );
     strictEqual(runCreateWorktreeMock.mock.calls[0][0].logger, outputMock);
+    strictEqual(runCreateWorktreeMock.mock.calls[0][0].postCreate, undefined);
+    strictEqual(runPostCreateWorktreeMock.mock.calls.length, 1);
     strictEqual(
-      runCreateWorktreeMock.mock.calls[0][0].postCreate,
-      "afterAction",
+      runPostCreateWorktreeMock.mock.calls[0][0].worktreeName,
+      "feature",
     );
+    strictEqual(runPostCreateWorktreeMock.mock.calls[0][0].logger, outputMock);
   });
 
   it("maps validation errors to validation exit codes", async () => {
@@ -126,6 +133,7 @@ describe("createHandler", () => {
       new WorktreeActionConflictError().message,
     );
     strictEqual(exitWithErrorMock.mock.calls[0][1], 2);
+    strictEqual(runPostCreateWorktreeMock.mock.calls.length, 0);
   });
 
   it("exits with the propagated process exit code when core requests it", async () => {
@@ -141,6 +149,7 @@ describe("createHandler", () => {
 
     await createHandler(["feature", "--exec", "echo hello"]);
 
+    strictEqual(runPostCreateWorktreeMock.mock.calls.length, 1);
     strictEqual(exitMock.mock.calls[0][0], 0);
     strictEqual(exitWithSuccessMock.mock.calls.length, 0);
   });

--- a/packages/cli/src/handlers/create.test.ts
+++ b/packages/cli/src/handlers/create.test.ts
@@ -8,7 +8,10 @@ import {
 import { err, ok } from "@phantompane/utils";
 
 const exitMock = vi.fn();
+const resolveWorktreeActionMock = vi.fn();
+const validateWorktreeActionMock = vi.fn();
 const runCreateWorktreeMock = vi.fn();
+const runWorktreeActionMock = vi.fn();
 const runPostCreateWorktreeMock = vi.fn();
 const exitWithErrorMock = vi.fn((message, code) => {
   throw new Error(`Exit with code ${code}: ${message}`);
@@ -33,9 +36,12 @@ afterAll(() => {
 });
 
 vi.doMock("@phantompane/core", () => ({
+  resolveWorktreeAction: resolveWorktreeActionMock,
   runCreateWorktree: runCreateWorktreeMock,
+  runWorktreeAction: runWorktreeActionMock,
   runPostCreateWorktree: runPostCreateWorktreeMock,
   TmuxSessionRequiredError,
+  validateWorktreeAction: validateWorktreeActionMock,
   WorktreeActionConflictError,
   WorktreeAlreadyExistsError,
 }));
@@ -66,7 +72,30 @@ const { createHandler } = await import("./create.ts");
 describe("createHandler", () => {
   const resetMocks = () => {
     exitMock.mockReset();
+    resolveWorktreeActionMock.mockReset();
+    resolveWorktreeActionMock.mockImplementation((options) => {
+      if (options.shell && options.exec !== undefined) {
+        return err(new WorktreeActionConflictError());
+      }
+      if (options.shell) {
+        return ok({ kind: "shell" });
+      }
+      if (options.exec !== undefined) {
+        return ok({ kind: "exec", command: options.exec });
+      }
+      if (options.tmuxDirection) {
+        return ok({ kind: "tmux", direction: options.tmuxDirection });
+      }
+      return ok(undefined);
+    });
+    validateWorktreeActionMock.mockReset();
+    validateWorktreeActionMock.mockResolvedValue(ok(undefined));
     runCreateWorktreeMock.mockReset();
+    runWorktreeActionMock.mockReset();
+    runWorktreeActionMock.mockImplementation((options) => {
+      options.onStarted?.();
+      return Promise.resolve(ok({}));
+    });
     runPostCreateWorktreeMock.mockReset();
     runPostCreateWorktreeMock.mockResolvedValue(ok({ executedCommands: [] }));
     exitWithErrorMock.mockReset();
@@ -80,6 +109,8 @@ describe("createHandler", () => {
     resetMocks();
     runCreateWorktreeMock.mockResolvedValue(
       ok({
+        gitRoot: "/repo",
+        worktreesDirectory: "/repo/.git/phantom/worktrees",
         name: "feature",
         path: "/repo/.git/phantom/worktrees/feature",
         message: "Created worktree",
@@ -103,12 +134,13 @@ describe("createHandler", () => {
     strictEqual(runCreateWorktreeMock.mock.calls[0][0].name, "feature");
     strictEqual(runCreateWorktreeMock.mock.calls[0][0].base, "main");
     strictEqual(runCreateWorktreeMock.mock.calls[0][0].copyFiles[0], ".env");
+    strictEqual(runCreateWorktreeMock.mock.calls[0][0].logger, outputMock);
     strictEqual(
-      runCreateWorktreeMock.mock.calls[0][0].action.tmuxDirection,
+      runWorktreeActionMock.mock.calls[0][0].action.direction,
       "vertical",
     );
-    strictEqual(runCreateWorktreeMock.mock.calls[0][0].logger, outputMock);
     strictEqual(runCreateWorktreeMock.mock.calls[0][0].postCreate, undefined);
+    strictEqual(runWorktreeActionMock.mock.calls[0][0].logger, outputMock);
     strictEqual(runPostCreateWorktreeMock.mock.calls.length, 1);
     strictEqual(
       runPostCreateWorktreeMock.mock.calls[0][0].worktreeName,
@@ -119,9 +151,6 @@ describe("createHandler", () => {
 
   it("maps validation errors to validation exit codes", async () => {
     resetMocks();
-    runCreateWorktreeMock.mockResolvedValue(
-      err(new WorktreeActionConflictError()),
-    );
 
     await rejects(
       async () => await createHandler(["feature", "--shell", "--exec", "ls"]),
@@ -133,6 +162,7 @@ describe("createHandler", () => {
       new WorktreeActionConflictError().message,
     );
     strictEqual(exitWithErrorMock.mock.calls[0][1], 2);
+    strictEqual(runCreateWorktreeMock.mock.calls.length, 0);
     strictEqual(runPostCreateWorktreeMock.mock.calls.length, 0);
   });
 
@@ -140,12 +170,17 @@ describe("createHandler", () => {
     resetMocks();
     runCreateWorktreeMock.mockResolvedValue(
       ok({
+        gitRoot: "/repo",
+        worktreesDirectory: "/repo/.git/phantom/worktrees",
         name: "feature",
         path: "/repo/.git/phantom/worktrees/feature",
         message: "Created worktree",
-        exitProcessCode: 0,
       }),
     );
+    runWorktreeActionMock.mockImplementation((options) => {
+      options.onStarted?.();
+      return Promise.resolve(ok({ exitProcessCode: 0 }));
+    });
 
     await createHandler(["feature", "--exec", "echo hello"]);
 
@@ -154,9 +189,48 @@ describe("createHandler", () => {
     strictEqual(exitWithSuccessMock.mock.calls.length, 0);
   });
 
+  it("starts post-create when the requested action starts", async () => {
+    resetMocks();
+    let resolveAction!: (result: unknown) => void;
+    runCreateWorktreeMock.mockResolvedValue(
+      ok({
+        gitRoot: "/repo",
+        worktreesDirectory: "/repo/.git/phantom/worktrees",
+        name: "feature",
+        path: "/repo/.git/phantom/worktrees/feature",
+        message: "Created worktree",
+      }),
+    );
+    runWorktreeActionMock.mockImplementation((options) => {
+      options.onStarted?.();
+      return new Promise((resolve) => {
+        resolveAction = resolve;
+      });
+    });
+
+    const handler = createHandler(["feature", "--shell"]);
+
+    await vi.waitFor(() => {
+      strictEqual(runPostCreateWorktreeMock.mock.calls.length, 1);
+    });
+    strictEqual(exitWithSuccessMock.mock.calls.length, 0);
+
+    resolveAction(ok({}));
+    await rejects(async () => await handler, /Exit with code 0/);
+  });
+
   it("preserves process error exit codes from core actions", async () => {
     resetMocks();
     runCreateWorktreeMock.mockResolvedValue(
+      ok({
+        gitRoot: "/repo",
+        worktreesDirectory: "/repo/.git/phantom/worktrees",
+        name: "feature",
+        path: "/repo/.git/phantom/worktrees/feature",
+        message: "Created worktree",
+      }),
+    );
+    runWorktreeActionMock.mockResolvedValue(
       err(
         Object.assign(
           new Error("Command '/bin/sh' failed with exit code 127"),

--- a/packages/cli/src/handlers/create.ts
+++ b/packages/cli/src/handlers/create.ts
@@ -1,5 +1,6 @@
 import { parseArgs } from "node:util";
 import {
+  runPostCreateWorktree,
   runCreateWorktree,
   TmuxSessionRequiredError,
   WorktreeActionConflictError,
@@ -72,7 +73,6 @@ export async function createHandler(args: string[]): Promise<void> {
       tmuxDirection,
     },
     logger: output,
-    postCreate: "afterAction",
   });
 
   if (isErr(result)) {
@@ -83,6 +83,14 @@ export async function createHandler(args: string[]): Promise<void> {
         ? exitCodes.validationError
         : (getProcessExitCode(result.error) ?? exitCodes.generalError);
     exitWithError(result.error.message, exitCode);
+  }
+
+  const postCreateResult = await runPostCreateWorktree({
+    worktreeName: result.value.name,
+    logger: output,
+  });
+  if (isErr(postCreateResult)) {
+    exitWithError(postCreateResult.error.message, exitCodes.generalError);
   }
 
   if (result.value.exitProcessCode !== undefined) {

--- a/packages/cli/src/handlers/create.ts
+++ b/packages/cli/src/handlers/create.ts
@@ -72,6 +72,7 @@ export async function createHandler(args: string[]): Promise<void> {
       tmuxDirection,
     },
     logger: output,
+    postCreate: "afterAction",
   });
 
   if (isErr(result)) {

--- a/packages/cli/src/handlers/create.ts
+++ b/packages/cli/src/handlers/create.ts
@@ -1,8 +1,11 @@
 import { parseArgs } from "node:util";
 import {
+  resolveWorktreeAction,
   runPostCreateWorktree,
   runCreateWorktree,
+  runWorktreeAction,
   TmuxSessionRequiredError,
+  validateWorktreeAction,
   WorktreeActionConflictError,
   WorktreeAlreadyExistsError,
 } from "@phantompane/core";
@@ -63,15 +66,24 @@ export async function createHandler(args: string[]): Promise<void> {
         ? "horizontal"
         : undefined;
 
+  const actionResult = resolveWorktreeAction({
+    shell: values.shell ?? false,
+    exec: values.exec,
+    tmuxDirection,
+  });
+  if (isErr(actionResult)) {
+    exitWithError(actionResult.error.message, exitCodes.validationError);
+  }
+
+  const actionValidation = await validateWorktreeAction(actionResult.value);
+  if (isErr(actionValidation)) {
+    exitWithError(actionValidation.error.message, exitCodes.validationError);
+  }
+
   const result = await runCreateWorktree({
     name: positionals[0],
     base: values.base,
     copyFiles: values["copy-file"],
-    action: {
-      shell: values.shell ?? false,
-      exec: values.exec,
-      tmuxDirection,
-    },
     logger: output,
   });
 
@@ -85,16 +97,43 @@ export async function createHandler(args: string[]): Promise<void> {
     exitWithError(result.error.message, exitCode);
   }
 
-  const postCreateResult = await runPostCreateWorktree({
+  let postCreatePromise: ReturnType<typeof runPostCreateWorktree> | undefined;
+  const startPostCreate = () => {
+    return (postCreatePromise ??= runPostCreateWorktree({
+      worktreeName: result.value.name,
+      logger: output,
+    }));
+  };
+
+  const actionRunResult = await runWorktreeAction({
+    gitRoot: result.value.gitRoot,
+    worktreeDirectory: result.value.worktreesDirectory,
     worktreeName: result.value.name,
+    worktreePath: result.value.path,
+    action: actionResult.value,
     logger: output,
+    exitWithProcessCode: true,
+    onStarted: () => {
+      void startPostCreate();
+    },
   });
+  if (isErr(actionRunResult)) {
+    if (postCreatePromise) {
+      await postCreatePromise.catch(() => undefined);
+    }
+    exitWithError(
+      actionRunResult.error.message,
+      getProcessExitCode(actionRunResult.error) ?? exitCodes.generalError,
+    );
+  }
+
+  const postCreateResult = await startPostCreate();
   if (isErr(postCreateResult)) {
     exitWithError(postCreateResult.error.message, exitCodes.generalError);
   }
 
-  if (result.value.exitProcessCode !== undefined) {
-    return process.exit(result.value.exitProcessCode);
+  if (actionRunResult.value.exitProcessCode !== undefined) {
+    return process.exit(actionRunResult.value.exitProcessCode);
   }
 
   exitWithSuccess();

--- a/packages/cli/src/handlers/github-checkout-postcreate.test.ts
+++ b/packages/cli/src/handlers/github-checkout-postcreate.test.ts
@@ -8,6 +8,7 @@ const exitWithErrorMock = vi.fn((message, code) => {
 const outputLogMock = vi.fn();
 const outputErrorMock = vi.fn();
 const githubCheckoutMock = vi.fn();
+const runPostCreateWorktreeMock = vi.fn();
 
 vi.doMock("../errors.ts", () => ({
   exitWithError: exitWithErrorMock,
@@ -23,6 +24,7 @@ vi.doMock("../output.ts", () => ({
 
 vi.doMock("@phantompane/core", () => ({
   githubCheckout: githubCheckoutMock,
+  runPostCreateWorktree: runPostCreateWorktreeMock,
 }));
 
 const { githubCheckoutHandler } = await import("./github-checkout.ts");
@@ -47,12 +49,13 @@ describe("githubCheckoutHandler", () => {
     await githubCheckoutHandler(["123"]);
 
     // Verify that githubCheckout was called with options only
-    // The github library internally creates context and handles postCreate
+    // The handler defers postCreate so checkout output and navigation can happen first
     deepStrictEqual(githubCheckoutMock.mock.calls.length, 1);
     const [options] = githubCheckoutMock.mock.calls[0];
     deepStrictEqual(options, {
       number: "123",
       base: undefined,
+      postCreate: "skip",
     });
     deepStrictEqual(outputLogMock.mock.calls[0][0], "Checked out issue #123");
   });
@@ -80,6 +83,39 @@ describe("githubCheckoutHandler", () => {
       outputLogMock.mock.calls[0][0],
       "Worktree for PR #456 is already checked out",
     );
+  });
+
+  it("should run deferred post-create after checkout output", async () => {
+    exitWithErrorMock.mockClear();
+    outputLogMock.mockClear();
+    githubCheckoutMock.mockClear();
+    runPostCreateWorktreeMock.mockClear();
+
+    const postCreate = {
+      gitRoot: "/repo",
+      worktreesDirectory: "/repo/.git/phantom/worktrees",
+      worktreeName: "issues/123",
+      commands: ["pnpm install"],
+    };
+    githubCheckoutMock.mockResolvedValueOnce(
+      ok({
+        message: "Checked out issue #123",
+        worktree: "issues/123",
+        path: "/repo/.git/phantom/worktrees/issues/123",
+        postCreate,
+      }),
+    );
+    runPostCreateWorktreeMock.mockResolvedValueOnce(
+      ok({ executedCommands: ["pnpm install"] }),
+    );
+
+    await githubCheckoutHandler(["123"]);
+
+    deepStrictEqual(outputLogMock.mock.calls[0][0], "Checked out issue #123");
+    deepStrictEqual(runPostCreateWorktreeMock.mock.calls[0][0], {
+      ...postCreate,
+      logger: { log: outputLogMock, error: outputErrorMock },
+    });
   });
 
   it("should handle githubCheckout error", async () => {
@@ -117,6 +153,7 @@ describe("githubCheckoutHandler", () => {
     deepStrictEqual(githubCheckoutMock.mock.calls[0][0], {
       number: "123",
       base: "develop",
+      postCreate: "skip",
     });
   });
 
@@ -144,6 +181,7 @@ describe("githubCheckoutHandler", () => {
     deepStrictEqual(options, {
       number: "123",
       base: undefined,
+      postCreate: "skip",
     });
     deepStrictEqual(outputErrorMock.mock.calls.length, 0);
   });

--- a/packages/cli/src/handlers/github-checkout-postcreate.test.ts
+++ b/packages/cli/src/handlers/github-checkout-postcreate.test.ts
@@ -35,6 +35,8 @@ describe("githubCheckoutHandler", () => {
     outputLogMock.mockClear();
     outputErrorMock.mockClear();
     githubCheckoutMock.mockClear();
+    runPostCreateWorktreeMock.mockClear();
+    runPostCreateWorktreeMock.mockResolvedValue(ok({ executedCommands: [] }));
 
     githubCheckoutMock.mockImplementation(() =>
       Promise.resolve(
@@ -55,15 +57,19 @@ describe("githubCheckoutHandler", () => {
     deepStrictEqual(options, {
       number: "123",
       base: undefined,
-      postCreate: "skip",
     });
     deepStrictEqual(outputLogMock.mock.calls[0][0], "Checked out issue #123");
+    deepStrictEqual(runPostCreateWorktreeMock.mock.calls[0][0], {
+      worktreeName: "issues/123",
+      logger: { log: outputLogMock, error: outputErrorMock },
+    });
   });
 
   it("should handle existing worktree response", async () => {
     exitWithErrorMock.mockClear();
     outputLogMock.mockClear();
     githubCheckoutMock.mockClear();
+    runPostCreateWorktreeMock.mockClear();
 
     githubCheckoutMock.mockImplementation(() =>
       Promise.resolve(
@@ -83,6 +89,7 @@ describe("githubCheckoutHandler", () => {
       outputLogMock.mock.calls[0][0],
       "Worktree for PR #456 is already checked out",
     );
+    deepStrictEqual(runPostCreateWorktreeMock.mock.calls.length, 0);
   });
 
   it("should run deferred post-create after checkout output", async () => {
@@ -91,18 +98,11 @@ describe("githubCheckoutHandler", () => {
     githubCheckoutMock.mockClear();
     runPostCreateWorktreeMock.mockClear();
 
-    const postCreate = {
-      gitRoot: "/repo",
-      worktreesDirectory: "/repo/.git/phantom/worktrees",
-      worktreeName: "issues/123",
-      commands: ["pnpm install"],
-    };
     githubCheckoutMock.mockResolvedValueOnce(
       ok({
         message: "Checked out issue #123",
         worktree: "issues/123",
         path: "/repo/.git/phantom/worktrees/issues/123",
-        postCreate,
       }),
     );
     runPostCreateWorktreeMock.mockResolvedValueOnce(
@@ -113,7 +113,7 @@ describe("githubCheckoutHandler", () => {
 
     deepStrictEqual(outputLogMock.mock.calls[0][0], "Checked out issue #123");
     deepStrictEqual(runPostCreateWorktreeMock.mock.calls[0][0], {
-      ...postCreate,
+      worktreeName: "issues/123",
       logger: { log: outputLogMock, error: outputErrorMock },
     });
   });
@@ -121,6 +121,7 @@ describe("githubCheckoutHandler", () => {
   it("should handle githubCheckout error", async () => {
     exitWithErrorMock.mockClear();
     githubCheckoutMock.mockClear();
+    runPostCreateWorktreeMock.mockClear();
 
     githubCheckoutMock.mockImplementation(() =>
       Promise.resolve(err(new Error("GitHub API error"))),
@@ -137,6 +138,8 @@ describe("githubCheckoutHandler", () => {
   it("should pass base option to githubCheckout", async () => {
     exitWithErrorMock.mockClear();
     githubCheckoutMock.mockClear();
+    runPostCreateWorktreeMock.mockClear();
+    runPostCreateWorktreeMock.mockResolvedValue(ok({ executedCommands: [] }));
 
     githubCheckoutMock.mockImplementation(() =>
       Promise.resolve(
@@ -153,7 +156,6 @@ describe("githubCheckoutHandler", () => {
     deepStrictEqual(githubCheckoutMock.mock.calls[0][0], {
       number: "123",
       base: "develop",
-      postCreate: "skip",
     });
   });
 
@@ -162,6 +164,8 @@ describe("githubCheckoutHandler", () => {
     outputLogMock.mockClear();
     outputErrorMock.mockClear();
     githubCheckoutMock.mockClear();
+    runPostCreateWorktreeMock.mockClear();
+    runPostCreateWorktreeMock.mockResolvedValue(ok({ executedCommands: [] }));
 
     githubCheckoutMock.mockImplementation(() =>
       Promise.resolve(
@@ -181,7 +185,6 @@ describe("githubCheckoutHandler", () => {
     deepStrictEqual(options, {
       number: "123",
       base: undefined,
-      postCreate: "skip",
     });
     deepStrictEqual(outputErrorMock.mock.calls.length, 0);
   });

--- a/packages/cli/src/handlers/github-checkout.test.ts
+++ b/packages/cli/src/handlers/github-checkout.test.ts
@@ -10,6 +10,7 @@ const exitWithErrorMock = vi.fn((message, code) => {
 const outputLogMock = vi.fn();
 const outputErrorMock = vi.fn();
 const githubCheckoutMock = vi.fn();
+const runPostCreateWorktreeMock = vi.fn();
 const isInsideTmuxMock = vi.fn();
 const executeTmuxCommandMock = vi.fn();
 const getPhantomEnvMock = vi.fn();
@@ -28,6 +29,7 @@ vi.doMock("../output.ts", () => ({
 
 vi.doMock("@phantompane/core", () => ({
   githubCheckout: githubCheckoutMock,
+  runPostCreateWorktree: runPostCreateWorktreeMock,
 }));
 
 vi.doMock("@phantompane/process", () => ({

--- a/packages/cli/src/handlers/github-checkout.ts
+++ b/packages/cli/src/handlers/github-checkout.ts
@@ -69,7 +69,6 @@ export async function githubCheckoutHandler(args: string[]): Promise<void> {
   const result = await githubCheckout({
     number,
     base: values.base,
-    postCreate: "skip",
   });
 
   if (isErr(result)) {
@@ -105,9 +104,9 @@ export async function githubCheckoutHandler(args: string[]): Promise<void> {
       exitWithError("", exitCode);
     }
   }
-  if (result.value.postCreate) {
+  if (!result.value.alreadyExists) {
     const postCreateResult = await runPostCreateWorktree({
-      ...result.value.postCreate,
+      worktreeName: result.value.worktree,
       logger: output,
     });
     if (isErr(postCreateResult)) {

--- a/packages/cli/src/handlers/github-checkout.ts
+++ b/packages/cli/src/handlers/github-checkout.ts
@@ -1,5 +1,5 @@
 import { parseArgs } from "node:util";
-import { githubCheckout } from "@phantompane/core";
+import { githubCheckout, runPostCreateWorktree } from "@phantompane/core";
 import { getPhantomEnv } from "@phantompane/process";
 import { isErr } from "@phantompane/utils";
 import { executeTmuxCommand, isInsideTmux } from "@phantompane/tmux";
@@ -66,7 +66,11 @@ export async function githubCheckoutHandler(args: string[]): Promise<void> {
     );
   }
 
-  const result = await githubCheckout({ number, base: values.base });
+  const result = await githubCheckout({
+    number,
+    base: values.base,
+    postCreate: "skip",
+  });
 
   if (isErr(result)) {
     exitWithError(result.error.message, exitCodes.generalError);
@@ -99,6 +103,15 @@ export async function githubCheckoutHandler(args: string[]): Promise<void> {
           ? (tmuxResult.error.exitCode ?? exitCodes.generalError)
           : exitCodes.generalError;
       exitWithError("", exitCode);
+    }
+  }
+  if (result.value.postCreate) {
+    const postCreateResult = await runPostCreateWorktree({
+      ...result.value.postCreate,
+      logger: output,
+    });
+    if (isErr(postCreateResult)) {
+      exitWithError(postCreateResult.error.message, exitCodes.generalError);
     }
   }
 }

--- a/packages/core/src/exec.ts
+++ b/packages/core/src/exec.ts
@@ -12,6 +12,7 @@ export type ExecInWorktreeSuccess = SpawnSuccess;
 
 export interface ExecInWorktreeOptions {
   interactive?: boolean;
+  onStarted?: () => void;
 }
 
 export async function execInWorktree(
@@ -39,6 +40,8 @@ export async function execInWorktree(
     ? "inherit"
     : ["ignore", "inherit", "inherit"];
 
+  const onSpawned = options?.onStarted;
+
   return spawnProcess({
     command: cmd,
     args,
@@ -46,5 +49,6 @@ export async function execInWorktree(
       cwd: worktreePath,
       stdio,
     },
+    ...(onSpawned ? { onSpawned } : {}),
   });
 }

--- a/packages/core/src/github/checkout.ts
+++ b/packages/core/src/github/checkout.ts
@@ -16,6 +16,7 @@ export interface GitHubCheckoutOptions {
   number: string;
   base?: string;
   cwd?: string;
+  postCreate?: "run" | "skip";
 }
 
 export interface ListGitHubCheckoutTargetsOptions {
@@ -26,7 +27,14 @@ export interface ListGitHubCheckoutTargetsOptions {
 export async function githubCheckout(
   options: GitHubCheckoutOptions,
 ): Promise<Result<CheckoutResult>> {
-  const { number, base, cwd } = options;
+  const { number, base, cwd, postCreate } = options;
+  const checkoutOptions =
+    cwd || postCreate !== undefined
+      ? {
+          ...(cwd ? { cwd } : {}),
+          ...(postCreate !== undefined ? { postCreate } : {}),
+        }
+      : undefined;
   const { owner, repo } = cwd
     ? await getGitHubRepoInfo({ cwd })
     : await getGitHubRepoInfo();
@@ -51,14 +59,14 @@ export async function githubCheckout(
         ),
       );
     }
-    const result = cwd
-      ? await checkoutPullRequest(issue.pullRequest, undefined, { cwd })
+    const result = checkoutOptions
+      ? await checkoutPullRequest(issue.pullRequest, undefined, checkoutOptions)
       : await checkoutPullRequest(issue.pullRequest);
     return result;
   }
 
-  const result = cwd
-    ? await checkoutIssue(issue, base, { cwd })
+  const result = checkoutOptions
+    ? await checkoutIssue(issue, base, checkoutOptions)
     : await checkoutIssue(issue, base);
   return result;
 }

--- a/packages/core/src/github/checkout.ts
+++ b/packages/core/src/github/checkout.ts
@@ -16,7 +16,6 @@ export interface GitHubCheckoutOptions {
   number: string;
   base?: string;
   cwd?: string;
-  postCreate?: "run" | "skip";
 }
 
 export interface ListGitHubCheckoutTargetsOptions {
@@ -27,14 +26,8 @@ export interface ListGitHubCheckoutTargetsOptions {
 export async function githubCheckout(
   options: GitHubCheckoutOptions,
 ): Promise<Result<CheckoutResult>> {
-  const { number, base, cwd, postCreate } = options;
-  const checkoutOptions =
-    cwd || postCreate !== undefined
-      ? {
-          ...(cwd ? { cwd } : {}),
-          ...(postCreate !== undefined ? { postCreate } : {}),
-        }
-      : undefined;
+  const { number, base, cwd } = options;
+  const checkoutOptions = cwd ? { cwd } : undefined;
   const { owner, repo } = cwd
     ? await getGitHubRepoInfo({ cwd })
     : await getGitHubRepoInfo();

--- a/packages/core/src/github/checkout/issue.test.ts
+++ b/packages/core/src/github/checkout/issue.test.ts
@@ -6,6 +6,17 @@ const getGitRootMock = vi.fn();
 const createWorktreeCoreMock = vi.fn();
 const isPullRequestMock = vi.fn();
 const createContextMock = vi.fn();
+const createWorktreePostCreateTaskMock = vi.fn(
+  (
+    gitRoot: string,
+    worktreesDirectory: string,
+    worktreeName: string,
+    commands: string[] | undefined,
+  ) =>
+    commands
+      ? { gitRoot, worktreesDirectory, worktreeName, commands }
+      : undefined,
+);
 const validateWorktreeExistsMock = vi.fn();
 
 vi.doMock("@phantompane/git", () => ({
@@ -22,6 +33,7 @@ vi.doMock("../../context.ts", () => ({
 
 vi.doMock("../../worktree/create.ts", () => ({
   createWorktree: createWorktreeCoreMock,
+  createWorktreePostCreateTask: createWorktreePostCreateTaskMock,
 }));
 
 vi.doMock("../../worktree/validate.ts", () => ({
@@ -35,6 +47,7 @@ describe("checkoutIssue", () => {
     getGitRootMock.mockClear();
     createWorktreeCoreMock.mockClear();
     isPullRequestMock.mockClear();
+    createWorktreePostCreateTaskMock.mockClear();
     validateWorktreeExistsMock.mockClear();
   };
 

--- a/packages/core/src/github/checkout/issue.test.ts
+++ b/packages/core/src/github/checkout/issue.test.ts
@@ -295,4 +295,53 @@ describe("checkoutIssue", () => {
     equal(worktreeName, "issues/333");
     equal(options.branch, "issues/333");
   });
+
+  it("should return post-create task without running commands when skipped", async () => {
+    resetMocks();
+    const mockGitRoot = "/path/to/repo";
+    const mockIssue = {
+      number: 444,
+    };
+
+    isPullRequestMock.mockImplementation(() => false);
+    getGitRootMock.mockImplementation(async () => mockGitRoot);
+    createContextMock.mockImplementation(async () => ({
+      gitRoot: mockGitRoot,
+      worktreesDirectory: `${mockGitRoot}/.git/phantom/worktrees`,
+      directoryNameSeparator: "/",
+      config: {
+        postCreate: {
+          copyFiles: [".env"],
+          commands: ["pnpm install"],
+        },
+      },
+    }));
+    validateWorktreeExistsMock.mockImplementation(async () => ({
+      ok: false,
+      error: new Error("Worktree not found"),
+    }));
+    createWorktreeCoreMock.mockImplementation(async () => ({
+      ok: true,
+      value: {
+        message: "Success",
+        path: "/path/to/repo/.git/phantom/worktrees/issues/444",
+      },
+    }));
+
+    const result = await checkoutIssue(mockIssue, undefined, {
+      postCreate: "skip",
+    });
+
+    ok(isOk(result));
+    if (isOk(result)) {
+      deepEqual(result.value.postCreate, {
+        gitRoot: mockGitRoot,
+        worktreesDirectory: `${mockGitRoot}/.git/phantom/worktrees`,
+        worktreeName: "issues/444",
+        commands: ["pnpm install"],
+      });
+    }
+    deepEqual(createWorktreeCoreMock.mock.calls[0][4], [".env"]);
+    equal(createWorktreeCoreMock.mock.calls[0][5], undefined);
+  });
 });

--- a/packages/core/src/github/checkout/issue.test.ts
+++ b/packages/core/src/github/checkout/issue.test.ts
@@ -6,17 +6,6 @@ const getGitRootMock = vi.fn();
 const createWorktreeCoreMock = vi.fn();
 const isPullRequestMock = vi.fn();
 const createContextMock = vi.fn();
-const createWorktreePostCreateTaskMock = vi.fn(
-  (
-    gitRoot: string,
-    worktreesDirectory: string,
-    worktreeName: string,
-    commands: string[] | undefined,
-  ) =>
-    commands
-      ? { gitRoot, worktreesDirectory, worktreeName, commands }
-      : undefined,
-);
 const validateWorktreeExistsMock = vi.fn();
 
 vi.doMock("@phantompane/git", () => ({
@@ -33,7 +22,6 @@ vi.doMock("../../context.ts", () => ({
 
 vi.doMock("../../worktree/create.ts", () => ({
   createWorktree: createWorktreeCoreMock,
-  createWorktreePostCreateTask: createWorktreePostCreateTaskMock,
 }));
 
 vi.doMock("../../worktree/validate.ts", () => ({
@@ -47,7 +35,6 @@ describe("checkoutIssue", () => {
     getGitRootMock.mockClear();
     createWorktreeCoreMock.mockClear();
     isPullRequestMock.mockClear();
-    createWorktreePostCreateTaskMock.mockClear();
     validateWorktreeExistsMock.mockClear();
   };
 
@@ -151,6 +138,7 @@ describe("checkoutIssue", () => {
     deepEqual(options, {
       branch: "issues/456",
       base: undefined,
+      copyFiles: undefined,
     });
   });
 
@@ -192,6 +180,7 @@ describe("checkoutIssue", () => {
     deepEqual(options, {
       branch: "issues/789",
       base: "develop",
+      copyFiles: undefined,
     });
   });
 
@@ -296,7 +285,7 @@ describe("checkoutIssue", () => {
     equal(options.branch, "issues/333");
   });
 
-  it("should return post-create task without running commands when skipped", async () => {
+  it("should pass configured copy files without post-create commands", async () => {
     resetMocks();
     const mockGitRoot = "/path/to/repo";
     const mockIssue = {
@@ -328,20 +317,12 @@ describe("checkoutIssue", () => {
       },
     }));
 
-    const result = await checkoutIssue(mockIssue, undefined, {
-      postCreate: "skip",
-    });
+    const result = await checkoutIssue(mockIssue);
 
     ok(isOk(result));
-    if (isOk(result)) {
-      deepEqual(result.value.postCreate, {
-        gitRoot: mockGitRoot,
-        worktreesDirectory: `${mockGitRoot}/.git/phantom/worktrees`,
-        worktreeName: "issues/444",
-        commands: ["pnpm install"],
-      });
-    }
-    deepEqual(createWorktreeCoreMock.mock.calls[0][4], [".env"]);
-    equal(createWorktreeCoreMock.mock.calls[0][5], undefined);
+    const [, , , options, directoryNameSeparator] =
+      createWorktreeCoreMock.mock.calls[0];
+    deepEqual(options.copyFiles, [".env"]);
+    equal(directoryNameSeparator, "/");
   });
 });

--- a/packages/core/src/github/checkout/issue.ts
+++ b/packages/core/src/github/checkout/issue.ts
@@ -2,16 +2,12 @@ import { getGitRoot } from "@phantompane/git";
 import { type GitHubIssue, isPullRequest } from "@phantompane/github";
 import { err, isErr, ok, type Result } from "@phantompane/utils";
 import { createContext } from "../../context.ts";
-import {
-  createWorktree as createWorktreeCore,
-  createWorktreePostCreateTask,
-} from "../../worktree/create.ts";
+import { createWorktree as createWorktreeCore } from "../../worktree/create.ts";
 import { validateWorktreeExists } from "../../worktree/validate.ts";
 import type { CheckoutResult } from "./pr.ts";
 
 export interface CheckoutIssueOptions {
   cwd?: string;
-  postCreate?: "run" | "skip";
 }
 
 export async function checkoutIssue(
@@ -50,13 +46,6 @@ export async function checkoutIssue(
     });
   }
 
-  const postCreateTask = createWorktreePostCreateTask(
-    context.gitRoot,
-    context.worktreesDirectory,
-    worktreeName,
-    context.config?.postCreate?.commands,
-  );
-
   const result = await createWorktreeCore(
     context.gitRoot,
     context.worktreesDirectory,
@@ -64,9 +53,8 @@ export async function checkoutIssue(
     {
       branch: branchName,
       base,
+      copyFiles: context.config?.postCreate?.copyFiles,
     },
-    context.config?.postCreate?.copyFiles,
-    options.postCreate === "skip" ? undefined : postCreateTask?.commands,
     context.directoryNameSeparator,
   );
 
@@ -79,6 +67,5 @@ export async function checkoutIssue(
     worktree: worktreeName,
     path: result.value.path,
     createdBranch: true,
-    postCreate: options.postCreate === "skip" ? postCreateTask : undefined,
   });
 }

--- a/packages/core/src/github/checkout/issue.ts
+++ b/packages/core/src/github/checkout/issue.ts
@@ -2,12 +2,16 @@ import { getGitRoot } from "@phantompane/git";
 import { type GitHubIssue, isPullRequest } from "@phantompane/github";
 import { err, isErr, ok, type Result } from "@phantompane/utils";
 import { createContext } from "../../context.ts";
-import { createWorktree as createWorktreeCore } from "../../worktree/create.ts";
+import {
+  createWorktree as createWorktreeCore,
+  createWorktreePostCreateTask,
+} from "../../worktree/create.ts";
 import { validateWorktreeExists } from "../../worktree/validate.ts";
 import type { CheckoutResult } from "./pr.ts";
 
 export interface CheckoutIssueOptions {
   cwd?: string;
+  postCreate?: "run" | "skip";
 }
 
 export async function checkoutIssue(
@@ -46,6 +50,13 @@ export async function checkoutIssue(
     });
   }
 
+  const postCreateTask = createWorktreePostCreateTask(
+    context.gitRoot,
+    context.worktreesDirectory,
+    worktreeName,
+    context.config?.postCreate?.commands,
+  );
+
   const result = await createWorktreeCore(
     context.gitRoot,
     context.worktreesDirectory,
@@ -55,7 +66,7 @@ export async function checkoutIssue(
       base,
     },
     context.config?.postCreate?.copyFiles,
-    context.config?.postCreate?.commands,
+    options.postCreate === "skip" ? undefined : postCreateTask?.commands,
     context.directoryNameSeparator,
   );
 
@@ -68,5 +79,6 @@ export async function checkoutIssue(
     worktree: worktreeName,
     path: result.value.path,
     createdBranch: true,
+    postCreate: options.postCreate === "skip" ? postCreateTask : undefined,
   });
 }

--- a/packages/core/src/github/checkout/pr.test.ts
+++ b/packages/core/src/github/checkout/pr.test.ts
@@ -8,17 +8,6 @@ const fetchMock = vi.fn();
 const attachWorktreeCoreMock = vi.fn();
 const setUpstreamBranchMock = vi.fn();
 const createContextMock = vi.fn();
-const createWorktreePostCreateTaskMock = vi.fn(
-  (
-    gitRoot: string,
-    worktreesDirectory: string,
-    worktreeName: string,
-    commands: string[] | undefined,
-  ) =>
-    commands
-      ? { gitRoot, worktreesDirectory, worktreeName, commands }
-      : undefined,
-);
 const validateWorktreeExistsMock = vi.fn();
 
 vi.doMock("@phantompane/git", () => ({
@@ -34,10 +23,6 @@ vi.doMock("../../context.ts", () => ({
 
 vi.doMock("../../worktree/attach.ts", () => ({
   attachWorktreeCore: attachWorktreeCoreMock,
-}));
-
-vi.doMock("../../worktree/create.ts", () => ({
-  createWorktreePostCreateTask: createWorktreePostCreateTaskMock,
 }));
 
 vi.doMock("../../worktree/validate.ts", () => ({
@@ -57,7 +42,6 @@ describe("checkoutPullRequest", () => {
     fetchMock.mockClear();
     attachWorktreeCoreMock.mockClear();
     setUpstreamBranchMock.mockClear();
-    createWorktreePostCreateTaskMock.mockClear();
     validateWorktreeExistsMock.mockClear();
   };
 
@@ -475,7 +459,7 @@ describe("checkoutPullRequest", () => {
     equal(setUpstreamBranchMock.mock.calls.length, 0);
   });
 
-  it("should return post-create task without running commands when skipped", async () => {
+  it("should pass configured copy files without post-create commands", async () => {
     resetMocks();
     const mockGitRoot = "/path/to/repo";
     const mockPullRequest = {
@@ -523,20 +507,10 @@ describe("checkoutPullRequest", () => {
       value: undefined,
     }));
 
-    const result = await checkoutPullRequest(mockPullRequest, undefined, {
-      postCreate: "skip",
-    });
+    const result = await checkoutPullRequest(mockPullRequest);
 
     ok(isOk(result));
-    if (isOk(result)) {
-      deepEqual(result.value.postCreate, {
-        gitRoot: mockGitRoot,
-        worktreesDirectory: `${mockGitRoot}/.git/phantom/worktrees`,
-        worktreeName: "feature-branch",
-        commands: ["pnpm install"],
-      });
-    }
     deepEqual(attachWorktreeCoreMock.mock.calls[0][3], [".env"]);
-    equal(attachWorktreeCoreMock.mock.calls[0][4], undefined);
+    equal(attachWorktreeCoreMock.mock.calls[0][4], "/");
   });
 });

--- a/packages/core/src/github/checkout/pr.test.ts
+++ b/packages/core/src/github/checkout/pr.test.ts
@@ -1,4 +1,4 @@
-import { equal, ok } from "node:assert/strict";
+import { deepEqual, equal, ok } from "node:assert/strict";
 import { describe, it, vi } from "vitest";
 import { isErr, isOk } from "@phantompane/utils";
 
@@ -473,5 +473,70 @@ describe("checkoutPullRequest", () => {
 
     // Verify upstream function was not called when fetch fails
     equal(setUpstreamBranchMock.mock.calls.length, 0);
+  });
+
+  it("should return post-create task without running commands when skipped", async () => {
+    resetMocks();
+    const mockGitRoot = "/path/to/repo";
+    const mockPullRequest = {
+      number: 888,
+      isFromFork: false,
+      head: {
+        ref: "feature-branch",
+        repo: {
+          full_name: "owner/repo",
+        },
+      },
+      base: {
+        repo: {
+          full_name: "owner/repo",
+        },
+      },
+    };
+
+    getGitRootMock.mockImplementation(async () => mockGitRoot);
+    createContextMock.mockImplementation(async () => ({
+      gitRoot: mockGitRoot,
+      worktreesDirectory: `${mockGitRoot}/.git/phantom/worktrees`,
+      directoryNameSeparator: "/",
+      config: {
+        postCreate: {
+          copyFiles: [".env"],
+          commands: ["pnpm install"],
+        },
+      },
+    }));
+    validateWorktreeExistsMock.mockImplementation(async () => ({
+      ok: false,
+      error: new Error("Worktree not found"),
+    }));
+    fetchMock.mockImplementation(async () => ({
+      ok: true,
+      value: undefined,
+    }));
+    attachWorktreeCoreMock.mockImplementation(async () => ({
+      ok: true,
+      value: "/path/to/repo/.git/phantom/worktrees/feature-branch",
+    }));
+    setUpstreamBranchMock.mockImplementation(async () => ({
+      ok: true,
+      value: undefined,
+    }));
+
+    const result = await checkoutPullRequest(mockPullRequest, undefined, {
+      postCreate: "skip",
+    });
+
+    ok(isOk(result));
+    if (isOk(result)) {
+      deepEqual(result.value.postCreate, {
+        gitRoot: mockGitRoot,
+        worktreesDirectory: `${mockGitRoot}/.git/phantom/worktrees`,
+        worktreeName: "feature-branch",
+        commands: ["pnpm install"],
+      });
+    }
+    deepEqual(attachWorktreeCoreMock.mock.calls[0][3], [".env"]);
+    equal(attachWorktreeCoreMock.mock.calls[0][4], undefined);
   });
 });

--- a/packages/core/src/github/checkout/pr.test.ts
+++ b/packages/core/src/github/checkout/pr.test.ts
@@ -8,6 +8,17 @@ const fetchMock = vi.fn();
 const attachWorktreeCoreMock = vi.fn();
 const setUpstreamBranchMock = vi.fn();
 const createContextMock = vi.fn();
+const createWorktreePostCreateTaskMock = vi.fn(
+  (
+    gitRoot: string,
+    worktreesDirectory: string,
+    worktreeName: string,
+    commands: string[] | undefined,
+  ) =>
+    commands
+      ? { gitRoot, worktreesDirectory, worktreeName, commands }
+      : undefined,
+);
 const validateWorktreeExistsMock = vi.fn();
 
 vi.doMock("@phantompane/git", () => ({
@@ -23,6 +34,10 @@ vi.doMock("../../context.ts", () => ({
 
 vi.doMock("../../worktree/attach.ts", () => ({
   attachWorktreeCore: attachWorktreeCoreMock,
+}));
+
+vi.doMock("../../worktree/create.ts", () => ({
+  createWorktreePostCreateTask: createWorktreePostCreateTaskMock,
 }));
 
 vi.doMock("../../worktree/validate.ts", () => ({
@@ -42,6 +57,7 @@ describe("checkoutPullRequest", () => {
     fetchMock.mockClear();
     attachWorktreeCoreMock.mockClear();
     setUpstreamBranchMock.mockClear();
+    createWorktreePostCreateTaskMock.mockClear();
     validateWorktreeExistsMock.mockClear();
   };
 

--- a/packages/core/src/github/checkout/pr.ts
+++ b/packages/core/src/github/checkout/pr.ts
@@ -8,10 +8,6 @@ import type { GitHubPullRequest } from "@phantompane/github";
 import { err, isErr, ok, type Result } from "@phantompane/utils";
 import { createContext } from "../../context.ts";
 import { attachWorktreeCore } from "../../worktree/attach.ts";
-import {
-  createWorktreePostCreateTask,
-  type WorktreePostCreateTask,
-} from "../../worktree/create.ts";
 import { validateWorktreeExists } from "../../worktree/validate.ts";
 
 export interface CheckoutResult {
@@ -20,12 +16,10 @@ export interface CheckoutResult {
   path: string;
   alreadyExists?: boolean;
   createdBranch?: boolean;
-  postCreate?: WorktreePostCreateTask;
 }
 
 export interface CheckoutPullRequestOptions {
   cwd?: string;
-  postCreate?: "run" | "skip";
 }
 
 function getForkWorktreeName(pullRequest: GitHubPullRequest): string {
@@ -105,20 +99,11 @@ export async function checkoutPullRequest(
     );
   }
 
-  // Attach the worktree to the fetched branch
-  const postCreateTask = createWorktreePostCreateTask(
-    context.gitRoot,
-    context.worktreesDirectory,
-    worktreeName,
-    context.config?.postCreate?.commands,
-  );
-
   const attachResult = await attachWorktreeCore(
     context.gitRoot,
     context.worktreesDirectory,
     worktreeName,
     context.config?.postCreate?.copyFiles,
-    options.postCreate === "skip" ? undefined : postCreateTask?.commands,
     context.directoryNameSeparator,
   );
 
@@ -135,6 +120,5 @@ export async function checkoutPullRequest(
     worktree: worktreeName,
     path: attachResult.value,
     createdBranch,
-    postCreate: options.postCreate === "skip" ? postCreateTask : undefined,
   });
 }

--- a/packages/core/src/github/checkout/pr.ts
+++ b/packages/core/src/github/checkout/pr.ts
@@ -8,6 +8,10 @@ import type { GitHubPullRequest } from "@phantompane/github";
 import { err, isErr, ok, type Result } from "@phantompane/utils";
 import { createContext } from "../../context.ts";
 import { attachWorktreeCore } from "../../worktree/attach.ts";
+import {
+  createWorktreePostCreateTask,
+  type WorktreePostCreateTask,
+} from "../../worktree/create.ts";
 import { validateWorktreeExists } from "../../worktree/validate.ts";
 
 export interface CheckoutResult {
@@ -16,10 +20,12 @@ export interface CheckoutResult {
   path: string;
   alreadyExists?: boolean;
   createdBranch?: boolean;
+  postCreate?: WorktreePostCreateTask;
 }
 
 export interface CheckoutPullRequestOptions {
   cwd?: string;
+  postCreate?: "run" | "skip";
 }
 
 function getForkWorktreeName(pullRequest: GitHubPullRequest): string {
@@ -100,12 +106,19 @@ export async function checkoutPullRequest(
   }
 
   // Attach the worktree to the fetched branch
+  const postCreateTask = createWorktreePostCreateTask(
+    context.gitRoot,
+    context.worktreesDirectory,
+    worktreeName,
+    context.config?.postCreate?.commands,
+  );
+
   const attachResult = await attachWorktreeCore(
     context.gitRoot,
     context.worktreesDirectory,
     worktreeName,
     context.config?.postCreate?.copyFiles,
-    context.config?.postCreate?.commands,
+    options.postCreate === "skip" ? undefined : postCreateTask?.commands,
     context.directoryNameSeparator,
   );
 
@@ -122,5 +135,6 @@ export async function checkoutPullRequest(
     worktree: worktreeName,
     path: attachResult.value,
     createdBranch,
+    postCreate: options.postCreate === "skip" ? postCreateTask : undefined,
   });
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,6 +5,7 @@ export * from "./exec.ts";
 export * from "./github/checkout.ts";
 export * from "./paths.ts";
 export * from "./shell.ts";
+export * from "./worktree/action.ts";
 export * from "./worktree/attach.ts";
 export * from "./worktree/create.ts";
 export * from "./worktree/current.ts";

--- a/packages/core/src/shell.ts
+++ b/packages/core/src/shell.ts
@@ -10,10 +10,15 @@ import { validateWorktreeExists } from "./worktree/validate.ts";
 
 export type ShellInWorktreeSuccess = SpawnSuccess;
 
+export interface ShellInWorktreeOptions {
+  onStarted?: () => void;
+}
+
 export async function shellInWorktree(
   gitRoot: string,
   worktreeDirectory: string,
   worktreeName: string,
+  options?: ShellInWorktreeOptions,
 ): Promise<
   Result<ShellInWorktreeSuccess, WorktreeNotFoundError | ProcessError>
 > {
@@ -28,6 +33,7 @@ export async function shellInWorktree(
 
   const worktreePath = validation.value.path;
   const shell = process.env.SHELL || "/bin/sh";
+  const onSpawned = options?.onStarted;
 
   return spawnProcess({
     command: shell,
@@ -39,5 +45,6 @@ export async function shellInWorktree(
         ...getPhantomEnv(worktreeName, worktreePath),
       },
     },
+    ...(onSpawned ? { onSpawned } : {}),
   });
 }

--- a/packages/core/src/worktree/action.test.ts
+++ b/packages/core/src/worktree/action.test.ts
@@ -1,0 +1,127 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it, vi } from "vitest";
+import { err, ok } from "@phantompane/utils";
+import { WorktreeActionConflictError } from "./errors.ts";
+
+const shellInWorktreeMock = vi.fn();
+const execInWorktreeMock = vi.fn();
+const executeTmuxCommandMock = vi.fn();
+const isInsideTmuxMock = vi.fn();
+const getPhantomEnvMock = vi.fn();
+
+vi.doMock("../shell.ts", () => ({
+  shellInWorktree: shellInWorktreeMock,
+}));
+
+vi.doMock("../exec.ts", () => ({
+  execInWorktree: execInWorktreeMock,
+}));
+
+vi.doMock("@phantompane/tmux", () => ({
+  executeTmuxCommand: executeTmuxCommandMock,
+  isInsideTmux: isInsideTmuxMock,
+}));
+
+vi.doMock("@phantompane/process", () => ({
+  getPhantomEnv: getPhantomEnvMock,
+}));
+
+const { resolveWorktreeAction, runWorktreeAction } =
+  await import("./action.ts");
+
+describe("resolveWorktreeAction", () => {
+  it("returns an error when multiple actions are requested", () => {
+    const result = resolveWorktreeAction({
+      shell: true,
+      exec: "echo hello",
+    });
+
+    strictEqual(result.ok, false);
+    if (!result.ok) {
+      strictEqual(result.error instanceof WorktreeActionConflictError, true);
+    }
+  });
+});
+
+describe("runWorktreeAction", () => {
+  const resetMocks = () => {
+    shellInWorktreeMock.mockReset();
+    execInWorktreeMock.mockReset();
+    executeTmuxCommandMock.mockReset();
+    isInsideTmuxMock.mockReset();
+    getPhantomEnvMock.mockReset();
+  };
+
+  it("starts shell actions with the start callback", async () => {
+    resetMocks();
+    const onStarted = vi.fn();
+    shellInWorktreeMock.mockResolvedValue(ok({ exitCode: 0 }));
+
+    const result = await runWorktreeAction({
+      gitRoot: "/repo",
+      worktreeDirectory: "/repo/.git/phantom/worktrees",
+      worktreeName: "feature",
+      worktreePath: "/repo/.git/phantom/worktrees/feature",
+      action: { kind: "shell" },
+      onStarted,
+    });
+
+    strictEqual(result.ok, true);
+    deepStrictEqual(shellInWorktreeMock.mock.calls[0], [
+      "/repo",
+      "/repo/.git/phantom/worktrees",
+      "feature",
+      { onStarted },
+    ]);
+  });
+
+  it("starts tmux actions only after tmux opens successfully", async () => {
+    resetMocks();
+    const onStarted = vi.fn();
+    executeTmuxCommandMock.mockResolvedValue(ok({ exitCode: 0 }));
+    getPhantomEnvMock.mockReturnValue({
+      PHANTOM_NAME: "feature",
+      PHANTOM_PATH: "/repo/.git/phantom/worktrees/feature",
+    });
+
+    const result = await runWorktreeAction({
+      gitRoot: "/repo",
+      worktreeDirectory: "/repo/.git/phantom/worktrees",
+      worktreeName: "feature",
+      worktreePath: "/repo/.git/phantom/worktrees/feature",
+      action: { kind: "tmux", direction: "new" },
+      onStarted,
+    });
+
+    strictEqual(result.ok, true);
+    strictEqual(onStarted.mock.calls.length, 1);
+    deepStrictEqual(executeTmuxCommandMock.mock.calls[0][0], {
+      direction: "new",
+      command: process.env.SHELL || "/bin/sh",
+      cwd: "/repo/.git/phantom/worktrees/feature",
+      env: {
+        PHANTOM_NAME: "feature",
+        PHANTOM_PATH: "/repo/.git/phantom/worktrees/feature",
+      },
+      windowName: "feature",
+    });
+  });
+
+  it("does not start tmux actions when opening tmux fails", async () => {
+    resetMocks();
+    const onStarted = vi.fn();
+    executeTmuxCommandMock.mockResolvedValue(err(new Error("tmux failed")));
+
+    const result = await runWorktreeAction({
+      gitRoot: "/repo",
+      worktreeDirectory: "/repo/.git/phantom/worktrees",
+      worktreeName: "feature",
+      worktreePath: "/repo/.git/phantom/worktrees/feature",
+      action: { kind: "tmux", direction: "new" },
+      onStarted,
+    });
+
+    strictEqual(result.ok, false);
+    strictEqual(onStarted.mock.calls.length, 0);
+  });
+});

--- a/packages/core/src/worktree/action.ts
+++ b/packages/core/src/worktree/action.ts
@@ -36,6 +36,7 @@ export interface RunWorktreeActionOptions {
   action?: ResolvedWorktreeAction;
   logger?: WorktreeLogger;
   exitWithProcessCode?: boolean;
+  onStarted?: () => void;
 }
 
 export interface RunWorktreeActionSuccess {
@@ -98,6 +99,7 @@ export async function runWorktreeAction(
     action,
     logger,
     exitWithProcessCode = false,
+    onStarted,
   } = options;
 
   if (!action) {
@@ -112,6 +114,7 @@ export async function runWorktreeAction(
       gitRoot,
       worktreeDirectory,
       worktreeName,
+      ...(onStarted ? [{ onStarted }] : []),
     );
     if (isErr(shellResult)) {
       return err(shellResult.error);
@@ -135,7 +138,10 @@ export async function runWorktreeAction(
       worktreeDirectory,
       worktreeName,
       [shell, "-c", action.command],
-      { interactive: true },
+      {
+        interactive: true,
+        ...(onStarted ? { onStarted } : {}),
+      },
     );
     if (isErr(execResult)) {
       return err(execResult.error);
@@ -165,6 +171,7 @@ export async function runWorktreeAction(
   if (isErr(tmuxResult)) {
     return err(tmuxResult.error);
   }
+  onStarted?.();
 
   return ok({});
 }

--- a/packages/core/src/worktree/action.ts
+++ b/packages/core/src/worktree/action.ts
@@ -36,6 +36,7 @@ export interface RunWorktreeActionOptions {
   action?: ResolvedWorktreeAction;
   logger?: WorktreeLogger;
   exitWithProcessCode?: boolean;
+  onStarted?: () => void;
 }
 
 export interface RunWorktreeActionSuccess {
@@ -98,6 +99,7 @@ export async function runWorktreeAction(
     action,
     logger,
     exitWithProcessCode = false,
+    onStarted,
   } = options;
 
   if (!action) {
@@ -107,6 +109,7 @@ export async function runWorktreeAction(
   if (action.kind === "shell") {
     logger?.log(`\nEntering worktree '${worktreeName}' at ${worktreePath}`);
     logger?.log("Type 'exit' to return to your original directory\n");
+    onStarted?.();
 
     const shellResult = await shellInWorktree(
       gitRoot,
@@ -128,6 +131,7 @@ export async function runWorktreeAction(
     logger?.log(
       `\nExecuting command in worktree '${worktreeName}': ${action.command}`,
     );
+    onStarted?.();
 
     const shell = process.env.SHELL || "/bin/sh";
     const execResult = await execInWorktree(
@@ -165,6 +169,7 @@ export async function runWorktreeAction(
   if (isErr(tmuxResult)) {
     return err(tmuxResult.error);
   }
+  onStarted?.();
 
   return ok({});
 }

--- a/packages/core/src/worktree/action.ts
+++ b/packages/core/src/worktree/action.ts
@@ -36,7 +36,6 @@ export interface RunWorktreeActionOptions {
   action?: ResolvedWorktreeAction;
   logger?: WorktreeLogger;
   exitWithProcessCode?: boolean;
-  onStarted?: () => void;
 }
 
 export interface RunWorktreeActionSuccess {
@@ -99,7 +98,6 @@ export async function runWorktreeAction(
     action,
     logger,
     exitWithProcessCode = false,
-    onStarted,
   } = options;
 
   if (!action) {
@@ -109,7 +107,6 @@ export async function runWorktreeAction(
   if (action.kind === "shell") {
     logger?.log(`\nEntering worktree '${worktreeName}' at ${worktreePath}`);
     logger?.log("Type 'exit' to return to your original directory\n");
-    onStarted?.();
 
     const shellResult = await shellInWorktree(
       gitRoot,
@@ -131,7 +128,6 @@ export async function runWorktreeAction(
     logger?.log(
       `\nExecuting command in worktree '${worktreeName}': ${action.command}`,
     );
-    onStarted?.();
 
     const shell = process.env.SHELL || "/bin/sh";
     const execResult = await execInWorktree(
@@ -169,7 +165,6 @@ export async function runWorktreeAction(
   if (isErr(tmuxResult)) {
     return err(tmuxResult.error);
   }
-  onStarted?.();
 
   return ok({});
 }

--- a/packages/core/src/worktree/attach-flow.test.ts
+++ b/packages/core/src/worktree/attach-flow.test.ts
@@ -13,7 +13,6 @@ const getWorktreePathFromDirectoryMock = vi.fn(
 );
 const validateWorktreeNameMock = vi.fn();
 const copyFilesMock = vi.fn();
-const executePostCreateCommandsMock = vi.fn();
 const execInWorktreeMock = vi.fn();
 
 const originalProcessEnv = process.env;
@@ -44,10 +43,6 @@ vi.doMock("../paths.ts", () => ({
 
 vi.doMock("./validate.ts", () => ({
   validateWorktreeName: validateWorktreeNameMock,
-}));
-
-vi.doMock("./post-create.ts", () => ({
-  executePostCreateCommands: executePostCreateCommandsMock,
 }));
 
 vi.doMock("./file-copier.ts", () => ({
@@ -83,7 +78,6 @@ describe("runAttachWorktree", () => {
     getWorktreePathFromDirectoryMock.mockClear();
     validateWorktreeNameMock.mockReset();
     copyFilesMock.mockReset();
-    executePostCreateCommandsMock.mockReset();
     execInWorktreeMock.mockReset();
 
     for (const key of Object.keys(processEnvMock)) {
@@ -116,9 +110,6 @@ describe("runAttachWorktree", () => {
         skippedFiles: [],
       }),
     );
-    executePostCreateCommandsMock.mockResolvedValue(
-      ok({ executedCommands: ["npm install"] }),
-    );
     const logger = {
       log: vi.fn(),
       warn: vi.fn(),
@@ -136,11 +127,7 @@ describe("runAttachWorktree", () => {
       "/repo/.git/phantom/worktrees/feature",
       [".env", "config.json"],
     ]);
-    strictEqual(
-      logger.log.mock.calls[0][0],
-      "\nRunning post-create commands...",
-    );
-    strictEqual(logger.log.mock.calls[1][0], "Attached phantom: feature");
+    strictEqual(logger.log.mock.calls[0][0], "Attached phantom: feature");
   });
 
   it("executes --exec actions from core", async () => {

--- a/packages/core/src/worktree/attach.test.ts
+++ b/packages/core/src/worktree/attach.test.ts
@@ -57,7 +57,6 @@ describe("attachWorktreeCore", () => {
       "/repo/.git/phantom/worktrees",
       "feature-branch",
       undefined,
-      undefined,
       "/",
     );
 
@@ -98,7 +97,6 @@ describe("attachWorktreeCore", () => {
       "/repo/.git/phantom/worktrees",
       "feature/branch",
       undefined,
-      undefined,
       "/",
     );
 
@@ -123,7 +121,6 @@ describe("attachWorktreeCore", () => {
       "/repo",
       "/repo/.git/phantom/worktrees",
       "existing-feature",
-      undefined,
       undefined,
       "/",
     );
@@ -151,7 +148,6 @@ describe("attachWorktreeCore", () => {
       "/repo/.git/phantom/worktrees",
       "non-existent",
       undefined,
-      undefined,
       "/",
     );
 
@@ -178,7 +174,6 @@ describe("attachWorktreeCore", () => {
       "/repo/.git/phantom/worktrees",
       "feature",
       undefined,
-      undefined,
       "/",
     );
 
@@ -200,7 +195,6 @@ describe("attachWorktreeCore", () => {
       "/repo",
       "/repo/.git/phantom/worktrees",
       "feature",
-      undefined,
       undefined,
       "/",
     );
@@ -228,7 +222,6 @@ describe("attachWorktreeCore", () => {
       "/repo",
       "/repo/.git/phantom/worktrees",
       "feature/test",
-      undefined,
       undefined,
       "-",
     );

--- a/packages/core/src/worktree/attach.ts
+++ b/packages/core/src/worktree/attach.ts
@@ -11,13 +11,8 @@ import {
   type WorktreeActionOptions,
   type WorktreeLogger,
 } from "./action.ts";
-import {
-  BranchNotFoundError,
-  WorktreeAlreadyExistsError,
-  WorktreeError,
-} from "./errors.ts";
+import { BranchNotFoundError, WorktreeAlreadyExistsError } from "./errors.ts";
 import { copyFiles } from "./file-copier.ts";
-import { executePostCreateCommands } from "./post-create.ts";
 import { validateWorktreeName } from "./validate.ts";
 
 export interface RunAttachWorktreeOptions {
@@ -36,8 +31,7 @@ export async function attachWorktreeCore(
   gitRoot: string,
   worktreeDirectory: string,
   name: string,
-  postCreateCopyFiles: string[] | undefined,
-  postCreateCommands: string[] | undefined,
+  filesToCopy: string[] | undefined,
   directoryNameSeparator: string,
   logger?: WorktreeLogger,
 ): Promise<Result<string, Error>> {
@@ -79,30 +73,12 @@ export async function attachWorktreeCore(
     );
   }
 
-  if (postCreateCopyFiles && postCreateCopyFiles.length > 0) {
-    const copyResult = await copyFiles(
-      gitRoot,
-      worktreePath,
-      postCreateCopyFiles,
-    );
+  if (filesToCopy && filesToCopy.length > 0) {
+    const copyResult = await copyFiles(gitRoot, worktreePath, filesToCopy);
     if (isErr(copyResult)) {
       logger?.warn?.(
         `Warning: Failed to copy some files: ${copyResult.error.message}`,
       );
-    }
-  }
-
-  if (postCreateCommands && postCreateCommands.length > 0) {
-    logger?.log?.("\nRunning post-create commands...");
-    const commandsResult = await executePostCreateCommands({
-      gitRoot,
-      worktreesDirectory: worktreeDirectory,
-      worktreeName: name,
-      commands: postCreateCommands,
-      logger,
-    });
-    if (isErr(commandsResult)) {
-      return err(new WorktreeError(commandsResult.error.message));
     }
   }
 
@@ -136,7 +112,6 @@ export async function runAttachWorktree(
       context.worktreesDirectory,
       options.name,
       filesToCopy,
-      context.config?.postCreate?.commands,
       context.directoryNameSeparator,
       options.logger,
     );

--- a/packages/core/src/worktree/create-flow.test.ts
+++ b/packages/core/src/worktree/create-flow.test.ts
@@ -162,7 +162,7 @@ describe("runCreateWorktree", () => {
       [".env", "config.json"],
     ]);
     strictEqual(
-      logger.log.mock.calls[1][0],
+      logger.log.mock.calls[0][0],
       "Created worktree 'fuzzy-cats-dance' at /repo/.git/phantom/worktrees/fuzzy-cats-dance",
     );
   });
@@ -271,6 +271,52 @@ describe("runCreateWorktree", () => {
     strictEqual(
       logger.log.mock.calls[1][0],
       "\nOpening worktree 'feature' in tmux window...",
+    );
+  });
+
+  it("runs post-create commands after opening the requested action", async () => {
+    resetMocks();
+    processEnvMock.SHELL = "/bin/bash";
+    accessMock.mockResolvedValue(undefined);
+    validateWorktreeNameMock.mockReturnValue(ok(undefined));
+    validateWorktreeDoesNotExistMock.mockResolvedValue(ok(undefined));
+    addWorktreeMock.mockResolvedValue(undefined);
+    getGitRootMock.mockResolvedValue("/repo");
+    createContextMock.mockResolvedValue({
+      gitRoot: "/repo",
+      worktreesDirectory: "/repo/.git/phantom/worktrees",
+      directoryNameSeparator: "/",
+      config: {
+        postCreate: {
+          commands: ["npm install"],
+        },
+      },
+      preferences: {},
+    });
+    isInsideTmuxMock.mockResolvedValue(true);
+    executeTmuxCommandMock.mockResolvedValue(ok({ exitCode: 0 }));
+    executePostCreateCommandsMock.mockResolvedValue(
+      ok({ executedCommands: ["npm install"] }),
+    );
+    getPhantomEnvMock.mockReturnValue({
+      PHANTOM_NAME: "feature",
+      PHANTOM_PATH: "/repo/.git/phantom/worktrees/feature",
+    });
+
+    const result = await runCreateWorktree({
+      name: "feature",
+      action: {
+        tmuxDirection: "new",
+      },
+    });
+
+    strictEqual(result.ok, true);
+    strictEqual(executeTmuxCommandMock.mock.calls.length, 1);
+    strictEqual(executePostCreateCommandsMock.mock.calls.length, 1);
+    strictEqual(
+      executeTmuxCommandMock.mock.invocationCallOrder[0] <
+        executePostCreateCommandsMock.mock.invocationCallOrder[0],
+      true,
     );
   });
 });

--- a/packages/core/src/worktree/create-flow.test.ts
+++ b/packages/core/src/worktree/create-flow.test.ts
@@ -1,6 +1,6 @@
 import { deepStrictEqual, strictEqual } from "node:assert";
-import { afterAll, describe, it, vi } from "vitest";
-import { err, ok } from "@phantompane/utils";
+import { describe, it, vi } from "vitest";
+import { ok } from "@phantompane/utils";
 
 const accessMock = vi.fn();
 const mkdirMock = vi.fn();
@@ -15,17 +15,6 @@ const getWorktreePathFromDirectoryMock = vi.fn(
     `${worktreeDirectory}/${name.replaceAll("/", separator)}`,
 );
 const copyFilesMock = vi.fn();
-const isInsideTmuxMock = vi.fn();
-const executeTmuxCommandMock = vi.fn();
-const getPhantomEnvMock = vi.fn();
-
-const originalProcessEnv = process.env;
-const processEnvMock: NodeJS.ProcessEnv = {};
-process.env = processEnvMock;
-
-afterAll(() => {
-  process.env = originalProcessEnv;
-});
 
 vi.doMock("node:fs/promises", () => {
   const mockedFs = {
@@ -65,15 +54,6 @@ vi.doMock("./file-copier.ts", () => ({
   copyFiles: copyFilesMock,
 }));
 
-vi.doMock("@phantompane/process", () => ({
-  getPhantomEnv: getPhantomEnvMock,
-}));
-
-vi.doMock("@phantompane/tmux", () => ({
-  executeTmuxCommand: executeTmuxCommandMock,
-  isInsideTmux: isInsideTmuxMock,
-}));
-
 const { runCreateWorktree } = await import("./create.ts");
 
 describe("runCreateWorktree", () => {
@@ -88,13 +68,6 @@ describe("runCreateWorktree", () => {
     generateUniqueNameMock.mockReset();
     getWorktreePathFromDirectoryMock.mockClear();
     copyFilesMock.mockReset();
-    isInsideTmuxMock.mockReset();
-    executeTmuxCommandMock.mockReset();
-    getPhantomEnvMock.mockReset();
-
-    for (const key of Object.keys(processEnvMock)) {
-      delete processEnvMock[key];
-    }
   };
 
   it("merges configured copy files with CLI copy files and auto-generates the name", async () => {
@@ -135,6 +108,11 @@ describe("runCreateWorktree", () => {
 
     strictEqual(result.ok, true);
     if (result.ok) {
+      strictEqual(result.value.gitRoot, "/repo");
+      strictEqual(
+        result.value.worktreesDirectory,
+        "/repo/.git/phantom/worktrees",
+      );
       strictEqual(result.value.name, "fuzzy-cats-dance");
       strictEqual(
         result.value.path,
@@ -185,120 +163,5 @@ describe("runCreateWorktree", () => {
       base: "HEAD",
       cwd: "/selected/repo",
     });
-  });
-
-  it("returns a validation error when multiple open actions are requested", async () => {
-    resetMocks();
-
-    const result = await runCreateWorktree({
-      name: "feature",
-      action: {
-        shell: true,
-        exec: "echo hello",
-      },
-    });
-
-    strictEqual(result.ok, false);
-    if (!result.ok) {
-      strictEqual(
-        result.error.message,
-        "Cannot use --shell, --exec, and --tmux options together",
-      );
-    }
-    strictEqual(getGitRootMock.mock.calls.length, 0);
-  });
-
-  it("opens the created worktree in tmux from core", async () => {
-    resetMocks();
-    processEnvMock.SHELL = "/bin/bash";
-    accessMock.mockResolvedValue(undefined);
-    validateWorktreeNameMock.mockReturnValue(ok(undefined));
-    validateWorktreeDoesNotExistMock.mockResolvedValue(ok(undefined));
-    addWorktreeMock.mockResolvedValue(undefined);
-    getGitRootMock.mockResolvedValue("/repo");
-    createContextMock.mockResolvedValue({
-      gitRoot: "/repo",
-      worktreesDirectory: "/repo/.git/phantom/worktrees",
-      directoryNameSeparator: "/",
-      config: null,
-      preferences: {},
-    });
-    copyFilesMock.mockResolvedValue(
-      ok({
-        copiedFiles: [],
-        skippedFiles: [],
-      }),
-    );
-    isInsideTmuxMock.mockResolvedValue(true);
-    executeTmuxCommandMock.mockResolvedValue(ok({ exitCode: 0 }));
-    getPhantomEnvMock.mockReturnValue({
-      PHANTOM_NAME: "feature",
-      PHANTOM_PATH: "/repo/.git/phantom/worktrees/feature",
-    });
-    const logger = {
-      log: vi.fn(),
-      warn: vi.fn(),
-    };
-
-    const result = await runCreateWorktree({
-      name: "feature",
-      action: {
-        tmuxDirection: "new",
-      },
-      logger,
-    });
-
-    strictEqual(result.ok, true);
-    deepStrictEqual(executeTmuxCommandMock.mock.calls[0][0], {
-      direction: "new",
-      command: "/bin/bash",
-      cwd: "/repo/.git/phantom/worktrees/feature",
-      env: {
-        PHANTOM_NAME: "feature",
-        PHANTOM_PATH: "/repo/.git/phantom/worktrees/feature",
-      },
-      windowName: "feature",
-    });
-    strictEqual(
-      logger.log.mock.calls[1][0],
-      "\nOpening worktree 'feature' in tmux window...",
-    );
-  });
-
-  it("returns an error when opening the requested action fails", async () => {
-    resetMocks();
-    processEnvMock.SHELL = "/bin/bash";
-    accessMock.mockResolvedValue(undefined);
-    validateWorktreeNameMock.mockReturnValue(ok(undefined));
-    validateWorktreeDoesNotExistMock.mockResolvedValue(ok(undefined));
-    addWorktreeMock.mockResolvedValue(undefined);
-    getGitRootMock.mockResolvedValue("/repo");
-    createContextMock.mockResolvedValue({
-      gitRoot: "/repo",
-      worktreesDirectory: "/repo/.git/phantom/worktrees",
-      directoryNameSeparator: "/",
-      config: {
-        postCreate: {
-          commands: ["npm install"],
-        },
-      },
-      preferences: {},
-    });
-    isInsideTmuxMock.mockResolvedValue(true);
-    executeTmuxCommandMock.mockResolvedValue(err(new Error("tmux failed")));
-    getPhantomEnvMock.mockReturnValue({
-      PHANTOM_NAME: "feature",
-      PHANTOM_PATH: "/repo/.git/phantom/worktrees/feature",
-    });
-
-    const result = await runCreateWorktree({
-      name: "feature",
-      action: {
-        tmuxDirection: "new",
-      },
-    });
-
-    strictEqual(result.ok, false);
-    strictEqual(executeTmuxCommandMock.mock.calls.length, 1);
   });
 });

--- a/packages/core/src/worktree/create-flow.test.ts
+++ b/packages/core/src/worktree/create-flow.test.ts
@@ -1,6 +1,6 @@
 import { deepStrictEqual, strictEqual } from "node:assert";
 import { afterAll, describe, it, vi } from "vitest";
-import { ok } from "@phantompane/utils";
+import { err, ok } from "@phantompane/utils";
 
 const accessMock = vi.fn();
 const mkdirMock = vi.fn();
@@ -318,5 +318,43 @@ describe("runCreateWorktree", () => {
         executePostCreateCommandsMock.mock.invocationCallOrder[0],
       true,
     );
+  });
+
+  it("does not start post-create when opening the requested action fails", async () => {
+    resetMocks();
+    processEnvMock.SHELL = "/bin/bash";
+    accessMock.mockResolvedValue(undefined);
+    validateWorktreeNameMock.mockReturnValue(ok(undefined));
+    validateWorktreeDoesNotExistMock.mockResolvedValue(ok(undefined));
+    addWorktreeMock.mockResolvedValue(undefined);
+    getGitRootMock.mockResolvedValue("/repo");
+    createContextMock.mockResolvedValue({
+      gitRoot: "/repo",
+      worktreesDirectory: "/repo/.git/phantom/worktrees",
+      directoryNameSeparator: "/",
+      config: {
+        postCreate: {
+          commands: ["npm install"],
+        },
+      },
+      preferences: {},
+    });
+    isInsideTmuxMock.mockResolvedValue(true);
+    executeTmuxCommandMock.mockResolvedValue(err(new Error("tmux failed")));
+    getPhantomEnvMock.mockReturnValue({
+      PHANTOM_NAME: "feature",
+      PHANTOM_PATH: "/repo/.git/phantom/worktrees/feature",
+    });
+
+    const result = await runCreateWorktree({
+      name: "feature",
+      action: {
+        tmuxDirection: "new",
+      },
+    });
+
+    strictEqual(result.ok, false);
+    strictEqual(executeTmuxCommandMock.mock.calls.length, 1);
+    strictEqual(executePostCreateCommandsMock.mock.calls.length, 0);
   });
 });

--- a/packages/core/src/worktree/create-flow.test.ts
+++ b/packages/core/src/worktree/create-flow.test.ts
@@ -15,7 +15,6 @@ const getWorktreePathFromDirectoryMock = vi.fn(
     `${worktreeDirectory}/${name.replaceAll("/", separator)}`,
 );
 const copyFilesMock = vi.fn();
-const executePostCreateCommandsMock = vi.fn();
 const isInsideTmuxMock = vi.fn();
 const executeTmuxCommandMock = vi.fn();
 const getPhantomEnvMock = vi.fn();
@@ -66,10 +65,6 @@ vi.doMock("./file-copier.ts", () => ({
   copyFiles: copyFilesMock,
 }));
 
-vi.doMock("./post-create.ts", () => ({
-  executePostCreateCommands: executePostCreateCommandsMock,
-}));
-
 vi.doMock("@phantompane/process", () => ({
   getPhantomEnv: getPhantomEnvMock,
 }));
@@ -93,7 +88,6 @@ describe("runCreateWorktree", () => {
     generateUniqueNameMock.mockReset();
     getWorktreePathFromDirectoryMock.mockClear();
     copyFilesMock.mockReset();
-    executePostCreateCommandsMock.mockReset();
     isInsideTmuxMock.mockReset();
     executeTmuxCommandMock.mockReset();
     getPhantomEnvMock.mockReset();
@@ -128,9 +122,6 @@ describe("runCreateWorktree", () => {
         copiedFiles: [".env", "config.json"],
         skippedFiles: [],
       }),
-    );
-    executePostCreateCommandsMock.mockResolvedValue(
-      ok({ executedCommands: ["npm install"] }),
     );
     const logger = {
       log: vi.fn(),
@@ -274,53 +265,7 @@ describe("runCreateWorktree", () => {
     );
   });
 
-  it("runs post-create commands after opening the requested action", async () => {
-    resetMocks();
-    processEnvMock.SHELL = "/bin/bash";
-    accessMock.mockResolvedValue(undefined);
-    validateWorktreeNameMock.mockReturnValue(ok(undefined));
-    validateWorktreeDoesNotExistMock.mockResolvedValue(ok(undefined));
-    addWorktreeMock.mockResolvedValue(undefined);
-    getGitRootMock.mockResolvedValue("/repo");
-    createContextMock.mockResolvedValue({
-      gitRoot: "/repo",
-      worktreesDirectory: "/repo/.git/phantom/worktrees",
-      directoryNameSeparator: "/",
-      config: {
-        postCreate: {
-          commands: ["npm install"],
-        },
-      },
-      preferences: {},
-    });
-    isInsideTmuxMock.mockResolvedValue(true);
-    executeTmuxCommandMock.mockResolvedValue(ok({ exitCode: 0 }));
-    executePostCreateCommandsMock.mockResolvedValue(
-      ok({ executedCommands: ["npm install"] }),
-    );
-    getPhantomEnvMock.mockReturnValue({
-      PHANTOM_NAME: "feature",
-      PHANTOM_PATH: "/repo/.git/phantom/worktrees/feature",
-    });
-
-    const result = await runCreateWorktree({
-      name: "feature",
-      action: {
-        tmuxDirection: "new",
-      },
-    });
-
-    strictEqual(result.ok, true);
-    strictEqual(executeTmuxCommandMock.mock.calls.length, 1);
-    strictEqual(executePostCreateCommandsMock.mock.calls.length, 1);
-    strictEqual(
-      executeTmuxCommandMock.mock.invocationCallOrder[0] <
-        executePostCreateCommandsMock.mock.invocationCallOrder[0],
-      true,
-    );
-  });
-
-  it("does not start post-create when opening the requested action fails", async () => {
+  it("returns an error when opening the requested action fails", async () => {
     resetMocks();
     processEnvMock.SHELL = "/bin/bash";
     accessMock.mockResolvedValue(undefined);
@@ -355,6 +300,5 @@ describe("runCreateWorktree", () => {
 
     strictEqual(result.ok, false);
     strictEqual(executeTmuxCommandMock.mock.calls.length, 1);
-    strictEqual(executePostCreateCommandsMock.mock.calls.length, 0);
   });
 });

--- a/packages/core/src/worktree/create.test.ts
+++ b/packages/core/src/worktree/create.test.ts
@@ -109,8 +109,6 @@ describe("createWorktree", () => {
       "/test/repo/.git/phantom/worktrees",
       "feature-branch",
       {},
-      undefined,
-      undefined,
       "/",
     );
 
@@ -151,8 +149,6 @@ describe("createWorktree", () => {
       "/test/repo/.git/phantom/worktrees",
       "new-feature",
       {},
-      undefined,
-      undefined,
       "/",
     );
 
@@ -175,8 +171,6 @@ describe("createWorktree", () => {
       "/test/repo/.git/phantom/worktrees",
       "existing",
       {},
-      undefined,
-      undefined,
       "/",
     );
 
@@ -205,8 +199,6 @@ describe("createWorktree", () => {
         branch: "custom-branch",
         base: "main",
       },
-      undefined,
-      undefined,
       "/",
     );
 
@@ -232,8 +224,6 @@ describe("createWorktree", () => {
       "/test/repo/.git/phantom/worktrees",
       "bad-branch",
       {},
-      undefined,
-      undefined,
       "/",
     );
 
@@ -261,8 +251,6 @@ describe("createWorktree", () => {
       "/test/repo/.git/phantom/worktrees",
       "feature/test",
       {},
-      undefined,
-      undefined,
       "-",
     );
 
@@ -280,7 +268,7 @@ describe("createWorktree", () => {
     }
   });
 
-  it("merges explicit and post-create copy files without duplicates", async () => {
+  it("copies requested files", async () => {
     resetMocks();
     accessMock.mockImplementation(() => Promise.resolve());
     validateWorktreeNameMock.mockImplementation(() => ok(undefined));
@@ -302,10 +290,8 @@ describe("createWorktree", () => {
       "/test/repo/.git/phantom/worktrees",
       "feature",
       {
-        copyFiles: [".env", "config.json"],
+        copyFiles: [".env", "config.json", ".npmrc"],
       },
-      [".env", ".npmrc"],
-      undefined,
       "/",
     );
 
@@ -337,8 +323,6 @@ describe("createWorktree", () => {
         "/test/phantom-external",
         "feature-branch",
         {},
-        undefined,
-        undefined,
         "/",
       );
 
@@ -381,8 +365,6 @@ describe("createWorktree", () => {
         "/tmp/phantom-worktrees",
         "feature-branch",
         {},
-        undefined,
-        undefined,
         "/",
       );
 
@@ -418,8 +400,6 @@ describe("createWorktree", () => {
         "/test/phantom-external",
         "feature-branch",
         {},
-        undefined,
-        undefined,
         "/",
       );
 

--- a/packages/core/src/worktree/create.ts
+++ b/packages/core/src/worktree/create.ts
@@ -3,14 +3,7 @@ import { getGitRoot, addWorktree } from "@phantompane/git";
 import { err, isErr, isOk, ok, type Result } from "@phantompane/utils";
 import { createContext } from "../context.ts";
 import { getWorktreePathFromDirectory } from "../paths.ts";
-import {
-  mergeWorktreeCopyFiles,
-  resolveWorktreeAction,
-  runWorktreeAction,
-  validateWorktreeAction,
-  type WorktreeActionOptions,
-  type WorktreeLogger,
-} from "./action.ts";
+import { mergeWorktreeCopyFiles, type WorktreeLogger } from "./action.ts";
 import { copyFiles } from "./file-copier.ts";
 import { type WorktreeAlreadyExistsError, WorktreeError } from "./errors.ts";
 import { generateUniqueName } from "./generate-name.ts";
@@ -39,16 +32,16 @@ export interface RunCreateWorktreeOptions {
   gitRoot?: string;
   base?: string;
   copyFiles?: string[];
-  action?: WorktreeActionOptions;
   logger?: WorktreeLogger;
 }
 
 export interface RunCreateWorktreeSuccess {
+  gitRoot: string;
+  worktreesDirectory: string;
   name: string;
   path: string;
   message: string;
   copyError?: string;
-  exitProcessCode?: number;
 }
 
 export async function createWorktree(
@@ -135,16 +128,6 @@ export async function createWorktree(
 export async function runCreateWorktree(
   options: RunCreateWorktreeOptions,
 ): Promise<Result<RunCreateWorktreeSuccess>> {
-  const actionResult = resolveWorktreeAction(options.action);
-  if (isErr(actionResult)) {
-    return actionResult;
-  }
-
-  const actionValidation = await validateWorktreeAction(actionResult.value);
-  if (isErr(actionValidation)) {
-    return actionValidation;
-  }
-
   try {
     const gitRoot = options.gitRoot ?? (await getGitRoot());
     const context = await createContext(gitRoot);
@@ -190,26 +173,13 @@ export async function runCreateWorktree(
       );
     }
 
-    const worktreeActionResult = await runWorktreeAction({
-      gitRoot: context.gitRoot,
-      worktreeDirectory: context.worktreesDirectory,
-      worktreeName,
-      worktreePath: createResult.value.path,
-      action: actionResult.value,
-      logger: options.logger,
-      exitWithProcessCode: true,
-    });
-
-    if (isErr(worktreeActionResult)) {
-      return err(worktreeActionResult.error);
-    }
-
     return ok({
+      gitRoot: context.gitRoot,
+      worktreesDirectory: context.worktreesDirectory,
       name: worktreeName,
       path: createResult.value.path,
       message: createResult.value.message,
       copyError: createResult.value.copyError,
-      exitProcessCode: worktreeActionResult.value.exitProcessCode,
     });
   } catch (error) {
     return err(error instanceof Error ? error : new Error(String(error)));

--- a/packages/core/src/worktree/create.ts
+++ b/packages/core/src/worktree/create.ts
@@ -4,10 +4,6 @@ import { err, isErr, isOk, ok, type Result } from "@phantompane/utils";
 import { createContext } from "../context.ts";
 import { getWorktreePathFromDirectory } from "../paths.ts";
 import {
-  executePostCreateCommands,
-  type PostCreateExecutionResult,
-} from "./post-create.ts";
-import {
   mergeWorktreeCopyFiles,
   resolveWorktreeAction,
   runWorktreeAction,
@@ -38,22 +34,6 @@ export interface CreateWorktreeSuccess {
   copyError?: string;
 }
 
-export type RunCreateWorktreePostCreateMode =
-  | "afterAction"
-  | "beforeAction"
-  | "skip";
-
-export interface WorktreePostCreateTask {
-  gitRoot: string;
-  worktreesDirectory: string;
-  worktreeName: string;
-  commands: string[];
-}
-
-export interface RunPostCreateWorktreeOptions extends WorktreePostCreateTask {
-  logger?: WorktreeLogger;
-}
-
 export interface RunCreateWorktreeOptions {
   name?: string;
   gitRoot?: string;
@@ -61,7 +41,6 @@ export interface RunCreateWorktreeOptions {
   copyFiles?: string[];
   action?: WorktreeActionOptions;
   logger?: WorktreeLogger;
-  postCreate?: RunCreateWorktreePostCreateMode;
 }
 
 export interface RunCreateWorktreeSuccess {
@@ -70,7 +49,6 @@ export interface RunCreateWorktreeSuccess {
   message: string;
   copyError?: string;
   exitProcessCode?: number;
-  postCreate?: WorktreePostCreateTask;
 }
 
 export async function createWorktree(
@@ -78,8 +56,6 @@ export async function createWorktree(
   worktreeDirectory: string,
   name: string,
   options: CreateWorktreeOptions,
-  postCreateCopyFiles: string[] | undefined,
-  postCreateCommands: string[] | undefined,
   directoryNameSeparator: string,
 ): Promise<
   Result<CreateWorktreeSuccess, WorktreeAlreadyExistsError | WorktreeError>
@@ -93,7 +69,6 @@ export async function createWorktree(
     branch = name,
     base = "HEAD",
     copyFiles: requestedCopyFiles,
-    logger,
   } = options;
 
   const worktreePath = getWorktreePathFromDirectory(
@@ -129,32 +104,18 @@ export async function createWorktree(
     let skippedFiles: string[] | undefined;
     let copyError: string | undefined;
 
-    const filesToCopy = mergeWorktreeCopyFiles(
-      requestedCopyFiles,
-      postCreateCopyFiles,
-    );
-
-    if (filesToCopy) {
-      const copyResult = await copyFiles(gitRoot, worktreePath, filesToCopy);
+    if (requestedCopyFiles) {
+      const copyResult = await copyFiles(
+        gitRoot,
+        worktreePath,
+        requestedCopyFiles,
+      );
 
       if (isOk(copyResult)) {
         copiedFiles = copyResult.value.copiedFiles;
         skippedFiles = copyResult.value.skippedFiles;
       } else {
         copyError = copyResult.error.message;
-      }
-    }
-
-    if (postCreateCommands && postCreateCommands.length > 0) {
-      const commandsResult = await runPostCreateWorktree({
-        gitRoot,
-        worktreesDirectory: worktreeDirectory,
-        worktreeName: name,
-        commands: postCreateCommands,
-        logger,
-      });
-      if (isErr(commandsResult)) {
-        return err(commandsResult.error);
       }
     }
 
@@ -171,46 +132,6 @@ export async function createWorktree(
   }
 }
 
-export async function runPostCreateWorktree(
-  options: RunPostCreateWorktreeOptions,
-): Promise<Result<PostCreateExecutionResult, WorktreeError>> {
-  if (options.commands.length === 0) {
-    return ok({ executedCommands: [] });
-  }
-
-  options.logger?.log?.("\nRunning post-create commands...");
-  const commandsResult = await executePostCreateCommands({
-    gitRoot: options.gitRoot,
-    worktreesDirectory: options.worktreesDirectory,
-    worktreeName: options.worktreeName,
-    commands: options.commands,
-    logger: options.logger,
-  });
-  if (isErr(commandsResult)) {
-    return err(new WorktreeError(commandsResult.error.message));
-  }
-
-  return commandsResult;
-}
-
-export function createWorktreePostCreateTask(
-  gitRoot: string,
-  worktreesDirectory: string,
-  worktreeName: string,
-  commands: string[] | undefined,
-): WorktreePostCreateTask | undefined {
-  if (!commands || commands.length === 0) {
-    return undefined;
-  }
-
-  return {
-    gitRoot,
-    worktreesDirectory,
-    worktreeName,
-    commands,
-  };
-}
-
 export async function runCreateWorktree(
   options: RunCreateWorktreeOptions,
 ): Promise<Result<RunCreateWorktreeSuccess>> {
@@ -223,8 +144,6 @@ export async function runCreateWorktree(
   if (isErr(actionValidation)) {
     return actionValidation;
   }
-
-  const postCreateMode = options.postCreate ?? "afterAction";
 
   try {
     const gitRoot = options.gitRoot ?? (await getGitRoot());
@@ -248,13 +167,6 @@ export async function runCreateWorktree(
       options.copyFiles,
     );
 
-    const postCreateTask = createWorktreePostCreateTask(
-      context.gitRoot,
-      context.worktreesDirectory,
-      worktreeName,
-      context.config?.postCreate?.commands,
-    );
-
     const createResult = await createWorktree(
       context.gitRoot,
       context.worktreesDirectory,
@@ -264,8 +176,6 @@ export async function runCreateWorktree(
         copyFiles: filesToCopy,
         logger: options.logger,
       },
-      undefined,
-      postCreateMode === "beforeAction" ? postCreateTask?.commands : undefined,
       context.directoryNameSeparator,
     );
     if (isErr(createResult)) {
@@ -280,42 +190,6 @@ export async function runCreateWorktree(
       );
     }
 
-    if (postCreateMode === "skip") {
-      return ok({
-        name: worktreeName,
-        path: createResult.value.path,
-        message: createResult.value.message,
-        copyError: createResult.value.copyError,
-        postCreate: postCreateTask,
-      });
-    }
-
-    let postCreatePromise:
-      | Promise<Result<PostCreateExecutionResult, WorktreeError>>
-      | undefined;
-    const startPostCreate = () => {
-      if (!postCreateTask) {
-        return undefined;
-      }
-      postCreatePromise ??= runPostCreateWorktree({
-        ...postCreateTask,
-        logger: options.logger,
-      });
-      return postCreatePromise;
-    };
-    const schedulePostCreate = () => {
-      if (!postCreateTask) {
-        return undefined;
-      }
-      postCreatePromise ??= Promise.resolve().then(() =>
-        runPostCreateWorktree({
-          ...postCreateTask,
-          logger: options.logger,
-        }),
-      );
-      return postCreatePromise;
-    };
-
     const worktreeActionResult = await runWorktreeAction({
       gitRoot: context.gitRoot,
       worktreeDirectory: context.worktreesDirectory,
@@ -324,23 +198,10 @@ export async function runCreateWorktree(
       action: actionResult.value,
       logger: options.logger,
       exitWithProcessCode: true,
-      onStarted:
-        postCreateMode === "afterAction" ? schedulePostCreate : undefined,
     });
 
     if (isErr(worktreeActionResult)) {
-      if (postCreatePromise) {
-        await postCreatePromise.catch(() => undefined);
-      }
       return err(worktreeActionResult.error);
-    }
-
-    const postCreateResult =
-      postCreateMode === "afterAction"
-        ? await (postCreatePromise ?? startPostCreate())
-        : undefined;
-    if (postCreateResult && isErr(postCreateResult)) {
-      return err(postCreateResult.error);
     }
 
     return ok({

--- a/packages/core/src/worktree/create.ts
+++ b/packages/core/src/worktree/create.ts
@@ -3,7 +3,10 @@ import { getGitRoot, addWorktree } from "@phantompane/git";
 import { err, isErr, isOk, ok, type Result } from "@phantompane/utils";
 import { createContext } from "../context.ts";
 import { getWorktreePathFromDirectory } from "../paths.ts";
-import { executePostCreateCommands } from "./post-create.ts";
+import {
+  executePostCreateCommands,
+  type PostCreateExecutionResult,
+} from "./post-create.ts";
 import {
   mergeWorktreeCopyFiles,
   resolveWorktreeAction,
@@ -35,6 +38,22 @@ export interface CreateWorktreeSuccess {
   copyError?: string;
 }
 
+export type RunCreateWorktreePostCreateMode =
+  | "afterAction"
+  | "beforeAction"
+  | "skip";
+
+export interface WorktreePostCreateTask {
+  gitRoot: string;
+  worktreesDirectory: string;
+  worktreeName: string;
+  commands: string[];
+}
+
+export interface RunPostCreateWorktreeOptions extends WorktreePostCreateTask {
+  logger?: WorktreeLogger;
+}
+
 export interface RunCreateWorktreeOptions {
   name?: string;
   gitRoot?: string;
@@ -42,6 +61,7 @@ export interface RunCreateWorktreeOptions {
   copyFiles?: string[];
   action?: WorktreeActionOptions;
   logger?: WorktreeLogger;
+  postCreate?: RunCreateWorktreePostCreateMode;
 }
 
 export interface RunCreateWorktreeSuccess {
@@ -50,6 +70,7 @@ export interface RunCreateWorktreeSuccess {
   message: string;
   copyError?: string;
   exitProcessCode?: number;
+  postCreate?: WorktreePostCreateTask;
 }
 
 export async function createWorktree(
@@ -125,8 +146,7 @@ export async function createWorktree(
     }
 
     if (postCreateCommands && postCreateCommands.length > 0) {
-      logger?.log?.("\nRunning post-create commands...");
-      const commandsResult = await executePostCreateCommands({
+      const commandsResult = await runPostCreateWorktree({
         gitRoot,
         worktreesDirectory: worktreeDirectory,
         worktreeName: name,
@@ -134,7 +154,7 @@ export async function createWorktree(
         logger,
       });
       if (isErr(commandsResult)) {
-        return err(new WorktreeError(commandsResult.error.message));
+        return err(commandsResult.error);
       }
     }
 
@@ -151,6 +171,46 @@ export async function createWorktree(
   }
 }
 
+export async function runPostCreateWorktree(
+  options: RunPostCreateWorktreeOptions,
+): Promise<Result<PostCreateExecutionResult, WorktreeError>> {
+  if (options.commands.length === 0) {
+    return ok({ executedCommands: [] });
+  }
+
+  options.logger?.log?.("\nRunning post-create commands...");
+  const commandsResult = await executePostCreateCommands({
+    gitRoot: options.gitRoot,
+    worktreesDirectory: options.worktreesDirectory,
+    worktreeName: options.worktreeName,
+    commands: options.commands,
+    logger: options.logger,
+  });
+  if (isErr(commandsResult)) {
+    return err(new WorktreeError(commandsResult.error.message));
+  }
+
+  return commandsResult;
+}
+
+export function createWorktreePostCreateTask(
+  gitRoot: string,
+  worktreesDirectory: string,
+  worktreeName: string,
+  commands: string[] | undefined,
+): WorktreePostCreateTask | undefined {
+  if (!commands || commands.length === 0) {
+    return undefined;
+  }
+
+  return {
+    gitRoot,
+    worktreesDirectory,
+    worktreeName,
+    commands,
+  };
+}
+
 export async function runCreateWorktree(
   options: RunCreateWorktreeOptions,
 ): Promise<Result<RunCreateWorktreeSuccess>> {
@@ -163,6 +223,8 @@ export async function runCreateWorktree(
   if (isErr(actionValidation)) {
     return actionValidation;
   }
+
+  const postCreateMode = options.postCreate ?? "afterAction";
 
   try {
     const gitRoot = options.gitRoot ?? (await getGitRoot());
@@ -186,6 +248,13 @@ export async function runCreateWorktree(
       options.copyFiles,
     );
 
+    const postCreateTask = createWorktreePostCreateTask(
+      context.gitRoot,
+      context.worktreesDirectory,
+      worktreeName,
+      context.config?.postCreate?.commands,
+    );
+
     const createResult = await createWorktree(
       context.gitRoot,
       context.worktreesDirectory,
@@ -196,7 +265,7 @@ export async function runCreateWorktree(
         logger: options.logger,
       },
       undefined,
-      context.config?.postCreate?.commands,
+      postCreateMode === "beforeAction" ? postCreateTask?.commands : undefined,
       context.directoryNameSeparator,
     );
     if (isErr(createResult)) {
@@ -211,6 +280,42 @@ export async function runCreateWorktree(
       );
     }
 
+    if (postCreateMode === "skip") {
+      return ok({
+        name: worktreeName,
+        path: createResult.value.path,
+        message: createResult.value.message,
+        copyError: createResult.value.copyError,
+        postCreate: postCreateTask,
+      });
+    }
+
+    let postCreatePromise:
+      | Promise<Result<PostCreateExecutionResult, WorktreeError>>
+      | undefined;
+    const startPostCreate = () => {
+      if (!postCreateTask) {
+        return undefined;
+      }
+      postCreatePromise ??= runPostCreateWorktree({
+        ...postCreateTask,
+        logger: options.logger,
+      });
+      return postCreatePromise;
+    };
+    const schedulePostCreate = () => {
+      if (!postCreateTask) {
+        return undefined;
+      }
+      postCreatePromise ??= Promise.resolve().then(() =>
+        runPostCreateWorktree({
+          ...postCreateTask,
+          logger: options.logger,
+        }),
+      );
+      return postCreatePromise;
+    };
+
     const worktreeActionResult = await runWorktreeAction({
       gitRoot: context.gitRoot,
       worktreeDirectory: context.worktreesDirectory,
@@ -219,9 +324,19 @@ export async function runCreateWorktree(
       action: actionResult.value,
       logger: options.logger,
       exitWithProcessCode: true,
+      onStarted:
+        postCreateMode === "afterAction" ? schedulePostCreate : undefined,
     });
+
+    const postCreateResult =
+      postCreateMode === "afterAction"
+        ? await (postCreatePromise ?? startPostCreate())
+        : undefined;
     if (isErr(worktreeActionResult)) {
       return err(worktreeActionResult.error);
+    }
+    if (postCreateResult && isErr(postCreateResult)) {
+      return err(postCreateResult.error);
     }
 
     return ok({

--- a/packages/core/src/worktree/create.ts
+++ b/packages/core/src/worktree/create.ts
@@ -328,13 +328,17 @@ export async function runCreateWorktree(
         postCreateMode === "afterAction" ? schedulePostCreate : undefined,
     });
 
+    if (isErr(worktreeActionResult)) {
+      if (postCreatePromise) {
+        await postCreatePromise.catch(() => undefined);
+      }
+      return err(worktreeActionResult.error);
+    }
+
     const postCreateResult =
       postCreateMode === "afterAction"
         ? await (postCreatePromise ?? startPostCreate())
         : undefined;
-    if (isErr(worktreeActionResult)) {
-      return err(worktreeActionResult.error);
-    }
     if (postCreateResult && isErr(postCreateResult)) {
       return err(postCreateResult.error);
     }

--- a/packages/core/src/worktree/post-create.test.ts
+++ b/packages/core/src/worktree/post-create.test.ts
@@ -3,15 +3,26 @@ import { describe, it, vi } from "vitest";
 import { err, isErr, isOk, ok } from "@phantompane/utils";
 
 const execInWorktreeMock = vi.fn();
+const getGitRootMock = vi.fn();
+const createContextMock = vi.fn();
 const logger = {
   log: vi.fn(),
 };
+
+vi.doMock("@phantompane/git", () => ({
+  getGitRoot: getGitRootMock,
+}));
+
+vi.doMock("../context.ts", () => ({
+  createContext: createContextMock,
+}));
 
 vi.doMock("../exec.ts", () => ({
   execInWorktree: execInWorktreeMock,
 }));
 
-const { executePostCreateCommands } = await import("./post-create.ts");
+const { executePostCreateCommands, runPostCreateWorktree } =
+  await import("./post-create.ts");
 
 describe("executePostCreateCommands", () => {
   it("should execute commands successfully", async () => {
@@ -145,5 +156,66 @@ describe("executePostCreateCommands", () => {
         "Post-create command failed with exit code 1: cmd2",
       );
     }
+  });
+});
+
+describe("runPostCreateWorktree", () => {
+  it("loads post-create commands from config and executes them", async () => {
+    execInWorktreeMock.mockClear();
+    getGitRootMock.mockClear();
+    createContextMock.mockClear();
+    logger.log.mockClear();
+    getGitRootMock.mockResolvedValue("/repo");
+    createContextMock.mockResolvedValue({
+      gitRoot: "/repo",
+      worktreesDirectory: "/repo/.git/phantom/worktrees",
+      config: {
+        postCreate: {
+          commands: ["pnpm install"],
+        },
+      },
+    });
+    execInWorktreeMock.mockResolvedValue(ok({ exitCode: 0 }));
+
+    const result = await runPostCreateWorktree({
+      worktreeName: "feature",
+      logger,
+    });
+
+    deepStrictEqual(isOk(result), true);
+    deepStrictEqual(getGitRootMock.mock.calls.length, 1);
+    deepStrictEqual(createContextMock.mock.calls[0], ["/repo"]);
+    deepStrictEqual(execInWorktreeMock.mock.calls[0].slice(0, 4), [
+      "/repo",
+      "/repo/.git/phantom/worktrees",
+      "feature",
+      [process.env.SHELL || "/bin/sh", "-c", "pnpm install"],
+    ]);
+    deepStrictEqual(
+      logger.log.mock.calls[0][0],
+      "\nRunning post-create commands...",
+    );
+  });
+
+  it("returns without executing when no post-create commands are configured", async () => {
+    execInWorktreeMock.mockClear();
+    getGitRootMock.mockClear();
+    createContextMock.mockClear();
+    getGitRootMock.mockResolvedValue("/repo");
+    createContextMock.mockResolvedValue({
+      gitRoot: "/repo",
+      worktreesDirectory: "/repo/.git/phantom/worktrees",
+      config: {},
+    });
+
+    const result = await runPostCreateWorktree({
+      worktreeName: "feature",
+    });
+
+    deepStrictEqual(isOk(result), true);
+    if (isOk(result)) {
+      deepStrictEqual(result.value.executedCommands, []);
+    }
+    deepStrictEqual(execInWorktreeMock.mock.calls.length, 0);
   });
 });

--- a/packages/core/src/worktree/post-create.ts
+++ b/packages/core/src/worktree/post-create.ts
@@ -1,6 +1,20 @@
+import { getGitRoot } from "@phantompane/git";
 import { err, isErr, ok, type Result } from "@phantompane/utils";
+import { createContext } from "../context.ts";
 import { execInWorktree } from "../exec.ts";
 import type { WorktreeLogger } from "./action.ts";
+import { WorktreeError } from "./errors.ts";
+
+export interface RunPostCreateWorktreeOptions {
+  gitRoot?: string;
+  worktreeName: string;
+  commands?: string[];
+  logger?: WorktreeLogger;
+}
+
+export interface HasPostCreateWorktreeCommandsOptions {
+  gitRoot?: string;
+}
 
 export interface PostCreateExecutionOptions {
   gitRoot: string;
@@ -12,6 +26,50 @@ export interface PostCreateExecutionOptions {
 
 export interface PostCreateExecutionResult {
   executedCommands: string[];
+}
+
+export async function hasPostCreateWorktreeCommands(
+  options: HasPostCreateWorktreeCommandsOptions = {},
+): Promise<Result<boolean, WorktreeError>> {
+  try {
+    const gitRoot = options.gitRoot ?? (await getGitRoot());
+    const context = await createContext(gitRoot);
+    return ok((context.config?.postCreate?.commands?.length ?? 0) > 0);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return err(new WorktreeError(message));
+  }
+}
+
+export async function runPostCreateWorktree(
+  options: RunPostCreateWorktreeOptions,
+): Promise<Result<PostCreateExecutionResult, WorktreeError>> {
+  try {
+    const gitRoot = options.gitRoot ?? (await getGitRoot());
+    const context = await createContext(gitRoot);
+    const commands = options.commands ?? context.config?.postCreate?.commands;
+
+    if (!commands || commands.length === 0) {
+      return ok({ executedCommands: [] });
+    }
+
+    options.logger?.log?.("\nRunning post-create commands...");
+    const commandsResult = await executePostCreateCommands({
+      gitRoot: context.gitRoot,
+      worktreesDirectory: context.worktreesDirectory,
+      worktreeName: options.worktreeName,
+      commands,
+      logger: options.logger,
+    });
+    if (isErr(commandsResult)) {
+      return err(new WorktreeError(commandsResult.error.message));
+    }
+
+    return commandsResult;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return err(new WorktreeError(message));
+  }
 }
 
 export async function executePostCreateCommands(

--- a/packages/mcp/src/tools/create-worktree.test.ts
+++ b/packages/mcp/src/tools/create-worktree.test.ts
@@ -100,8 +100,6 @@ describe("createWorktreeTool", () => {
         copyFiles: undefined,
       },
       undefined,
-      undefined,
-      undefined,
     ]);
 
     strictEqual(result.content.length, 1);
@@ -150,8 +148,6 @@ describe("createWorktreeTool", () => {
         base: "develop",
         copyFiles: undefined,
       },
-      undefined,
-      undefined,
       undefined,
     ]);
 

--- a/packages/mcp/src/tools/create-worktree.ts
+++ b/packages/mcp/src/tools/create-worktree.ts
@@ -30,8 +30,6 @@ export const createWorktreeTool: Tool<typeof schema> = {
         base: baseBranch,
         copyFiles: context.config?.postCreate?.copyFiles,
       },
-      undefined,
-      context.config?.postCreate?.commands,
       context.directoryNameSeparator,
     );
 

--- a/packages/process/src/spawn.test.ts
+++ b/packages/process/src/spawn.test.ts
@@ -162,6 +162,27 @@ describe("spawnProcess", () => {
     }
   });
 
+  it("should call onSpawned after the process starts", async () => {
+    const mockChildProcess = new EventEmitter();
+    const onSpawned = vi.fn();
+    spawnMock.mockClear();
+    spawnMock.mockImplementation(() => {
+      setTimeout(() => {
+        mockChildProcess.emit("spawn");
+        mockChildProcess.emit("exit", 0, null);
+      }, 0);
+      return mockChildProcess;
+    });
+
+    const result = await spawnProcess({
+      command: "echo",
+      onSpawned,
+    });
+
+    strictEqual(isOk(result), true);
+    strictEqual(onSpawned.mock.calls.length, 1);
+  });
+
   it("should use default values when args and options are not provided", async () => {
     const mockChildProcess = new EventEmitter();
     spawnMock.mockClear();

--- a/packages/process/src/spawn.ts
+++ b/packages/process/src/spawn.ts
@@ -19,17 +19,22 @@ export interface SpawnConfig {
   command: string;
   args?: string[];
   options?: SpawnOptions;
+  onSpawned?: () => void;
 }
 
 export async function spawnProcess(
   config: SpawnConfig,
 ): Promise<Result<SpawnSuccess, ProcessError>> {
   return new Promise((resolve) => {
-    const { command, args = [], options = {} } = config;
+    const { command, args = [], options = {}, onSpawned } = config;
 
     const childProcess: ChildProcess = nodeSpawn(command, args, {
       stdio: "inherit",
       ...options,
+    });
+
+    childProcess.on("spawn", () => {
+      onSpawned?.();
     });
 
     childProcess.on("error", (error) => {

--- a/packages/server/src/services.test.ts
+++ b/packages/server/src/services.test.ts
@@ -2,7 +2,7 @@ import { deepStrictEqual, rejects, strictEqual } from "node:assert";
 import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import { WorktreeAlreadyExistsError } from "@phantompane/core";
 import type { CodexBridge, CodexMessage } from "@phantompane/codex";
 import { ServeStateStore } from "@phantompane/state";
@@ -20,6 +20,7 @@ const coreMocks = vi.hoisted(() => ({
   deleteBranch: vi.fn(),
   deleteWorktree: vi.fn(),
   githubCheckout: vi.fn(),
+  hasPostCreateWorktreeCommands: vi.fn(),
   listGitHubCheckoutTargets: vi.fn(),
   listWorktrees: vi.fn(),
   removeWorktree: vi.fn(),
@@ -53,6 +54,17 @@ const validInterlacedPngBytes = new Uint8Array([
   156, 99, 96, 96, 96, 0, 0, 0, 4, 0, 1, 246, 23, 56, 85, 0, 0, 0, 0, 73, 69,
   78, 68, 174, 66, 96, 130,
 ]);
+
+beforeEach(() => {
+  coreMocks.hasPostCreateWorktreeCommands.mockResolvedValue({
+    ok: true,
+    value: false,
+  });
+  coreMocks.runPostCreateWorktree.mockResolvedValue({
+    ok: true,
+    value: { executedCommands: [] },
+  });
+});
 
 class FakeCodexBridge {
   readonly notificationHandlers: Array<(message: CodexMessage) => void> = [];
@@ -6197,54 +6209,6 @@ describe("ServeServices", () => {
       projects: [createProject()],
     };
     const { codex, services } = await createHarness(state);
-    const postCreate = {
-      gitRoot: "/repo",
-      worktreesDirectory: "/repo/.git/phantom/worktrees",
-      worktreeName: "feature",
-      commands: ["pnpm install"],
-    };
-    coreMocks.runCreateWorktree.mockResolvedValueOnce({
-      ok: true,
-      value: {
-        name: "feature",
-        path: "/repo/.git/phantom/worktrees/feature",
-        postCreate,
-      },
-    });
-    coreMocks.runPostCreateWorktree.mockReturnValueOnce(
-      new Promise(() => undefined),
-    );
-    codex.startThread.mockResolvedValueOnce({ thread: { id: "thread_new" } });
-
-    const chat = await services.createChat("proj_1", { name: "feature" });
-
-    strictEqual(chat.worktreeName, "feature");
-    strictEqual(
-      coreMocks.runCreateWorktree.mock.calls[0][0].postCreate,
-      "skip",
-    );
-    strictEqual(coreMocks.runPostCreateWorktree.mock.calls.length, 0);
-    await vi.waitFor(() => {
-      strictEqual(coreMocks.runPostCreateWorktree.mock.calls.length, 1);
-    });
-    deepStrictEqual(
-      coreMocks.runPostCreateWorktree.mock.calls[0][0],
-      postCreate,
-    );
-  });
-
-  it("waits to send messages until deferred post-create commands finish", async () => {
-    const state = {
-      ...createTestState(),
-      projects: [createProject()],
-    };
-    const { codex, services } = await createHarness(state);
-    const postCreate = {
-      gitRoot: "/repo",
-      worktreesDirectory: "/repo/.git/phantom/worktrees",
-      worktreeName: "feature",
-      commands: ["pnpm install"],
-    };
     let resolvePostCreate!: (value: {
       ok: true;
       value: { executedCommands: string[] };
@@ -6254,8 +6218,60 @@ describe("ServeServices", () => {
       value: {
         name: "feature",
         path: "/repo/.git/phantom/worktrees/feature",
-        postCreate,
       },
+    });
+    coreMocks.hasPostCreateWorktreeCommands.mockResolvedValueOnce({
+      ok: true,
+      value: true,
+    });
+    coreMocks.runPostCreateWorktree.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolvePostCreate = resolve;
+      }),
+    );
+    codex.startThread.mockResolvedValueOnce({ thread: { id: "thread_new" } });
+
+    const chat = await services.createChat("proj_1", { name: "feature" });
+
+    strictEqual(chat.worktreeName, "feature");
+    strictEqual(
+      coreMocks.runCreateWorktree.mock.calls[0][0].postCreate,
+      undefined,
+    );
+    await vi.waitFor(() => {
+      strictEqual(coreMocks.runPostCreateWorktree.mock.calls.length, 1);
+    });
+    deepStrictEqual(coreMocks.runPostCreateWorktree.mock.calls[0][0], {
+      gitRoot: "/repo",
+      worktreeName: "feature",
+    });
+    resolvePostCreate({
+      ok: true,
+      value: { executedCommands: ["pnpm install"] },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+
+  it("waits to send messages until deferred post-create commands finish", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+    };
+    const { codex, services } = await createHarness(state);
+    let resolvePostCreate!: (value: {
+      ok: true;
+      value: { executedCommands: string[] };
+    }) => void;
+    coreMocks.runCreateWorktree.mockResolvedValueOnce({
+      ok: true,
+      value: {
+        name: "feature",
+        path: "/repo/.git/phantom/worktrees/feature",
+      },
+    });
+    coreMocks.hasPostCreateWorktreeCommands.mockResolvedValueOnce({
+      ok: true,
+      value: true,
     });
     coreMocks.runPostCreateWorktree.mockReturnValueOnce(
       new Promise((resolve) => {
@@ -6386,7 +6402,6 @@ describe("ServeServices", () => {
         number: "42",
         base: undefined,
         cwd: "/repo",
-        postCreate: "skip",
       },
     ]);
     deepStrictEqual(codex.startThread.mock.calls[0], [

--- a/packages/server/src/services.test.ts
+++ b/packages/server/src/services.test.ts
@@ -24,6 +24,7 @@ const coreMocks = vi.hoisted(() => ({
   listWorktrees: vi.fn(),
   removeWorktree: vi.fn(),
   runCreateWorktree: vi.fn(),
+  runPostCreateWorktree: vi.fn(),
 }));
 
 const gitMocks = vi.hoisted(() => ({
@@ -6190,6 +6191,98 @@ describe("ServeServices", () => {
     deepStrictEqual(savedState.messages, []);
   });
 
+  it("defers post-create commands after creating a worktree chat", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+    };
+    const { codex, services } = await createHarness(state);
+    const postCreate = {
+      gitRoot: "/repo",
+      worktreesDirectory: "/repo/.git/phantom/worktrees",
+      worktreeName: "feature",
+      commands: ["pnpm install"],
+    };
+    coreMocks.runCreateWorktree.mockResolvedValueOnce({
+      ok: true,
+      value: {
+        name: "feature",
+        path: "/repo/.git/phantom/worktrees/feature",
+        postCreate,
+      },
+    });
+    coreMocks.runPostCreateWorktree.mockReturnValueOnce(
+      new Promise(() => undefined),
+    );
+    codex.startThread.mockResolvedValueOnce({ thread: { id: "thread_new" } });
+
+    const chat = await services.createChat("proj_1", { name: "feature" });
+
+    strictEqual(chat.worktreeName, "feature");
+    strictEqual(
+      coreMocks.runCreateWorktree.mock.calls[0][0].postCreate,
+      "skip",
+    );
+    strictEqual(coreMocks.runPostCreateWorktree.mock.calls.length, 0);
+    await vi.waitFor(() => {
+      strictEqual(coreMocks.runPostCreateWorktree.mock.calls.length, 1);
+    });
+    deepStrictEqual(
+      coreMocks.runPostCreateWorktree.mock.calls[0][0],
+      postCreate,
+    );
+  });
+
+  it("waits to send messages until deferred post-create commands finish", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+    };
+    const { codex, services } = await createHarness(state);
+    const postCreate = {
+      gitRoot: "/repo",
+      worktreesDirectory: "/repo/.git/phantom/worktrees",
+      worktreeName: "feature",
+      commands: ["pnpm install"],
+    };
+    let resolvePostCreate!: (value: {
+      ok: true;
+      value: { executedCommands: string[] };
+    }) => void;
+    coreMocks.runCreateWorktree.mockResolvedValueOnce({
+      ok: true,
+      value: {
+        name: "feature",
+        path: "/repo/.git/phantom/worktrees/feature",
+        postCreate,
+      },
+    });
+    coreMocks.runPostCreateWorktree.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolvePostCreate = resolve;
+      }),
+    );
+    codex.startThread.mockResolvedValueOnce({ thread: { id: "thread_new" } });
+    codex.startTurn.mockResolvedValueOnce({ turn: { id: "turn_1" } });
+
+    const chat = await services.createChat("proj_1", { name: "feature" });
+    await vi.waitFor(() => {
+      strictEqual(coreMocks.runPostCreateWorktree.mock.calls.length, 1);
+    });
+
+    const send = services.sendMessage(chat.id, { text: "start work" });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    strictEqual(codex.startTurn.mock.calls.length, 0);
+
+    resolvePostCreate({
+      ok: true,
+      value: { executedCommands: ["pnpm install"] },
+    });
+    await send;
+
+    strictEqual(codex.startTurn.mock.calls.length, 1);
+  });
+
   it("starts a new Codex thread in an existing worktree", async () => {
     const state = {
       ...createTestState(),
@@ -6293,6 +6386,7 @@ describe("ServeServices", () => {
         number: "42",
         base: undefined,
         cwd: "/repo",
+        postCreate: "skip",
       },
     ]);
     deepStrictEqual(codex.startThread.mock.calls[0], [

--- a/packages/server/src/services.ts
+++ b/packages/server/src/services.ts
@@ -26,7 +26,9 @@ import {
   listGitHubCheckoutTargets,
   removeWorktree,
   runCreateWorktree,
+  runPostCreateWorktree,
   WorktreeAlreadyExistsError,
+  type WorktreePostCreateTask,
 } from "@phantompane/core";
 import {
   CodexBridge,
@@ -310,6 +312,11 @@ export class ServeServices {
   private readonly activeTurnChatIds = new Set<string>();
   private readonly archiveOperationChatIds = new Set<string>();
   private readonly activeWorktreeOperationLocks = new Map<string, number>();
+  private readonly waitableWorktreeOperationLocks = new Map<string, number>();
+  private readonly worktreeOperationWaiters = new Map<
+    string,
+    Set<() => void>
+  >();
   private readonly reportedAgentErrors = new WeakSet<object>();
 
   constructor(options: ServeServicesOptions = {}) {
@@ -953,16 +960,19 @@ export class ServeServices {
         number: String(input.githubTargetNumber),
         base: input.base,
         cwd: project.rootPath,
+        postCreate: "skip",
       });
       if (!result.ok) {
         throw result.error;
       }
       try {
-        return await this.createExistingWorktreeChat(projectId, project, {
+        const chat = await this.createExistingWorktreeChat(projectId, project, {
           serviceTier: input.serviceTier,
           worktreeName: result.value.worktree,
           worktreePath: result.value.path,
         });
+        this.scheduleDeferredPostCreate(chat, result.value.postCreate);
+        return chat;
       } catch (error) {
         if (!result.value.alreadyExists) {
           try {
@@ -1010,6 +1020,7 @@ export class ServeServices {
       gitRoot: project.rootPath,
       name: inferredName,
       base: input.base,
+      postCreate: "skip",
     });
     if (
       !createResult.ok &&
@@ -1020,6 +1031,7 @@ export class ServeServices {
       createResult = await runCreateWorktree({
         gitRoot: project.rootPath,
         base: input.base,
+        postCreate: "skip",
       });
     }
 
@@ -1074,7 +1086,44 @@ export class ServeServices {
     }));
 
     this.eventHub.emit("chat.created", chat, { chatId: chat.id });
+    this.scheduleDeferredPostCreate(chat, createResult.value.postCreate);
     return chat;
+  }
+
+  private scheduleDeferredPostCreate(
+    chat: ChatRecord,
+    postCreate: WorktreePostCreateTask | undefined,
+  ): void {
+    if (!postCreate) {
+      return;
+    }
+
+    const release = this.acquireWorktreeOperationLock(chat.worktreePath, {
+      waitForMessages: true,
+    });
+    const timer = setTimeout(() => {
+      void this.runDeferredPostCreate(chat, postCreate, release);
+    }, 0);
+    timer.unref?.();
+  }
+
+  private async runDeferredPostCreate(
+    chat: ChatRecord,
+    postCreate: WorktreePostCreateTask,
+    release: () => void,
+  ): Promise<void> {
+    try {
+      const result = await runPostCreateWorktree(postCreate);
+      if (!result.ok) {
+        throw result.error;
+      }
+    } catch (error) {
+      await this.addAgentErrorMessage(chat.id, error);
+      this.emitAgentError(chat.id, error);
+    } finally {
+      release();
+      await this.drainQueuedMessagesAndReport(chat.id);
+    }
   }
 
   private async inferWorktreeName(
@@ -1347,8 +1396,13 @@ export class ServeServices {
     input: SendMessageInput,
   ): Promise<ChatRecord> {
     await this.resetStaleTransientChatState();
-    const state = await this.store.load();
-    const chat = this.requireChat(state, chatId);
+    let state = await this.store.load();
+    let chat = this.requireChat(state, chatId);
+    if (this.isWaitableWorktreeOperationActive(chat.worktreePath)) {
+      await this.waitForWorktreeOperation(chat.worktreePath);
+      state = await this.store.load();
+      chat = this.requireChat(state, chatId);
+    }
     const isDrainingQueuedMessage =
       this.drainingQueuedMessageChatIds.has(chatId);
     if (
@@ -2511,10 +2565,18 @@ export class ServeServices {
     }
   }
 
-  private acquireWorktreeOperationLock(worktreePath: string): () => void {
+  private acquireWorktreeOperationLock(
+    worktreePath: string,
+    options: { waitForMessages?: boolean } = {},
+  ): () => void {
     const activeCount =
       this.activeWorktreeOperationLocks.get(worktreePath) ?? 0;
     this.activeWorktreeOperationLocks.set(worktreePath, activeCount + 1);
+    if (options.waitForMessages) {
+      const waitableCount =
+        this.waitableWorktreeOperationLocks.get(worktreePath) ?? 0;
+      this.waitableWorktreeOperationLocks.set(worktreePath, waitableCount + 1);
+    }
     let released = false;
     return () => {
       if (released) {
@@ -2528,11 +2590,52 @@ export class ServeServices {
       } else {
         this.activeWorktreeOperationLocks.delete(worktreePath);
       }
+      if (options.waitForMessages) {
+        const nextWaitableCount =
+          (this.waitableWorktreeOperationLocks.get(worktreePath) ?? 1) - 1;
+        if (nextWaitableCount > 0) {
+          this.waitableWorktreeOperationLocks.set(
+            worktreePath,
+            nextWaitableCount,
+          );
+        } else {
+          this.waitableWorktreeOperationLocks.delete(worktreePath);
+          this.resolveWorktreeOperationWaiters(worktreePath);
+        }
+      }
     };
+  }
+
+  private resolveWorktreeOperationWaiters(worktreePath: string): void {
+    const waiters = this.worktreeOperationWaiters.get(worktreePath);
+    if (!waiters) {
+      return;
+    }
+
+    this.worktreeOperationWaiters.delete(worktreePath);
+    for (const resolveWaiter of waiters) {
+      resolveWaiter();
+    }
+  }
+
+  private async waitForWorktreeOperation(worktreePath: string): Promise<void> {
+    while (this.isWaitableWorktreeOperationActive(worktreePath)) {
+      await new Promise<void>((resolveWaiter) => {
+        const waiters =
+          this.worktreeOperationWaiters.get(worktreePath) ??
+          new Set<() => void>();
+        waiters.add(resolveWaiter);
+        this.worktreeOperationWaiters.set(worktreePath, waiters);
+      });
+    }
   }
 
   private isWorktreeOperationActive(worktreePath: string): boolean {
     return (this.activeWorktreeOperationLocks.get(worktreePath) ?? 0) > 0;
+  }
+
+  private isWaitableWorktreeOperationActive(worktreePath: string): boolean {
+    return (this.waitableWorktreeOperationLocks.get(worktreePath) ?? 0) > 0;
   }
 
   private assertNoBlockingWorktreeChat(

--- a/packages/server/src/services.ts
+++ b/packages/server/src/services.ts
@@ -22,13 +22,13 @@ import {
   deleteBranch,
   deleteWorktree as deleteWorktreeCore,
   githubCheckout,
-  listWorktrees,
+  hasPostCreateWorktreeCommands,
   listGitHubCheckoutTargets,
+  listWorktrees,
   removeWorktree,
   runCreateWorktree,
   runPostCreateWorktree,
   WorktreeAlreadyExistsError,
-  type WorktreePostCreateTask,
 } from "@phantompane/core";
 import {
   CodexBridge,
@@ -960,7 +960,6 @@ export class ServeServices {
         number: String(input.githubTargetNumber),
         base: input.base,
         cwd: project.rootPath,
-        postCreate: "skip",
       });
       if (!result.ok) {
         throw result.error;
@@ -971,7 +970,13 @@ export class ServeServices {
           worktreeName: result.value.worktree,
           worktreePath: result.value.path,
         });
-        this.scheduleDeferredPostCreate(chat, result.value.postCreate);
+        if (!result.value.alreadyExists) {
+          await this.scheduleDeferredPostCreate(
+            chat,
+            project.rootPath,
+            result.value.worktree,
+          );
+        }
         return chat;
       } catch (error) {
         if (!result.value.alreadyExists) {
@@ -1020,7 +1025,6 @@ export class ServeServices {
       gitRoot: project.rootPath,
       name: inferredName,
       base: input.base,
-      postCreate: "skip",
     });
     if (
       !createResult.ok &&
@@ -1031,7 +1035,6 @@ export class ServeServices {
       createResult = await runCreateWorktree({
         gitRoot: project.rootPath,
         base: input.base,
-        postCreate: "skip",
       });
     }
 
@@ -1086,15 +1089,26 @@ export class ServeServices {
     }));
 
     this.eventHub.emit("chat.created", chat, { chatId: chat.id });
-    this.scheduleDeferredPostCreate(chat, createResult.value.postCreate);
+    await this.scheduleDeferredPostCreate(
+      chat,
+      project.rootPath,
+      createResult.value.name,
+    );
     return chat;
   }
 
-  private scheduleDeferredPostCreate(
+  private async scheduleDeferredPostCreate(
     chat: ChatRecord,
-    postCreate: WorktreePostCreateTask | undefined,
-  ): void {
-    if (!postCreate) {
+    gitRoot: string,
+    worktreeName: string,
+  ): Promise<void> {
+    const hasCommands = await hasPostCreateWorktreeCommands({ gitRoot });
+    if (!hasCommands.ok) {
+      await this.addAgentErrorMessage(chat.id, hasCommands.error);
+      this.emitAgentError(chat.id, hasCommands.error);
+      return;
+    }
+    if (!hasCommands.value) {
       return;
     }
 
@@ -1102,18 +1116,22 @@ export class ServeServices {
       waitForMessages: true,
     });
     const timer = setTimeout(() => {
-      void this.runDeferredPostCreate(chat, postCreate, release);
+      void this.runDeferredPostCreate(chat, gitRoot, worktreeName, release);
     }, 0);
     timer.unref?.();
   }
 
   private async runDeferredPostCreate(
     chat: ChatRecord,
-    postCreate: WorktreePostCreateTask,
+    gitRoot: string,
+    worktreeName: string,
     release: () => void,
   ): Promise<void> {
     try {
-      const result = await runPostCreateWorktree(postCreate);
+      const result = await runPostCreateWorktree({
+        gitRoot,
+        worktreeName,
+      });
       if (!result.ok) {
         throw result.error;
       }


### PR DESCRIPTION
## Summary

- Split postCreate execution out of worktree create/checkout APIs so create only creates the worktree and copies configured files.
- Move CLI create action orchestration into the handler so postCreate starts after the requested worktree action opens.
- Run CLI GitHub checkout postCreate explicitly from the handler after checkout output/navigation.
- Let Serve create and select the chat/worktree before scheduling postCreate, while delaying first messages until deferred setup completes.

## Testing

- `pnpm --filter @phantompane/process test`
- `pnpm --filter @phantompane/core test`
- `pnpm --filter @phantompane/cli-private test`
- `pnpm --filter @phantompane/process typecheck`
- `pnpm --filter @phantompane/core typecheck`
- `pnpm --filter @phantompane/cli-private typecheck`
- `pnpm --filter @phantompane/server test`
- `pnpm --filter @phantompane/mcp test`
- `TURBO_CACHE_DIR=/tmp/phantom-turbo-cache pnpm ready`