### PR TITLE
fix: prune accumulated chat history

### DIFF
--- a/packages/server/src/services.test.ts
+++ b/packages/server/src/services.test.ts
@@ -2200,14 +2200,10 @@ describe("ServeServices", () => {
         message.eventType,
       ]),
       [
-        ["msg_user_1", "user", "initial request", undefined],
-        ["msg_event", "event", "item/started: agentMessage", "item/started"],
-        [
-          "msg_assistant_1",
-          "assistant",
-          "first update",
-          "item/agentMessage/delta",
-        ],
+        ["chat_1_codex_turn_1_0", "user", "initial request", undefined],
+        ["chat_1_codex_turn_1_1", "assistant", "first update", undefined],
+        ["chat_1_codex_turn_1_2", "user", "follow up", undefined],
+        ["chat_1_codex_turn_1_3", "assistant", "second update", undefined],
         ["msg_user_2", "user", "follow up", undefined],
         [
           "msg_assistant_2",
@@ -2296,10 +2292,12 @@ describe("ServeServices", () => {
       ]),
       [
         ["user", "initial request", undefined],
-        ["assistant", "first update", "item/agentMessage/delta"],
+        ["assistant", "first update", undefined],
+        ["user", "follow up", undefined],
+        ["assistant", "second update", undefined],
+        ["assistant", "newer update", undefined],
         ["user", "follow up", undefined],
         ["assistant", "second update", "item/agentMessage/delta"],
-        ["assistant", "newer update", undefined],
         ["user", "queued next", "chat.message.queued"],
       ],
     );
@@ -2501,15 +2499,11 @@ describe("ServeServices", () => {
         message.eventType,
       ]),
       [
-        ["msg_user_1", "user", "initial request", undefined],
-        [
-          "msg_assistant_1",
-          "assistant",
-          "first update",
-          "item/agentMessage/delta",
-        ],
-        ["msg_user_2", "user", "follow up", undefined],
+        ["chat_1_codex_turn_1_0", "user", "initial request", undefined],
+        ["chat_1_codex_turn_1_1", "assistant", "first update", undefined],
+        ["chat_1_codex_turn_2_0", "user", "follow up", undefined],
         ["chat_1_codex_turn_2_1", "assistant", "newer update", undefined],
+        ["msg_user_2", "user", "follow up", undefined],
         ["msg_queued", "user", "queued next", "chat.message.queued"],
       ],
     );
@@ -2585,13 +2579,11 @@ describe("ServeServices", () => {
         message.eventType,
       ]),
       [
-        ["msg_user_1", "user", "initial request", undefined],
-        [
-          "msg_assistant_1",
-          "assistant",
-          "first update",
-          "item/agentMessage/delta",
-        ],
+        ["chat_1_codex_turn_1_0", "user", "initial request", undefined],
+        ["chat_1_codex_turn_1_1", "assistant", "first update", undefined],
+        ["chat_1_codex_turn_1_2", "user", "adjust course", undefined],
+        ["chat_1_codex_turn_1_3", "assistant", "adjusted update", undefined],
+        ["chat_1_codex_turn_1_4", "assistant", "newer update", undefined],
         ["msg_steered", "user", "adjust course", undefined],
         [
           "msg_assistant_2",
@@ -2599,7 +2591,6 @@ describe("ServeServices", () => {
           "adjusted update",
           "item/agentMessage/delta",
         ],
-        ["chat_1_codex_turn_1_4", "assistant", "newer update", undefined],
       ],
     );
   });
@@ -2668,11 +2659,13 @@ describe("ServeServices", () => {
     deepStrictEqual(
       messages.map((message) => [message.id, message.role, message.text]),
       [
-        ["msg_user_1", "user", "initial request"],
-        ["msg_assistant_1", "assistant", "repeated update"],
+        ["chat_1_codex_turn_1_0", "user", "initial request"],
+        ["chat_1_codex_turn_1_1", "assistant", "repeated update"],
+        ["chat_1_codex_turn_1_2", "user", "follow up"],
+        ["chat_1_codex_turn_1_3", "assistant", "second update"],
+        ["chat_1_codex_turn_1_4", "assistant", "repeated update"],
         ["msg_user_2", "user", "follow up"],
         ["msg_assistant_2", "assistant", "second update"],
-        ["chat_1_codex_turn_1_4", "assistant", "repeated update"],
       ],
     );
   });
@@ -2784,7 +2777,7 @@ describe("ServeServices", () => {
     );
   });
 
-  it("keeps repeated active local turns separate from older Codex history", async () => {
+  it("keeps only the latest active local turn overlay with older Codex history", async () => {
     const state = {
       ...createTestState(),
       projects: [createProject()],
@@ -2825,7 +2818,6 @@ describe("ServeServices", () => {
       ],
     };
     const { codex, services } = await createHarness(state);
-    markChatActiveInCurrentProcess(services, "chat_1");
     codex.readThread.mockResolvedValueOnce({
       thread: {
         turns: [
@@ -2866,13 +2858,6 @@ describe("ServeServices", () => {
           "second repeat response",
           undefined,
         ],
-        ["msg_current_user_1", "user", "repeat request", undefined],
-        [
-          "msg_current_assistant_1",
-          "assistant",
-          "first repeat response",
-          "item/agentMessage/delta",
-        ],
         ["msg_current_user_2", "user", "repeat follow up", undefined],
         [
           "msg_current_assistant_2",
@@ -2882,6 +2867,447 @@ describe("ServeServices", () => {
         ],
       ],
     );
+  });
+
+  it("drops stale local Codex events before the latest active user message", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "running", activeTurnId: "turn_current" })],
+      messages: [
+        {
+          id: "msg_old_user",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "old request",
+          createdAt: "2026-05-08T00:45:00.000Z",
+        },
+        {
+          id: "msg_old_command",
+          chatId: "chat_1",
+          role: "event" as const,
+          text: "",
+          eventType: "item/commandExecution/outputDelta",
+          itemId: "cmd_old",
+          createdAt: "2026-05-08T00:45:01.000Z",
+        },
+        {
+          id: "msg_old_assistant",
+          chatId: "chat_1",
+          role: "assistant" as const,
+          text: "old local delta",
+          eventType: "item/agentMessage/delta",
+          itemId: "assistant_old",
+          createdAt: "2026-05-08T00:45:02.000Z",
+        },
+        {
+          id: "msg_latest_user",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "latest request",
+          createdAt: "2026-05-08T00:46:00.000Z",
+        },
+        {
+          id: "msg_latest_command",
+          chatId: "chat_1",
+          role: "event" as const,
+          text: "",
+          eventType: "item/commandExecution/outputDelta",
+          itemId: "cmd_latest",
+          createdAt: "2026-05-08T00:46:01.000Z",
+        },
+      ],
+    };
+    const { codex, services, store } = await createHarness(state);
+    codex.readThread.mockResolvedValueOnce({
+      thread: {
+        turns: [
+          {
+            id: "turn_old",
+            items: [
+              { type: "userMessage", text: "old request" },
+              { type: "agentMessage", text: "old local delta" },
+            ],
+          },
+        ],
+      },
+    });
+
+    const messages = await services.getMessages("chat_1");
+    const savedState = await store.load();
+
+    deepStrictEqual(
+      messages.map((message) => [
+        message.id,
+        message.role,
+        message.text,
+        message.eventType,
+      ]),
+      [
+        ["chat_1_codex_turn_old_0", "user", "old request", undefined],
+        ["chat_1_codex_turn_old_1", "assistant", "old local delta", undefined],
+        ["msg_latest_user", "user", "latest request", undefined],
+        [
+          "msg_latest_command",
+          "event",
+          "",
+          "item/commandExecution/outputDelta",
+        ],
+      ],
+    );
+    deepStrictEqual(
+      savedState.messages.map((message) => message.id),
+      ["msg_latest_user", "msg_latest_command"],
+    );
+  });
+
+  it("prunes accumulated idle local timeline after two repeated submitted user messages", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "idle", activeTurnId: null })],
+      messages: [
+        {
+          id: "msg_old_user",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "retry",
+          createdAt: "2026-05-08T00:45:00.000Z",
+        },
+        {
+          id: "msg_old_assistant",
+          chatId: "chat_1",
+          role: "assistant" as const,
+          text: "old local delta",
+          eventType: "item/agentMessage/delta",
+          itemId: "assistant_old",
+          createdAt: "2026-05-08T00:45:02.000Z",
+        },
+        {
+          id: "msg_latest_user",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "retry",
+          createdAt: "2026-05-08T00:46:00.000Z",
+        },
+        {
+          id: "msg_latest_assistant",
+          chatId: "chat_1",
+          role: "assistant" as const,
+          text: "latest local delta",
+          eventType: "item/agentMessage/delta",
+          itemId: "assistant_latest",
+          createdAt: "2026-05-08T00:46:01.000Z",
+        },
+      ],
+    };
+    const { codex, services, store } = await createHarness(state);
+    codex.readThread.mockResolvedValueOnce({
+      thread: {
+        turns: [
+          {
+            id: "turn_old",
+            items: [
+              {
+                type: "userMessage",
+                text: "retry",
+                createdAt: "2026-05-08T00:45:00.000Z",
+              },
+              {
+                type: "agentMessage",
+                text: "old local delta",
+                createdAt: "2026-05-08T00:45:02.000Z",
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const messages = await services.getMessages("chat_1");
+    const savedState = await store.load();
+
+    deepStrictEqual(
+      messages.map((message) => [
+        message.id,
+        message.role,
+        message.text,
+        message.eventType,
+      ]),
+      [
+        ["chat_1_codex_turn_old_0", "user", "retry", undefined],
+        ["chat_1_codex_turn_old_1", "assistant", "old local delta", undefined],
+        ["msg_latest_user", "user", "retry", undefined],
+        [
+          "msg_latest_assistant",
+          "assistant",
+          "latest local delta",
+          "item/agentMessage/delta",
+        ],
+      ],
+    );
+    deepStrictEqual(
+      savedState.messages.map((message) => [
+        message.id,
+        message.role,
+        message.text,
+        message.eventType,
+      ]),
+      [
+        ["msg_latest_user", "user", "retry", undefined],
+        [
+          "msg_latest_assistant",
+          "assistant",
+          "latest local delta",
+          "item/agentMessage/delta",
+        ],
+      ],
+    );
+  });
+
+  it("clears retained steered state while pruning accumulated idle local timeline", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "idle", activeTurnId: null })],
+      messages: [
+        {
+          id: "msg_old_user",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "old request",
+          createdAt: "2026-05-08T00:45:00.000Z",
+        },
+        {
+          id: "msg_old_assistant",
+          chatId: "chat_1",
+          role: "assistant" as const,
+          text: "old local delta",
+          eventType: "item/agentMessage/delta",
+          itemId: "assistant_old",
+          createdAt: "2026-05-08T00:45:02.000Z",
+        },
+        {
+          id: "msg_latest_steered",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "adjust course",
+          eventType: "chat.message.steered",
+          itemId: "turn_old",
+          createdAt: "2026-05-08T00:46:00.000Z",
+        },
+      ],
+    };
+    const { codex, services, store } = await createHarness(state);
+    codex.readThread.mockResolvedValueOnce({
+      thread: {
+        turns: [
+          {
+            id: "turn_old",
+            items: [
+              { type: "userMessage", text: "old request" },
+              { type: "agentMessage", text: "old local delta" },
+            ],
+          },
+        ],
+      },
+    });
+
+    const messages = await services.getMessages("chat_1");
+    const savedState = await store.load();
+
+    deepStrictEqual(
+      messages.map((message) => [
+        message.id,
+        message.role,
+        message.text,
+        message.eventType,
+      ]),
+      [
+        ["chat_1_codex_turn_old_0", "user", "old request", undefined],
+        ["chat_1_codex_turn_old_1", "assistant", "old local delta", undefined],
+        ["msg_latest_steered", "user", "adjust course", undefined],
+      ],
+    );
+    deepStrictEqual(
+      savedState.messages.map((message) => [
+        message.id,
+        message.role,
+        message.text,
+        message.eventType,
+      ]),
+      [["msg_latest_steered", "user", "adjust course", undefined]],
+    );
+  });
+
+  it("rechecks accumulated idle local timeline after an earlier no-op cleanup pass", async () => {
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "idle", activeTurnId: null })],
+    };
+    const { codex, services, store } = await createHarness(state);
+
+    await services.listProjects();
+    await store.update((nextState) => ({
+      ...nextState,
+      messages: [
+        {
+          id: "msg_old_user",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "retry",
+          createdAt: "2026-05-08T00:45:00.000Z",
+        },
+        {
+          id: "msg_old_assistant",
+          chatId: "chat_1",
+          role: "assistant" as const,
+          text: "old local delta",
+          eventType: "item/agentMessage/delta",
+          itemId: "assistant_old",
+          createdAt: "2026-05-08T00:45:02.000Z",
+        },
+        {
+          id: "msg_latest_user",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "retry",
+          createdAt: "2026-05-08T00:46:00.000Z",
+        },
+      ],
+    }));
+    codex.readThread.mockResolvedValueOnce({
+      thread: {
+        turns: [
+          {
+            id: "turn_old",
+            items: [
+              { type: "userMessage", text: "retry" },
+              { type: "agentMessage", text: "old local delta" },
+            ],
+          },
+        ],
+      },
+    });
+
+    const messages = await services.getMessages("chat_1");
+    const savedState = await store.load();
+
+    deepStrictEqual(
+      messages.map((message) => [
+        message.id,
+        message.role,
+        message.text,
+        message.eventType,
+      ]),
+      [
+        ["chat_1_codex_turn_old_0", "user", "retry", undefined],
+        ["chat_1_codex_turn_old_1", "assistant", "old local delta", undefined],
+        ["msg_latest_user", "user", "retry", undefined],
+      ],
+    );
+    deepStrictEqual(
+      savedState.messages.map((message) => message.id),
+      ["msg_latest_user"],
+    );
+  });
+
+  it("preserves queued messages while pruning accumulated idle local timeline", async () => {
+    const queuedMessage = {
+      id: "queue_1",
+      chatId: "chat_1",
+      messageId: "msg_queued",
+      text: "queued request",
+      createdAt: "2026-05-08T00:47:00.000Z",
+    };
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "idle", activeTurnId: null })],
+      messages: [
+        {
+          id: "msg_old_user",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "old request",
+          createdAt: "2026-05-08T00:45:00.000Z",
+        },
+        {
+          id: "msg_old_command",
+          chatId: "chat_1",
+          role: "event" as const,
+          text: "",
+          eventType: "item/commandExecution/outputDelta",
+          itemId: "cmd_old",
+          createdAt: "2026-05-08T00:45:01.000Z",
+        },
+        {
+          id: "msg_latest_user",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "latest request",
+          createdAt: "2026-05-08T00:46:00.000Z",
+        },
+        {
+          id: "msg_latest_command",
+          chatId: "chat_1",
+          role: "event" as const,
+          text: "",
+          eventType: "item/commandExecution/outputDelta",
+          itemId: "cmd_latest",
+          createdAt: "2026-05-08T00:46:01.000Z",
+        },
+        {
+          id: "msg_queued",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "queued request",
+          eventType: "chat.message.queued",
+          createdAt: "2026-05-08T00:47:00.000Z",
+        },
+      ],
+      queuedMessages: [queuedMessage],
+    };
+    const { codex, services, store } = await createHarness(state);
+    codex.readThread.mockResolvedValueOnce({
+      thread: {
+        turns: [
+          {
+            id: "turn_old",
+            items: [{ type: "userMessage", text: "old request" }],
+          },
+        ],
+      },
+    });
+
+    const messages = await services.getMessages("chat_1");
+    const savedState = await store.load();
+
+    deepStrictEqual(
+      messages.map((message) => [
+        message.id,
+        message.role,
+        message.text,
+        message.eventType,
+      ]),
+      [
+        ["chat_1_codex_turn_old_0", "user", "old request", undefined],
+        ["msg_latest_user", "user", "latest request", undefined],
+        [
+          "msg_latest_command",
+          "event",
+          "",
+          "item/commandExecution/outputDelta",
+        ],
+        ["msg_queued", "user", "queued request", "chat.message.queued"],
+      ],
+    );
+    deepStrictEqual(
+      savedState.messages.map((message) => message.id),
+      ["msg_latest_user", "msg_latest_command", "msg_queued"],
+    );
+    deepStrictEqual(savedState.queuedMessages, [queuedMessage]);
   });
 
   it("preserves local attachment metadata when Codex thread history matches a sent user message", async () => {
@@ -3181,7 +3607,6 @@ describe("ServeServices", () => {
       [
         ["chat_1_codex_turn_1_0", "user", "install skills", undefined],
         ["chat_1_codex_turn_1_1", "assistant", "already installed", undefined],
-        ["msg_interrupted", "user", "use npx", undefined],
         [
           "chat_1_codex_turn_2_0",
           "user",
@@ -3923,7 +4348,7 @@ describe("ServeServices", () => {
     );
   });
 
-  it("keeps local Codex events before later live assistant deltas", async () => {
+  it("drops stale local Codex events before a later active user message", async () => {
     const state = {
       ...createTestState(),
       projects: [createProject()],
@@ -3984,8 +4409,6 @@ describe("ServeServices", () => {
       [
         ["user", "fix the UI", undefined],
         ["assistant", "done", undefined],
-        ["event", "", "item/commandExecution/outputDelta"],
-        ["assistant", "still working", "item/agentMessage/delta"],
         ["user", "next request", undefined],
       ],
     );
@@ -4130,7 +4553,7 @@ describe("ServeServices", () => {
     );
   });
 
-  it("keeps local Codex events between live assistant deltas and later user messages", async () => {
+  it("drops stale local Codex events between live assistant deltas and later user messages", async () => {
     const state = {
       ...createTestState(),
       projects: [createProject()],
@@ -4191,8 +4614,6 @@ describe("ServeServices", () => {
       [
         ["user", "fix the UI", undefined],
         ["assistant", "done", undefined],
-        ["assistant", "still working", "item/agentMessage/delta"],
-        ["event", "", "item/commandExecution/outputDelta"],
         ["user", "next request", undefined],
       ],
     );
@@ -4451,7 +4872,7 @@ describe("ServeServices", () => {
     );
   });
 
-  it("keeps local Codex events between a deduplicated and retained repeated user message", async () => {
+  it("drops stale local Codex events between a deduplicated and retained repeated user message", async () => {
     const state = {
       ...createTestState(),
       projects: [createProject()],
@@ -4519,8 +4940,6 @@ describe("ServeServices", () => {
       ]),
       [
         ["user", "repeat", undefined],
-        ["event", "", "item/commandExecution/outputDelta"],
-        ["assistant", "still working", "item/agentMessage/delta"],
         ["user", "repeat", undefined],
       ],
     );
@@ -4587,16 +5006,11 @@ describe("ServeServices", () => {
         message.text,
         message.eventType,
       ]),
-      [
-        ["user", "retry", undefined],
-        ["assistant", "still working", "item/agentMessage/delta"],
-        ["event", "", "item/commandExecution/outputDelta"],
-        ["user", "retry", undefined],
-      ],
+      [["user", "retry", undefined]],
     );
   });
 
-  it("keeps local Codex events before a later repeated user boundary", async () => {
+  it("drops stale local Codex events before a later repeated user boundary", async () => {
     const state = {
       ...createTestState(),
       projects: [createProject()],
@@ -4669,8 +5083,6 @@ describe("ServeServices", () => {
       ]),
       [
         ["user", "repeat", undefined],
-        ["assistant", "still working", "item/agentMessage/delta"],
-        ["event", "", "item/commandExecution/outputDelta"],
         ["user", "repeat", undefined],
       ],
     );
@@ -5086,8 +5498,7 @@ describe("ServeServices", () => {
       ]),
       [
         ["chat_1_codex_turn_1_0", "user", "start", undefined],
-        ["msg_live_delta", "assistant", "working", "item/agentMessage/delta"],
-        ["msg_steered", "user", "adjust now", "chat.message.steered"],
+        ["msg_steered", "user", "adjust now", undefined],
         ["msg_queued", "user", "next queued", "chat.message.queued"],
       ],
     );
@@ -5222,8 +5633,8 @@ describe("ServeServices", () => {
         ["chat_1_codex_turn_1_0", "user", "repeat", undefined],
         ["chat_1_codex_turn_1_1", "user", "repeat", undefined],
         ["chat_1_codex_turn_1_2", "assistant", "between repeats", undefined],
-        ["msg_live_delta", "assistant", "streaming", "item/agentMessage/delta"],
         ["chat_1_codex_turn_1_3", "user", "repeat", undefined],
+        ["msg_steered_2", "user", "repeat", undefined],
       ],
     );
   });
@@ -5304,8 +5715,7 @@ describe("ServeServices", () => {
         ["chat_1_codex_turn_1_1", "user", "repeat", undefined],
         ["chat_1_codex_turn_1_2", "assistant", "between repeats", undefined],
         ["chat_1_codex_turn_1_3", "user", "repeat", undefined],
-        ["msg_live_delta", "assistant", "streaming", "item/agentMessage/delta"],
-        ["msg_steered_3", "user", "repeat", "chat.message.steered"],
+        ["msg_steered_3", "user", "repeat", undefined],
       ],
     );
   });
@@ -5678,10 +6088,17 @@ describe("ServeServices", () => {
           "user",
           "repeat",
           undefined,
-          "2026-04-25T00:01:00.000Z",
+          "2026-04-25T00:00:00.000Z",
         ],
         [
           "chat_1_codex_turn_1_2",
+          "user",
+          "repeat",
+          undefined,
+          "2026-04-25T00:00:00.000Z",
+        ],
+        [
+          "msg_steered_repeat_2",
           "user",
           "repeat",
           undefined,
@@ -5958,10 +6375,17 @@ describe("ServeServices", () => {
           "user",
           "repeat",
           undefined,
-          "2026-04-25T00:01:00.000Z",
+          "2026-04-25T00:00:00.000Z",
         ],
         [
           "chat_1_codex_turn_1_1",
+          "user",
+          "repeat",
+          undefined,
+          "2026-04-25T00:00:00.000Z",
+        ],
+        [
+          "msg_steered_without_input_2",
           "user",
           "repeat",
           undefined,

--- a/packages/server/src/services.test.ts
+++ b/packages/server/src/services.test.ts
@@ -3310,6 +3310,123 @@ describe("ServeServices", () => {
     deepStrictEqual(savedState.queuedMessages, [queuedMessage]);
   });
 
+  it("preserves historical attachment metadata while pruning accumulated idle local timeline", async () => {
+    const attachment = {
+      name: "screenshot.png",
+      path: "/tmp/phantom-attachments/chat_1/screenshot.png",
+      mimeType: "image/png",
+      size: 68,
+    };
+    const state = {
+      ...createTestState(),
+      projects: [createProject()],
+      chats: [createChat({ status: "idle", activeTurnId: null })],
+      messages: [
+        {
+          id: "msg_old_user",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "old request",
+          attachments: [attachment],
+          createdAt: "2026-05-08T00:45:00.000Z",
+        },
+        {
+          id: "msg_old_assistant",
+          chatId: "chat_1",
+          role: "assistant" as const,
+          text: "old local delta",
+          eventType: "item/agentMessage/delta",
+          itemId: "assistant_old",
+          createdAt: "2026-05-08T00:45:02.000Z",
+        },
+        {
+          id: "msg_latest_user",
+          chatId: "chat_1",
+          role: "user" as const,
+          text: "latest request",
+          createdAt: "2026-05-08T00:46:00.000Z",
+        },
+        {
+          id: "msg_latest_assistant",
+          chatId: "chat_1",
+          role: "assistant" as const,
+          text: "latest local delta",
+          eventType: "item/agentMessage/delta",
+          itemId: "assistant_latest",
+          createdAt: "2026-05-08T00:46:01.000Z",
+        },
+      ],
+    };
+    const { codex, services, store } = await createHarness(state);
+    codex.readThread.mockResolvedValueOnce({
+      thread: {
+        turns: [
+          {
+            id: "turn_old",
+            items: [
+              { type: "userMessage", text: "old request" },
+              { type: "agentMessage", text: "old local delta" },
+            ],
+          },
+        ],
+      },
+    });
+
+    const messages = await services.getMessages("chat_1");
+    const savedState = await store.load();
+
+    deepStrictEqual(
+      messages.map((message) => ({
+        attachments: message.attachments,
+        eventType: message.eventType,
+        id: message.id,
+        role: message.role,
+        text: message.text,
+      })),
+      [
+        {
+          attachments: [attachment],
+          eventType: undefined,
+          id: "chat_1_codex_turn_old_0",
+          role: "user",
+          text: "old request",
+        },
+        {
+          attachments: undefined,
+          eventType: undefined,
+          id: "chat_1_codex_turn_old_1",
+          role: "assistant",
+          text: "old local delta",
+        },
+        {
+          attachments: undefined,
+          eventType: undefined,
+          id: "msg_latest_user",
+          role: "user",
+          text: "latest request",
+        },
+        {
+          attachments: undefined,
+          eventType: "item/agentMessage/delta",
+          id: "msg_latest_assistant",
+          role: "assistant",
+          text: "latest local delta",
+        },
+      ],
+    );
+    deepStrictEqual(
+      savedState.messages.map((message) => ({
+        attachments: message.attachments,
+        id: message.id,
+      })),
+      [
+        { attachments: [attachment], id: "msg_old_user" },
+        { attachments: undefined, id: "msg_latest_user" },
+        { attachments: undefined, id: "msg_latest_assistant" },
+      ],
+    );
+  });
+
   it("preserves local attachment metadata when Codex thread history matches a sent user message", async () => {
     const attachment = {
       name: "screenshot.png",

--- a/packages/server/src/services.ts
+++ b/packages/server/src/services.ts
@@ -311,6 +311,7 @@ export class ServeServices {
   private readonly archiveOperationChatIds = new Set<string>();
   private readonly activeWorktreeOperationLocks = new Map<string, number>();
   private readonly reportedAgentErrors = new WeakSet<object>();
+  private accumulatedLocalTimelineStateCheckKey: string | null = null;
 
   constructor(options: ServeServicesOptions = {}) {
     this.eventHub = options.eventHub ?? new EventHub();
@@ -2847,22 +2848,55 @@ export class ServeServices {
     const hasStaleTransientChat = state.chats.some((chat) =>
       this.isStaleTransientChat(chat),
     );
-    const hasStoredHiddenRichEventContent = state.messages.some(
+    const hasStoredHiddenRichEventContentSnapshot = state.messages.some(
       hasHiddenRichEventContent,
     );
-    if (!hasStaleTransientChat && !hasStoredHiddenRichEventContent) {
+    const accumulatedLocalTimelineStateCheckKey =
+      createAccumulatedLocalTimelineStateCheckKey(state);
+    const shouldCheckAccumulatedLocalTimeline =
+      this.accumulatedLocalTimelineStateCheckKey !==
+      accumulatedLocalTimelineStateCheckKey;
+    const hasAccumulatedLocalTimelineChatSnapshot =
+      shouldCheckAccumulatedLocalTimeline &&
+      findAccumulatedLocalTimelineChatIds(state).size > 0;
+    if (
+      !hasStaleTransientChat &&
+      !hasStoredHiddenRichEventContentSnapshot &&
+      !hasAccumulatedLocalTimelineChatSnapshot
+    ) {
+      if (shouldCheckAccumulatedLocalTimeline) {
+        this.accumulatedLocalTimelineStateCheckKey =
+          accumulatedLocalTimelineStateCheckKey;
+      }
       return new Set();
     }
 
     const resetChatIds = new Set<string>();
+    let didCheckAccumulatedLocalTimeline = false;
     const timestamp = createTimestamp();
-    await this.store.update((nextState) => {
+    const updatedState = await this.store.update((nextState) => {
       resetChatIds.clear();
+      const nextAccumulatedLocalTimelineStateCheckKey =
+        createAccumulatedLocalTimelineStateCheckKey(nextState);
+      const shouldCheckNextAccumulatedLocalTimeline =
+        this.accumulatedLocalTimelineStateCheckKey !==
+        nextAccumulatedLocalTimelineStateCheckKey;
+      didCheckAccumulatedLocalTimeline =
+        shouldCheckNextAccumulatedLocalTimeline;
+      const accumulatedLocalTimelineChatIds =
+        shouldCheckNextAccumulatedLocalTimeline
+          ? findAccumulatedLocalTimelineChatIds(nextState)
+          : new Set<string>();
+      const pruneMessageChatIds = new Set(accumulatedLocalTimelineChatIds);
+      const hasStoredHiddenRichEventContent = nextState.messages.some(
+        hasHiddenRichEventContent,
+      );
       const chats = nextState.chats.map((chat) => {
         if (!this.isStaleTransientChat(chat)) {
           return chat;
         }
         resetChatIds.add(chat.id);
+        pruneMessageChatIds.add(chat.id);
         return {
           ...chat,
           status: "idle" as const,
@@ -2870,22 +2904,40 @@ export class ServeServices {
           updatedAt: timestamp,
         };
       });
-      if (resetChatIds.size === 0 && !hasStoredHiddenRichEventContent) {
+      if (
+        resetChatIds.size === 0 &&
+        pruneMessageChatIds.size === 0 &&
+        !hasStoredHiddenRichEventContent
+      ) {
         return nextState;
       }
+      const retainedPrunedMessageIds = findRetainedPrunedMessageIds(
+        nextState.messages,
+        pruneMessageChatIds,
+      );
       return {
         ...nextState,
         chats,
-        messages: nextState.messages.map((message) => {
-          const nextMessage =
-            resetChatIds.has(message.chatId) &&
-            message.eventType === "chat.message.steered"
-              ? { ...message, eventType: undefined }
-              : message;
-          return stripHiddenRichEventContent(nextMessage);
-        }),
+        messages: nextState.messages
+          .filter(
+            (message) =>
+              !pruneMessageChatIds.has(message.chatId) ||
+              retainedPrunedMessageIds.has(message.id),
+          )
+          .map((message) => {
+            const nextMessage =
+              pruneMessageChatIds.has(message.chatId) &&
+              message.eventType === "chat.message.steered"
+                ? { ...message, eventType: undefined }
+                : message;
+            return stripHiddenRichEventContent(nextMessage);
+          }),
       };
     });
+    if (didCheckAccumulatedLocalTimeline) {
+      this.accumulatedLocalTimelineStateCheckKey =
+        createAccumulatedLocalTimelineStateCheckKey(updatedState);
+    }
     return resetChatIds;
   }
 
@@ -4063,6 +4115,161 @@ function resolveChatMessageTimeline({
     activeTurnId,
     chat.activeTurnId != null,
     canonicalLocalTranscriptMatch.localMessageCodexOrderMatches,
+  );
+}
+
+function localMessagesForCurrentActiveTurn(
+  localMessages: ChatMessageRecord[],
+): ChatMessageRecord[] {
+  const latestLocalUserCreatedAt = localMessages
+    .filter(isActiveTurnLocalUserBoundary)
+    .map((message) => message.createdAt)
+    .sort((left, right) => right.localeCompare(left))[0];
+  if (!latestLocalUserCreatedAt) {
+    return localMessages;
+  }
+  return localMessages.filter(
+    (message) =>
+      isQueuedMessage(message) || message.createdAt >= latestLocalUserCreatedAt,
+  );
+}
+
+function isActiveTurnLocalUserBoundary(message: ChatMessageRecord): boolean {
+  return message.role === "user" && !isQueuedMessage(message);
+}
+
+function createAccumulatedLocalTimelineStateCheckKey(
+  state: ServeState,
+): string {
+  return [
+    state.messages.length,
+    ...state.chats.map((chat) =>
+      [
+        chat.id,
+        chat.codexThreadId ?? "",
+        chat.status,
+        chat.activeTurnId ?? "",
+        chat.updatedAt,
+      ].join(":"),
+    ),
+  ].join("|");
+}
+
+function findAccumulatedLocalTimelineChatIds(
+  state: ServeState,
+): ReadonlySet<string> {
+  const eligibleChatIds = new Set<string>();
+  for (const chat of state.chats) {
+    if (canPruneAccumulatedLocalTimeline(chat)) {
+      eligibleChatIds.add(chat.id);
+    }
+  }
+  if (eligibleChatIds.size === 0) {
+    return new Set();
+  }
+
+  const statsByChatId = new Map<
+    string,
+    {
+      earliestTransientCreatedAt: string | null;
+      latestUserCreatedAt: string | null;
+      userBoundaryCount: number;
+    }
+  >();
+  for (const message of state.messages) {
+    if (!eligibleChatIds.has(message.chatId)) {
+      continue;
+    }
+    const stats = statsByChatId.get(message.chatId) ?? {
+      earliestTransientCreatedAt: null,
+      latestUserCreatedAt: null,
+      userBoundaryCount: 0,
+    };
+    if (isActiveTurnLocalUserBoundary(message)) {
+      stats.userBoundaryCount += 1;
+      if (
+        stats.latestUserCreatedAt === null ||
+        message.createdAt > stats.latestUserCreatedAt
+      ) {
+        stats.latestUserCreatedAt = message.createdAt;
+      }
+    }
+    if (
+      isTransientLocalCodexMessage(message) &&
+      (stats.earliestTransientCreatedAt === null ||
+        message.createdAt < stats.earliestTransientCreatedAt)
+    ) {
+      stats.earliestTransientCreatedAt = message.createdAt;
+    }
+    statsByChatId.set(message.chatId, stats);
+  }
+
+  return new Set(
+    Array.from(statsByChatId.entries())
+      .filter(([, stats]) =>
+        hasAccumulatedLocalTimelineStats(
+          stats.userBoundaryCount,
+          stats.latestUserCreatedAt,
+          stats.earliestTransientCreatedAt,
+        ),
+      )
+      .map(([chatId]) => chatId),
+  );
+}
+
+function canPruneAccumulatedLocalTimeline(chat: ChatRecord): boolean {
+  return Boolean(
+    chat.codexThreadId && chat.status === "idle" && !chat.activeTurnId,
+  );
+}
+
+function hasAccumulatedLocalTimelineStats(
+  userBoundaryCount: number,
+  latestUserCreatedAt: string | null,
+  earliestTransientCreatedAt: string | null,
+): boolean {
+  if (
+    userBoundaryCount < 2 ||
+    !latestUserCreatedAt ||
+    !earliestTransientCreatedAt ||
+    earliestTransientCreatedAt >= latestUserCreatedAt
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function findRetainedPrunedMessageIds(
+  messages: ChatMessageRecord[],
+  chatIds: ReadonlySet<string>,
+): ReadonlySet<string> {
+  if (chatIds.size === 0) {
+    return new Set();
+  }
+  const messagesByChatId = new Map<string, ChatMessageRecord[]>();
+  for (const message of messages) {
+    if (!chatIds.has(message.chatId)) {
+      continue;
+    }
+    const chatMessages = messagesByChatId.get(message.chatId) ?? [];
+    chatMessages.push(message);
+    messagesByChatId.set(message.chatId, chatMessages);
+  }
+
+  const retainedMessageIds = new Set<string>();
+  for (const chatMessages of messagesByChatId.values()) {
+    for (const message of localMessagesForCurrentActiveTurn(chatMessages)) {
+      retainedMessageIds.add(message.id);
+    }
+  }
+  return retainedMessageIds;
+}
+
+function isTransientLocalCodexMessage(message: ChatMessageRecord): boolean {
+  return (
+    message.role === "event" ||
+    message.eventType === "item/agentMessage/delta" ||
+    message.eventType === "chat.message.steered"
   );
 }
 

--- a/packages/server/src/services.ts
+++ b/packages/server/src/services.ts
@@ -4121,21 +4121,53 @@ function resolveChatMessageTimeline({
 function localMessagesForCurrentActiveTurn(
   localMessages: ChatMessageRecord[],
 ): ChatMessageRecord[] {
-  const latestLocalUserCreatedAt = localMessages
-    .filter(isActiveTurnLocalUserBoundary)
-    .map((message) => message.createdAt)
-    .sort((left, right) => right.localeCompare(left))[0];
+  const latestLocalUserCreatedAt =
+    findLatestLocalUserBoundaryCreatedAt(localMessages);
   if (!latestLocalUserCreatedAt) {
     return localMessages;
   }
   return localMessages.filter(
     (message) =>
-      isQueuedMessage(message) || message.createdAt >= latestLocalUserCreatedAt,
+      isQueuedMessage(message) ||
+      isHistoricalLocalMetadataForCodexMessageMerge(
+        message,
+        latestLocalUserCreatedAt,
+      ) ||
+      message.createdAt >= latestLocalUserCreatedAt,
   );
+}
+
+function findLatestLocalUserBoundaryCreatedAt(
+  localMessages: ChatMessageRecord[],
+): string | undefined {
+  return localMessages
+    .filter(isActiveTurnLocalUserBoundary)
+    .map((message) => message.createdAt)
+    .sort((left, right) => right.localeCompare(left))[0];
 }
 
 function isActiveTurnLocalUserBoundary(message: ChatMessageRecord): boolean {
   return message.role === "user" && !isQueuedMessage(message);
+}
+
+function isHistoricalLocalMetadataForCodexMessageMerge(
+  message: ChatMessageRecord,
+  latestLocalUserCreatedAt: string | undefined,
+): boolean {
+  return Boolean(
+    latestLocalUserCreatedAt &&
+    message.createdAt < latestLocalUserCreatedAt &&
+    hasLocalMetadataForCodexMessageMerge(message),
+  );
+}
+
+function hasLocalMetadataForCodexMessageMerge(
+  message: ChatMessageRecord,
+): boolean {
+  return (
+    isFallbackTranscriptMatchableLocalMessage(message) &&
+    (message.attachments?.length ?? 0) > 0
+  );
 }
 
 function createAccumulatedLocalTimelineStateCheckKey(
@@ -4302,6 +4334,13 @@ function mergeCodexAndLocalMessages(
       activeTurnId,
       activeLocalTurnStartIndex,
     );
+  const fallbackLocalMetadataMatches = findFallbackLocalMetadataMatches(
+    mergedCodexMessages,
+    localMessages,
+    fallbackTranscriptLocalMessageMatches,
+    activeTurnId,
+    activeLocalTurnStartIndex,
+  );
   const liveAssistantDeltaCodexOrderLimits =
     findLiveAssistantDeltaCodexOrderLimits(
       localMessages,
@@ -4340,6 +4379,28 @@ function mergeCodexAndLocalMessages(
       }
       unmatchedCodexMessageIndexes.splice(
         unmatchedCodexMessageIndexes.indexOf(fallbackTranscriptCodexIndex),
+        1,
+      );
+      return false;
+    }
+    const fallbackLocalMetadataCodexIndex = fallbackLocalMetadataMatches.get(
+      message.id,
+    );
+    if (
+      fallbackLocalMetadataCodexIndex !== undefined &&
+      unmatchedCodexMessageIndexes.includes(fallbackLocalMetadataCodexIndex)
+    ) {
+      const fallbackCodexMessage =
+        mergedCodexMessages[fallbackLocalMetadataCodexIndex];
+      if (fallbackCodexMessage) {
+        mergedCodexMessages[fallbackLocalMetadataCodexIndex] =
+          mergeLocalMessageMetadataIntoCodexMessage(
+            fallbackCodexMessage,
+            message,
+          );
+      }
+      unmatchedCodexMessageIndexes.splice(
+        unmatchedCodexMessageIndexes.indexOf(fallbackLocalMetadataCodexIndex),
         1,
       );
       return false;
@@ -5473,6 +5534,68 @@ function findFallbackTranscriptLocalMessageMatches(
     }
     nextSearchLocalEntryIndex =
       turnMatches[0]?.localEntryIndex ?? nextSearchLocalEntryIndex;
+  }
+  return matches;
+}
+
+function findFallbackLocalMetadataMatches(
+  codexMessages: InternalChatMessageRecord[],
+  localMessages: ChatMessageRecord[],
+  fallbackTranscriptLocalMessageMatches: ReadonlyMap<string, number>,
+  activeTurnId: string | null,
+  activeLocalTurnStartIndex: number,
+): ReadonlyMap<string, number> {
+  const localEntries = localMessages
+    .map((message, index) => ({ index, message }))
+    .filter(({ message }) => isFallbackTranscriptMatchableLocalMessage(message))
+    .filter(
+      ({ index }) => activeTurnId === null || index < activeLocalTurnStartIndex,
+    );
+  if (localEntries.length === 0) {
+    return new Map();
+  }
+
+  const matches = new Map<string, number>();
+  const latestLocalUserCreatedAt =
+    findLatestLocalUserBoundaryCreatedAt(localMessages);
+  const usedCodexMessageIndexes = new Set(
+    fallbackTranscriptLocalMessageMatches.values(),
+  );
+  const codexEntries = codexMessages
+    .map((message, index) => ({ index, message }))
+    .filter(
+      ({ index, message }) =>
+        !usedCodexMessageIndexes.has(index) &&
+        message.hasFallbackTimestamp &&
+        message.codexTurnId !== activeTurnId &&
+        isTranscriptMessage(message),
+    )
+    .sort(
+      (left, right) =>
+        (left.message.codexOrder ?? left.index) -
+        (right.message.codexOrder ?? right.index),
+    );
+
+  for (const { message: localMessage } of localEntries) {
+    if (
+      fallbackTranscriptLocalMessageMatches.has(localMessage.id) ||
+      !isHistoricalLocalMetadataForCodexMessageMerge(
+        localMessage,
+        latestLocalUserCreatedAt,
+      )
+    ) {
+      continue;
+    }
+    const matchedEntry = codexEntries.find(
+      ({ index, message }) =>
+        !usedCodexMessageIndexes.has(index) &&
+        messageFingerprint(message) === messageFingerprint(localMessage),
+    );
+    if (!matchedEntry) {
+      continue;
+    }
+    matches.set(localMessage.id, matchedEntry.index);
+    usedCodexMessageIndexes.add(matchedEntry.index);
   }
   return matches;
 }


### PR DESCRIPTION
## Summary

- Prune accumulated local Codex timeline artifacts for stale or idle chats so old `item/*` events and assistant deltas do not keep appearing at the bottom of chat history.
- Keep only the latest local user boundary and later local overlay when cleaning accumulated timelines, while preserving Codex thread history as the canonical transcript.
- Add regression coverage for stale local Codex events, repeated local turns, fallback Codex history, and repeated steered boundaries.

## Testing

- `pnpm --filter @phantompane/server test -- services.test.ts`
- `pnpm ready`
- Verified against a copied real state for `chat_3eb56697-db4f-4803-bea2-516975c4e468`; local stored messages were reduced from 990 to 176, leaving only the latest user input plus queued overlay in local state.