### PR TITLE
feat: add project registry

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -15,6 +15,10 @@ This document provides a comprehensive reference for all Phantom commands and th
   - [exec](#exec)
   - [edit](#edit)
   - [ai](#ai)
+- [Project Registry](#project-registry)
+  - [project add](#project-add)
+  - [project list](#project-list)
+  - [project remove](#project-remove)
 - [Preferences](#preferences)
   - [preferences get](#preferences-get)
   - [preferences set](#preferences-set)
@@ -337,6 +341,132 @@ phantom ai feature-auth
 
 - Configure the assistant with `phantom preferences set ai <command>` (e.g., `claude` or `codex --full-auto`) stored as `phantom.ai` in global git config
 
+## Project Registry
+
+Phantom maintains an independent, global registry of Git repositories. It is available from any directory, so people and AI agents can find projects before choosing where to work.
+
+The registry is stored at `$XDG_STATE_HOME/phantom/projects.json` when `XDG_STATE_HOME` is an absolute path. If it is unset or relative, Phantom uses `~/.local/state/phantom/projects.json`.
+
+Each project record contains an opaque, stable `id`, the repository `name`, its absolute `rootPath`, and an ISO 8601 `createdAt` timestamp.
+
+### project add
+
+Register a Git repository. If `path` is omitted, Phantom uses the current directory. Phantom resolves paths inside a repository to the repository root, and adding the same root again is idempotent.
+
+```bash
+phantom project add [path] [--json]
+```
+
+**Options:**
+
+- `--json` - Output the registration result as JSON
+
+**Examples:**
+
+```bash
+# Register the repository containing the current directory
+phantom project add
+
+# Register a repository by path
+phantom project add ~/src/example
+
+# Return structured output for an agent or script
+phantom project add ~/src/example --json
+```
+
+JSON output reports whether the project was newly added or already registered:
+
+```json
+{
+  "status": "added",
+  "project": {
+    "id": "proj_550e8400-e29b-41d4-a716-446655440000",
+    "name": "example",
+    "rootPath": "/home/user/src/example",
+    "createdAt": "2026-07-20T12:00:00.000Z"
+  }
+}
+```
+
+### project list
+
+List registered projects. Projects are sorted by name, then by root path.
+
+```bash
+phantom project list [options]
+```
+
+**Options:**
+
+- `--json` - Output the versioned registry as JSON
+- `--names` - Output only project names, one per line
+- `--paths` - Output only project root paths, one per line
+
+The output options are mutually exclusive.
+
+**Examples:**
+
+```bash
+# Show each project's name, root path, and id
+phantom project list
+
+# Print paths for a shell script
+phantom project list --paths
+
+# Return structured output for an agent
+phantom project list --json
+```
+
+```json
+{
+  "version": 1,
+  "projects": [
+    {
+      "id": "proj_550e8400-e29b-41d4-a716-446655440000",
+      "name": "example",
+      "rootPath": "/home/user/src/example",
+      "createdAt": "2026-07-20T12:00:00.000Z"
+    }
+  ]
+}
+```
+
+### project remove
+
+Remove a project from the registry by id, name, or its exact stored root path. If a name matches more than one project, use an id or path instead.
+
+```bash
+phantom project remove <id|name|path> [--json]
+```
+
+**Options:**
+
+- `--json` - Output the removed project as JSON
+
+**Examples:**
+
+```bash
+# Remove by name
+phantom project remove example
+
+# Remove by id and return structured output
+phantom project remove proj_550e8400-e29b-41d4-a716-446655440000 --json
+```
+
+```json
+{
+  "status": "removed",
+  "project": {
+    "id": "proj_550e8400-e29b-41d4-a716-446655440000",
+    "name": "example",
+    "rootPath": "/home/user/src/example",
+    "createdAt": "2026-07-20T12:00:00.000Z"
+  }
+}
+```
+
+Removing a project only removes its registry record. It does not delete the Git repository, branches, or worktrees.
+
 ## Preferences
 
 Configure defaults for Phantom commands using global git config. Preferences are stored under the `phantom.<key>` namespace and currently support:
@@ -524,10 +654,10 @@ Phantom uses the following exit codes:
 
 - `0` - Success
 - `1` - General error
-- `2` - Invalid arguments
-- `3` - Git operation failed
-- `4` - Worktree operation failed
-- `127` - Command not found
+- `2` - Requested resource not found
+- `3` - Invalid arguments or validation error
+
+Commands that execute another process may propagate that process's exit code.
 
 ## Related Documentation
 

--- a/e2e/src/project.test.ts
+++ b/e2e/src/project.test.ts
@@ -1,0 +1,134 @@
+import assert from "node:assert";
+import { join } from "node:path";
+import { afterEach, beforeEach, it } from "vitest";
+import {
+  describeE2E,
+  runCommand,
+  setupRepo,
+  type RepoContext,
+} from "./helpers.ts";
+
+type ProjectRecord = {
+  id: string;
+  name: string;
+  rootPath: string;
+  createdAt: string;
+};
+
+describeE2E("phantom project e2e", () => {
+  let repo: RepoContext;
+
+  beforeEach(async () => {
+    repo = await setupRepo();
+  });
+
+  afterEach(async () => {
+    await repo.cleanup();
+  });
+
+  it("adds, lists, and removes a project through the global registry", async () => {
+    const projectEnv = {
+      ...repo.env,
+      XDG_STATE_HOME: join(repo.rootDir, "state"),
+    };
+    const addResult = await runCommand(
+      "phantom",
+      ["project", "add", repo.repoDir, "--json"],
+      {
+        cwd: repo.rootDir,
+        env: projectEnv,
+      },
+    );
+
+    assert.strictEqual(addResult.exitCode, 0, addResult.stderr);
+    const added = JSON.parse(addResult.stdout) as {
+      status: string;
+      project: ProjectRecord;
+    };
+    assert.strictEqual(added.status, "added");
+    assert.ok(added.project.id.length > 0);
+    assert.strictEqual(added.project.name, "repo");
+    assert.strictEqual(added.project.rootPath, repo.repoDir);
+    assert.ok(!Number.isNaN(Date.parse(added.project.createdAt)));
+
+    const linkedWorktreePath = join(repo.rootDir, "linked-worktree");
+    const worktreeResult = await runCommand(
+      "git",
+      ["worktree", "add", "-b", "project-linked", linkedWorktreePath],
+      {
+        cwd: repo.repoDir,
+        env: repo.env,
+      },
+    );
+    assert.strictEqual(worktreeResult.exitCode, 0, worktreeResult.stderr);
+
+    const linkedAddResult = await runCommand(
+      "phantom",
+      ["project", "add", linkedWorktreePath, "--json"],
+      {
+        cwd: linkedWorktreePath,
+        env: projectEnv,
+      },
+    );
+    assert.strictEqual(linkedAddResult.exitCode, 0, linkedAddResult.stderr);
+    assert.deepStrictEqual(JSON.parse(linkedAddResult.stdout), {
+      status: "existing",
+      project: added.project,
+    });
+
+    const listResult = await runCommand(
+      "phantom",
+      ["project", "list", "--json"],
+      {
+        cwd: repo.rootDir,
+        env: projectEnv,
+      },
+    );
+
+    assert.strictEqual(listResult.exitCode, 0, listResult.stderr);
+    assert.deepStrictEqual(JSON.parse(listResult.stdout), {
+      version: 1,
+      projects: [added.project],
+    });
+
+    const removeResult = await runCommand(
+      "phantom",
+      ["project", "remove", added.project.id, "--json"],
+      {
+        cwd: repo.rootDir,
+        env: projectEnv,
+      },
+    );
+
+    assert.strictEqual(removeResult.exitCode, 0, removeResult.stderr);
+    assert.deepStrictEqual(JSON.parse(removeResult.stdout), {
+      status: "removed",
+      project: added.project,
+    });
+
+    const emptyListResult = await runCommand(
+      "phantom",
+      ["project", "list", "--json"],
+      {
+        cwd: repo.rootDir,
+        env: projectEnv,
+      },
+    );
+    assert.strictEqual(emptyListResult.exitCode, 0, emptyListResult.stderr);
+    assert.deepStrictEqual(JSON.parse(emptyListResult.stdout), {
+      version: 1,
+      projects: [],
+    });
+
+    const gitResult = await runCommand(
+      "git",
+      ["rev-parse", "--is-inside-work-tree"],
+      {
+        cwd: repo.repoDir,
+        env: repo.env,
+      },
+    );
+    assert.strictEqual(gitResult.exitCode, 0, gitResult.stderr);
+    assert.strictEqual(gitResult.stdout, "true");
+  });
+});

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,6 +24,7 @@
     "@phantompane/mcp": "workspace:*",
     "@phantompane/preferences": "workspace:*",
     "@phantompane/process": "workspace:*",
+    "@phantompane/projects": "workspace:*",
     "@phantompane/utils": "workspace:*",
     "@phantompane/tmux": "workspace:*"
   }

--- a/packages/cli/src/bin/phantom.ts
+++ b/packages/cli/src/bin/phantom.ts
@@ -12,6 +12,10 @@ import { githubHandler } from "../handlers/github.ts";
 import { githubCheckoutHandler } from "../handlers/github-checkout.ts";
 import { listHandler } from "../handlers/list.ts";
 import { mcpHandler } from "../handlers/mcp.ts";
+import { projectAddHandler } from "../handlers/project-add.ts";
+import { projectListHandler } from "../handlers/project-list.ts";
+import { projectRemoveHandler } from "../handlers/project-remove.ts";
+import { projectHandler } from "../handlers/project.ts";
 import { preferencesHandler } from "../handlers/preferences.ts";
 import { preferencesGetHandler } from "../handlers/preferences-get.ts";
 import { preferencesRemoveHandler } from "../handlers/preferences-remove.ts";
@@ -29,6 +33,12 @@ import { execHelp } from "../help/exec.ts";
 import { githubCheckoutHelp, githubHelp } from "../help/github.ts";
 import { listHelp } from "../help/list.ts";
 import { mcpHelp } from "../help/mcp.ts";
+import {
+  projectAddHelp,
+  projectHelp,
+  projectListHelp,
+  projectRemoveHelp,
+} from "../help/project.ts";
 import {
   preferencesGetHelp,
   preferencesHelp,
@@ -146,6 +156,32 @@ const commands: Command[] = [
     description: "Manage MCP server for AI assistants",
     handler: mcpHandler,
     help: mcpHelp,
+  },
+  {
+    name: "project",
+    description: "Manage registered Git projects",
+    handler: projectHandler,
+    help: projectHelp,
+    subcommands: [
+      {
+        name: "add",
+        description: "Register a Git repository",
+        handler: projectAddHandler,
+        help: projectAddHelp,
+      },
+      {
+        name: "list",
+        description: "List registered Git projects",
+        handler: projectListHandler,
+        help: projectListHelp,
+      },
+      {
+        name: "remove",
+        description: "Remove a registered Git project",
+        handler: projectRemoveHandler,
+        help: projectRemoveHelp,
+      },
+    ],
   },
   {
     name: "github",

--- a/packages/cli/src/completions/phantom-bash.ts
+++ b/packages/cli/src/completions/phantom-bash.ts
@@ -72,7 +72,7 @@ _phantom_completion() {
     local cur prev words cword
     _init_completion || return
 
-    local commands="create attach list where delete exec edit ai shell preferences github gh version completion mcp"
+    local commands="create attach list where delete exec edit ai shell project preferences github gh version completion mcp"
     local global_opts="--help --version"
 
     if [[ \${cword} -eq 1 ]]; then
@@ -263,6 +263,39 @@ _phantom_completion() {
         completion)
             local shells="fish zsh bash"
             COMPREPLY=( $(compgen -W "\${shells}" -- "\${cur}") )
+            return 0
+            ;;
+        project)
+            if [[ \${cword} -eq 2 ]]; then
+                local subcommands="add list remove"
+                COMPREPLY=( $(compgen -W "\${subcommands}" -- "\${cur}") )
+                return 0
+            elif [[ \${words[2]} == "add" ]]; then
+                if [[ "\${cur}" == -* ]]; then
+                    local opts="--json"
+                    COMPREPLY=( $(compgen -W "\${opts}" -- "\${cur}") )
+                else
+                    _filedir -d
+                fi
+                return 0
+            elif [[ \${words[2]} == "list" ]]; then
+                local word
+                for word in "\${words[@]:3}"; do
+                    case "\${word}" in
+                        --json|--names|--paths)
+                            COMPREPLY=()
+                            return 0
+                            ;;
+                    esac
+                done
+                local opts="--json --names --paths"
+                COMPREPLY=( $(compgen -W "\${opts}" -- "\${cur}") )
+                return 0
+            elif [[ \${words[2]} == "remove" ]]; then
+                local opts="--json"
+                COMPREPLY=( $(compgen -W "\${opts}" -- "\${cur}") )
+                return 0
+            fi
             return 0
             ;;
         preferences)

--- a/packages/cli/src/completions/phantom-fish.ts
+++ b/packages/cli/src/completions/phantom-fish.ts
@@ -28,6 +28,16 @@ function __phantom_using_command
     return 1
 end
 
+function __phantom_project_list_has_output_mode
+    set -l tokens (commandline -opc)
+    for mode in --json --names --paths
+        if contains -- $mode $tokens
+            return 0
+        end
+    end
+    return 1
+end
+
 function __phantom_exec_before_command
     set -l tokens (commandline -opc)
     set -l non_options 0
@@ -93,6 +103,7 @@ complete -c phantom -n "__phantom_using_command" -a "exec" -d "Execute a command
 complete -c phantom -n "__phantom_using_command" -a "edit" -d "Open a worktree in your configured editor"
 complete -c phantom -n "__phantom_using_command" -a "ai" -d "Launch your configured AI coding assistant in a worktree"
 complete -c phantom -n "__phantom_using_command" -a "shell" -d "Open an interactive shell in a worktree directory"
+complete -c phantom -n "__phantom_using_command" -a "project" -d "Manage registered Git projects"
 complete -c phantom -n "__phantom_using_command" -a "preferences" -d "Manage editor/ai/worktreesDirectory/directoryNameSeparator preferences (stored in git config --global)"
 complete -c phantom -n "__phantom_using_command" -a "github" -d "GitHub integration commands"
 complete -c phantom -n "__phantom_using_command" -a "gh" -d "GitHub integration commands (alias)"
@@ -158,6 +169,15 @@ complete -c phantom -n "__phantom_using_command edit; and __fish_seen_subcommand
 
 # ai command options
 complete -c phantom -n "__phantom_using_command ai" -a "(__phantom_list_worktrees)"
+
+# project command
+complete -c phantom -n "__phantom_using_command project; and not __fish_seen_subcommand_from add list remove" -a "add list remove" -d "Manage registered Git projects"
+complete -c phantom -n "__phantom_using_command project; and __fish_seen_subcommand_from add" -l json -d "Output the registration result as JSON"
+complete -c phantom -n "__phantom_using_command project; and __fish_seen_subcommand_from add" -a "(__fish_complete_directories)" -d "Git repository directory"
+complete -c phantom -n "__phantom_using_command project; and __fish_seen_subcommand_from list; and not __phantom_project_list_has_output_mode" -l json -d "Output the registry as JSON"
+complete -c phantom -n "__phantom_using_command project; and __fish_seen_subcommand_from list; and not __phantom_project_list_has_output_mode" -l names -d "Output only project names"
+complete -c phantom -n "__phantom_using_command project; and __fish_seen_subcommand_from list; and not __phantom_project_list_has_output_mode" -l paths -d "Output only project root paths"
+complete -c phantom -n "__phantom_using_command project; and __fish_seen_subcommand_from remove" -l json -d "Output the removal result as JSON"
 
 # preferences command
 complete -c phantom -n "__phantom_using_command preferences" -a "get set remove" -d "Manage preferences"

--- a/packages/cli/src/completions/phantom-zsh.ts
+++ b/packages/cli/src/completions/phantom-zsh.ts
@@ -1,4 +1,4 @@
-export const ZSH_COMPLETION_SCRIPT = `#compdef phantom
+export const ZSH_COMPLETION_SCRIPT = String.raw`#compdef phantom
 # Zsh completion for phantom
 # Load with: eval "$(phantom completion zsh)"
 
@@ -15,6 +15,7 @@ _phantom() {
         'edit:Open a worktree in your configured editor'
         'ai:Launch your configured AI coding assistant in a worktree'
         'shell:Open an interactive shell in a worktree directory'
+        'project:Manage registered Git projects'
         'preferences:Manage editor/ai/worktreesDirectory/directoryNameSeparator preferences (git config --global)'
         'github:GitHub integration commands'
         'gh:GitHub integration commands (alias)'
@@ -113,6 +114,25 @@ _phantom() {
                     _arguments \
                         '1:worktree:(\${(q)worktrees[@]})'
                     ;;
+                project)
+                    if [[ \${#line} -eq 1 ]]; then
+                        _arguments \
+                            '1:subcommand:(add list remove)'
+                    elif [[ \${line[2]} == "add" ]]; then
+                        _arguments \
+                            '--json[Output the registration result as JSON]' \
+                            '1::path:_files -/'
+                    elif [[ \${line[2]} == "list" ]]; then
+                        _arguments \
+                            '(--names --paths)--json[Output the registry as JSON]' \
+                            '(--json --paths)--names[Output only project names]' \
+                            '(--json --names)--paths[Output only project root paths]'
+                    elif [[ \${line[2]} == "remove" ]]; then
+                        _arguments \
+                            '--json[Output the removal result as JSON]' \
+                            '1:project id, name, or path:'
+                    fi
+                    ;;
                 preferences)
                     _arguments \
                         '1:subcommand:(get set remove)' \
@@ -150,4 +170,4 @@ if [ "$funcstack[1]" = "_phantom" ]; then
     _phantom "$@"
 else
     compdef _phantom phantom
-fi`;
+fi`.replaceAll("\\${", "${");

--- a/packages/cli/src/completions/phantom.bash
+++ b/packages/cli/src/completions/phantom.bash
@@ -72,7 +72,7 @@ _phantom_completion() {
     local cur prev words cword
     _init_completion || return
 
-    local commands="create attach list where delete exec edit ai shell preferences github gh version completion mcp"
+    local commands="create attach list where delete exec edit ai shell project preferences github gh version completion mcp"
     local global_opts="--help --version"
 
     if [[ ${cword} -eq 1 ]]; then
@@ -263,6 +263,39 @@ _phantom_completion() {
         completion)
             local shells="fish zsh bash"
             COMPREPLY=( $(compgen -W "${shells}" -- "${cur}") )
+            return 0
+            ;;
+        project)
+            if [[ ${cword} -eq 2 ]]; then
+                local subcommands="add list remove"
+                COMPREPLY=( $(compgen -W "${subcommands}" -- "${cur}") )
+                return 0
+            elif [[ ${words[2]} == "add" ]]; then
+                if [[ "${cur}" == -* ]]; then
+                    local opts="--json"
+                    COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                else
+                    _filedir -d
+                fi
+                return 0
+            elif [[ ${words[2]} == "list" ]]; then
+                local word
+                for word in "${words[@]:3}"; do
+                    case "${word}" in
+                        --json|--names|--paths)
+                            COMPREPLY=()
+                            return 0
+                            ;;
+                    esac
+                done
+                local opts="--json --names --paths"
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            elif [[ ${words[2]} == "remove" ]]; then
+                local opts="--json"
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
             return 0
             ;;
         preferences)

--- a/packages/cli/src/completions/phantom.bash.test.shell.ts
+++ b/packages/cli/src/completions/phantom.bash.test.shell.ts
@@ -35,6 +35,90 @@ describe("phantom.bash completion", () => {
     ok(!completions.includes("serve"));
   });
 
+  it("completes the project command", () => {
+    const { completions, result } = runBashCompletion(completionScriptPath, [
+      "phantom",
+      "p",
+    ]);
+
+    strictEqual(result.status, 0, result.stderr);
+    ok(completions.includes("project"));
+  });
+
+  it("completes project subcommands", () => {
+    const { completions, result } = runBashCompletion(completionScriptPath, [
+      "phantom",
+      "project",
+      "",
+    ]);
+
+    strictEqual(result.status, 0, result.stderr);
+    ok(completions.includes("add"));
+    ok(completions.includes("list"));
+    ok(completions.includes("remove"));
+  });
+
+  it("completes project list output flags", () => {
+    const { completions, result } = runBashCompletion(completionScriptPath, [
+      "phantom",
+      "project",
+      "list",
+      "--",
+    ]);
+
+    strictEqual(result.status, 0, result.stderr);
+    ok(completions.includes("--json"));
+    ok(completions.includes("--names"));
+    ok(completions.includes("--paths"));
+  });
+
+  it("does not offer another project list output mode", () => {
+    for (const selectedMode of ["--json", "--names", "--paths"]) {
+      const { completions, result } = runBashCompletion(completionScriptPath, [
+        "phantom",
+        "project",
+        "list",
+        selectedMode,
+        "--",
+      ]);
+
+      strictEqual(result.status, 0, result.stderr);
+      ok(!completions.includes("--json"));
+      ok(!completions.includes("--names"));
+      ok(!completions.includes("--paths"));
+    }
+  });
+
+  it("completes the JSON flag for project mutations", () => {
+    for (const subcommand of ["add", "remove"]) {
+      const { completions, result } = runBashCompletion(completionScriptPath, [
+        "phantom",
+        "project",
+        subcommand,
+        "--j",
+      ]);
+
+      strictEqual(result.status, 0, result.stderr);
+      ok(completions.includes("--json"));
+    }
+  });
+
+  it("completes directories for project add", () => {
+    const setupScript = `
+_filedir() {
+  COMPREPLY=(demo-repository/)
+}
+`;
+    const { completions, result } = runBashCompletion(
+      completionScriptPath,
+      ["phantom", "project", "add", ""],
+      { setupScript },
+    );
+
+    strictEqual(result.status, 0, result.stderr);
+    ok(completions.includes("demo-repository/"));
+  });
+
   it("completes exec command arguments with the target command's completion", () => {
     const setupScript = `
 _dummy_complete() {

--- a/packages/cli/src/completions/phantom.fish
+++ b/packages/cli/src/completions/phantom.fish
@@ -28,6 +28,16 @@ function __phantom_using_command
     return 1
 end
 
+function __phantom_project_list_has_output_mode
+    set -l tokens (commandline -opc)
+    for mode in --json --names --paths
+        if contains -- $mode $tokens
+            return 0
+        end
+    end
+    return 1
+end
+
 function __phantom_exec_before_command
     set -l tokens (commandline -opc)
     set -l non_options 0
@@ -93,6 +103,7 @@ complete -c phantom -n "__phantom_using_command" -a "exec" -d "Execute a command
 complete -c phantom -n "__phantom_using_command" -a "edit" -d "Open a worktree in your configured editor"
 complete -c phantom -n "__phantom_using_command" -a "ai" -d "Launch your configured AI coding assistant in a worktree"
 complete -c phantom -n "__phantom_using_command" -a "shell" -d "Open an interactive shell in a worktree directory"
+complete -c phantom -n "__phantom_using_command" -a "project" -d "Manage registered Git projects"
 complete -c phantom -n "__phantom_using_command" -a "preferences" -d "Manage editor/ai/worktreesDirectory/directoryNameSeparator preferences (stored in git config --global)"
 complete -c phantom -n "__phantom_using_command" -a "github" -d "GitHub integration commands"
 complete -c phantom -n "__phantom_using_command" -a "gh" -d "GitHub integration commands (alias)"
@@ -158,6 +169,15 @@ complete -c phantom -n "__phantom_using_command edit; and __fish_seen_subcommand
 
 # ai command options
 complete -c phantom -n "__phantom_using_command ai" -a "(__phantom_list_worktrees)"
+
+# project command
+complete -c phantom -n "__phantom_using_command project; and not __fish_seen_subcommand_from add list remove" -a "add list remove" -d "Manage registered Git projects"
+complete -c phantom -n "__phantom_using_command project; and __fish_seen_subcommand_from add" -l json -d "Output the registration result as JSON"
+complete -c phantom -n "__phantom_using_command project; and __fish_seen_subcommand_from add" -a "(__fish_complete_directories)" -d "Git repository directory"
+complete -c phantom -n "__phantom_using_command project; and __fish_seen_subcommand_from list; and not __phantom_project_list_has_output_mode" -l json -d "Output the registry as JSON"
+complete -c phantom -n "__phantom_using_command project; and __fish_seen_subcommand_from list; and not __phantom_project_list_has_output_mode" -l names -d "Output only project names"
+complete -c phantom -n "__phantom_using_command project; and __fish_seen_subcommand_from list; and not __phantom_project_list_has_output_mode" -l paths -d "Output only project root paths"
+complete -c phantom -n "__phantom_using_command project; and __fish_seen_subcommand_from remove" -l json -d "Output the removal result as JSON"
 
 # preferences command
 complete -c phantom -n "__phantom_using_command preferences" -a "get set remove" -d "Manage preferences"

--- a/packages/cli/src/completions/phantom.fish.test.shell.ts
+++ b/packages/cli/src/completions/phantom.fish.test.shell.ts
@@ -35,6 +35,74 @@ describe("phantom.fish completion", () => {
     ok(!completions.includes("serve"));
   });
 
+  it("completes the project command", () => {
+    const { completions, result } = runFishCompletion(completionScriptPath, [
+      "phantom",
+      "p",
+    ]);
+
+    strictEqual(result.status, 0, result.stderr);
+    ok(completions.includes("project"));
+  });
+
+  it("completes project subcommands", () => {
+    const { completions, result } = runFishCompletion(completionScriptPath, [
+      "phantom",
+      "project",
+      "",
+    ]);
+
+    strictEqual(result.status, 0, result.stderr);
+    ok(completions.includes("add"));
+    ok(completions.includes("list"));
+    ok(completions.includes("remove"));
+  });
+
+  it("completes project list output flags", () => {
+    const { completions, result } = runFishCompletion(completionScriptPath, [
+      "phantom",
+      "project",
+      "list",
+      "--",
+    ]);
+
+    strictEqual(result.status, 0, result.stderr);
+    ok(completions.includes("--json"));
+    ok(completions.includes("--names"));
+    ok(completions.includes("--paths"));
+  });
+
+  it("does not offer another project list output mode", () => {
+    for (const selectedMode of ["--json", "--names", "--paths"]) {
+      const { completions, result } = runFishCompletion(completionScriptPath, [
+        "phantom",
+        "project",
+        "list",
+        selectedMode,
+        "--",
+      ]);
+
+      strictEqual(result.status, 0, result.stderr);
+      ok(!completions.includes("--json"));
+      ok(!completions.includes("--names"));
+      ok(!completions.includes("--paths"));
+    }
+  });
+
+  it("completes the JSON flag for project mutations", () => {
+    for (const subcommand of ["add", "remove"]) {
+      const { completions, result } = runFishCompletion(completionScriptPath, [
+        "phantom",
+        "project",
+        subcommand,
+        "--j",
+      ]);
+
+      strictEqual(result.status, 0, result.stderr);
+      ok(completions.includes("--json"));
+    }
+  });
+
   it("passes exec completions through to the invoked command", () => {
     const setupScript = `
 complete -c dummycmd -l from-dummy -d "Dummy option"

--- a/packages/cli/src/completions/phantom.zsh
+++ b/packages/cli/src/completions/phantom.zsh
@@ -15,6 +15,7 @@ _phantom() {
         'edit:Open a worktree in your configured editor'
         'ai:Launch your configured AI coding assistant in a worktree'
         'shell:Open an interactive shell in a worktree directory'
+        'project:Manage registered Git projects'
         'preferences:Manage editor/ai/worktreesDirectory/directoryNameSeparator preferences (git config --global)'
         'github:GitHub integration commands'
         'gh:GitHub integration commands (alias)'
@@ -59,6 +60,7 @@ _phantom() {
                 list)
                     _arguments \
                         '--fzf[Use fzf for interactive selection]' \
+                        '--no-default[Exclude the default worktree from the list]' \
                         '--names[Output only phantom names (for scripts and completion)]'
                     ;;
                 where|delete|shell)
@@ -111,6 +113,25 @@ _phantom() {
                     worktrees=(${(f)"$(phantom list --names 2>/dev/null)"})
                     _arguments \
                         '1:worktree:(${(q)worktrees[@]})'
+                    ;;
+                project)
+                    if [[ ${#line} -eq 1 ]]; then
+                        _arguments \
+                            '1:subcommand:(add list remove)'
+                    elif [[ ${line[2]} == "add" ]]; then
+                        _arguments \
+                            '--json[Output the registration result as JSON]' \
+                            '1::path:_files -/'
+                    elif [[ ${line[2]} == "list" ]]; then
+                        _arguments \
+                            '(--names --paths)--json[Output the registry as JSON]' \
+                            '(--json --paths)--names[Output only project names]' \
+                            '(--json --names)--paths[Output only project root paths]'
+                    elif [[ ${line[2]} == "remove" ]]; then
+                        _arguments \
+                            '--json[Output the removal result as JSON]' \
+                            '1:project id, name, or path:'
+                    fi
                     ;;
                 preferences)
                     _arguments \

--- a/packages/cli/src/completions/phantom.zsh.test.shell.ts
+++ b/packages/cli/src/completions/phantom.zsh.test.shell.ts
@@ -1,7 +1,9 @@
 import { ok, strictEqual } from "node:assert";
+import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { describe, it } from "vitest";
 import { fileURLToPath } from "node:url";
+import { ZSH_COMPLETION_SCRIPT } from "./phantom-zsh.ts";
 import { runZshCompletion } from "../test-utils/run-zsh-completion.ts";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -9,6 +11,13 @@ const __dirname = dirname(__filename);
 const completionScriptPath = join(__dirname, "phantom.zsh");
 
 describe("phantom.zsh completion", () => {
+  it("tests the completion script emitted by the CLI", () => {
+    strictEqual(
+      readFileSync(completionScriptPath, "utf8"),
+      `${ZSH_COMPLETION_SCRIPT}\n`,
+    );
+  });
+
   it("completes version when typing phantom v", () => {
     const { completions, result } = runZshCompletion(completionScriptPath, [
       "phantom",
@@ -33,5 +42,52 @@ describe("phantom.zsh completion", () => {
 
     ok(completions.includes("shell"));
     ok(!completions.includes("serve"));
+  });
+
+  it("completes the project command", () => {
+    const { completions, result } = runZshCompletion(completionScriptPath, [
+      "phantom",
+      "p",
+    ]);
+
+    strictEqual(result.status, 0, result.stderr);
+    ok(completions.includes("project"));
+  });
+
+  it("completes project subcommands", () => {
+    const { completions, result } = runZshCompletion(completionScriptPath, [
+      "phantom",
+      "project",
+      "",
+    ]);
+
+    strictEqual(result.status, 0, result.stderr);
+    ok(completions.includes("add"));
+    ok(completions.includes("list"));
+    ok(completions.includes("remove"));
+  });
+
+  it("completes project options", () => {
+    const listCompletion = runZshCompletion(completionScriptPath, [
+      "phantom",
+      "project",
+      "list",
+      "--",
+    ]);
+    strictEqual(listCompletion.result.status, 0, listCompletion.result.stderr);
+    ok(listCompletion.completions.includes("--json"));
+    ok(listCompletion.completions.includes("--names"));
+    ok(listCompletion.completions.includes("--paths"));
+
+    for (const subcommand of ["add", "remove"]) {
+      const { completions, result } = runZshCompletion(completionScriptPath, [
+        "phantom",
+        "project",
+        subcommand,
+        "--j",
+      ]);
+      strictEqual(result.status, 0, result.stderr);
+      ok(completions.includes("--json"));
+    }
   });
 });

--- a/packages/cli/src/handlers/project-add.ts
+++ b/packages/cli/src/handlers/project-add.ts
@@ -1,0 +1,62 @@
+import { realpath } from "node:fs/promises";
+import { resolve } from "node:path";
+import { getGitRoot } from "@phantompane/git";
+import { ProjectRegistryStore } from "@phantompane/projects";
+import { exitCodes, exitWithError, exitWithSuccess } from "../errors.ts";
+import { output } from "../output.ts";
+import { parseArgsOrExit } from "../parse-args.ts";
+
+export async function projectAddHandler(args: string[] = []): Promise<void> {
+  const { positionals, values } = parseArgsOrExit({
+    args,
+    options: {
+      json: {
+        type: "boolean",
+        default: false,
+      },
+    },
+    strict: true,
+    allowPositionals: true,
+  });
+
+  if (positionals.length > 1) {
+    exitWithError(
+      "Usage: phantom project add [path] [--json]",
+      exitCodes.validationError,
+    );
+  }
+
+  const rootPath = await resolveProjectRootPath(
+    positionals[0] ?? process.cwd(),
+  );
+  const { project, added } = await new ProjectRegistryStore().add(rootPath);
+
+  if (values.json) {
+    output.log(
+      JSON.stringify(
+        {
+          status: added ? "added" : "existing",
+          project,
+        },
+        null,
+        2,
+      ),
+    );
+  } else if (added) {
+    output.log(`Added project '${project.name}' (${project.rootPath})`);
+  } else {
+    output.log(
+      `Project '${project.name}' is already registered (${project.rootPath})`,
+    );
+  }
+
+  exitWithSuccess();
+}
+
+export async function resolveProjectRootPath(
+  inputPath: string,
+): Promise<string> {
+  const resolvedPath = await realpath(resolve(inputPath));
+  const gitRoot = await getGitRoot({ cwd: resolvedPath });
+  return await realpath(gitRoot);
+}

--- a/packages/cli/src/handlers/project-list.ts
+++ b/packages/cli/src/handlers/project-list.ts
@@ -1,0 +1,90 @@
+import {
+  PROJECT_REGISTRY_VERSION,
+  ProjectRegistryStore,
+  type ProjectRecord,
+} from "@phantompane/projects";
+import { exitCodes, exitWithError, exitWithSuccess } from "../errors.ts";
+import { output } from "../output.ts";
+import { parseArgsOrExit } from "../parse-args.ts";
+
+export async function projectListHandler(args: string[] = []): Promise<void> {
+  const { values } = parseArgsOrExit({
+    args,
+    options: {
+      json: {
+        type: "boolean",
+        default: false,
+      },
+      names: {
+        type: "boolean",
+        default: false,
+      },
+      paths: {
+        type: "boolean",
+        default: false,
+      },
+    },
+    strict: true,
+    allowPositionals: false,
+  });
+
+  const outputModes = [values.json, values.names, values.paths].filter(Boolean);
+  if (outputModes.length > 1) {
+    exitWithError(
+      "Only one of --json, --names, or --paths can be specified",
+      exitCodes.validationError,
+    );
+  }
+
+  const projects = sortProjects(await new ProjectRegistryStore().list());
+
+  if (values.json) {
+    output.log(
+      JSON.stringify(
+        {
+          version: PROJECT_REGISTRY_VERSION,
+          projects,
+        },
+        null,
+        2,
+      ),
+    );
+    exitWithSuccess();
+  }
+
+  if (projects.length === 0) {
+    if (!values.names && !values.paths) {
+      output.log("No projects found.");
+    }
+    exitWithSuccess();
+  }
+
+  for (const project of projects) {
+    if (values.names) {
+      output.log(project.name);
+    } else if (values.paths) {
+      output.log(project.rootPath);
+    } else {
+      output.log(`${project.name} (${project.rootPath}) [${project.id}]`);
+    }
+  }
+
+  exitWithSuccess();
+}
+
+function sortProjects(projects: ProjectRecord[]): ProjectRecord[] {
+  return [...projects].sort((left, right) => {
+    const nameComparison = compareStrings(left.name, right.name);
+    return nameComparison || compareStrings(left.rootPath, right.rootPath);
+  });
+}
+
+function compareStrings(left: string, right: string): number {
+  if (left < right) {
+    return -1;
+  }
+  if (left > right) {
+    return 1;
+  }
+  return 0;
+}

--- a/packages/cli/src/handlers/project-remove.ts
+++ b/packages/cli/src/handlers/project-remove.ts
@@ -1,0 +1,96 @@
+import {
+  ProjectRegistryStore,
+  type ProjectRecord,
+} from "@phantompane/projects";
+import { exitCodes, exitWithError, exitWithSuccess } from "../errors.ts";
+import { output } from "../output.ts";
+import { parseArgsOrExit } from "../parse-args.ts";
+import { resolveProjectRootPath } from "./project-add.ts";
+
+export async function projectRemoveHandler(args: string[] = []): Promise<void> {
+  const { positionals, values } = parseArgsOrExit({
+    args,
+    options: {
+      json: {
+        type: "boolean",
+        default: false,
+      },
+    },
+    strict: true,
+    allowPositionals: true,
+  });
+
+  if (positionals.length !== 1) {
+    exitWithError(
+      "Usage: phantom project remove <id|name|path> [--json]",
+      exitCodes.validationError,
+    );
+  }
+
+  const identifier = positionals[0];
+  const store = new ProjectRegistryStore();
+  const projects = await store.list();
+  const project = await findProject(projects, identifier);
+
+  if (!project) {
+    exitWithError(`Project '${identifier}' not found`, exitCodes.notFound);
+  }
+
+  const removedProject = await store.remove(project.id);
+  if (!removedProject) {
+    exitWithError(`Project '${identifier}' not found`, exitCodes.notFound);
+  }
+
+  if (values.json) {
+    output.log(
+      JSON.stringify(
+        {
+          status: "removed",
+          project: removedProject,
+        },
+        null,
+        2,
+      ),
+    );
+  } else {
+    output.log(
+      `Removed project '${removedProject.name}' (${removedProject.rootPath})`,
+    );
+  }
+
+  exitWithSuccess();
+}
+
+async function findProject(
+  projects: ProjectRecord[],
+  identifier: string,
+): Promise<ProjectRecord | null> {
+  const idMatch = projects.find((project) => project.id === identifier);
+  if (idMatch) {
+    return idMatch;
+  }
+
+  const pathMatch = projects.find((project) => project.rootPath === identifier);
+  if (pathMatch) {
+    return pathMatch;
+  }
+
+  const nameMatches = projects.filter((project) => project.name === identifier);
+  if (nameMatches.length === 1) {
+    return nameMatches[0]!;
+  }
+
+  if (nameMatches.length > 1) {
+    exitWithError(
+      `Project '${identifier}' is ambiguous; use its id or path`,
+      exitCodes.validationError,
+    );
+  }
+
+  try {
+    const rootPath = await resolveProjectRootPath(identifier);
+    return projects.find((project) => project.rootPath === rootPath) ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/cli/src/handlers/project.test.ts
+++ b/packages/cli/src/handlers/project.test.ts
@@ -1,0 +1,387 @@
+import { deepStrictEqual, rejects, strictEqual } from "node:assert";
+import { afterAll, beforeEach, describe, it, vi } from "vitest";
+
+const exitMock = vi.fn();
+const outputLogMock = vi.fn();
+const outputErrorMock = vi.fn();
+const getGitRootMock = vi.fn();
+const realpathMock = vi.fn();
+const storeAddMock = vi.fn();
+const storeListMock = vi.fn();
+const storeRemoveMock = vi.fn();
+
+const originalProcessExit = process.exit;
+
+process.exit = (code): never => {
+  exitMock(code);
+  throw new Error(`Exit with code ${code ?? 0}`);
+};
+
+vi.doMock("node:fs/promises", () => ({
+  realpath: realpathMock,
+}));
+
+vi.doMock("@phantompane/git", () => ({
+  getGitRoot: getGitRootMock,
+}));
+
+vi.doMock("@phantompane/projects", () => ({
+  PROJECT_REGISTRY_VERSION: 1,
+  ProjectRegistryStore: class {
+    add = storeAddMock;
+    list = storeListMock;
+    remove = storeRemoveMock;
+  },
+}));
+
+vi.doMock("../output.ts", () => ({
+  output: {
+    log: outputLogMock,
+    error: outputErrorMock,
+  },
+}));
+
+const { projectAddHandler } = await import("./project-add.ts");
+const { projectListHandler } = await import("./project-list.ts");
+const { projectRemoveHandler } = await import("./project-remove.ts");
+
+const alphaProject = {
+  id: "proj_00000000-0000-4000-8000-000000000001",
+  name: "alpha",
+  rootPath: "/repos/alpha",
+  createdAt: "2026-07-20T00:00:00.000Z",
+};
+
+const betaProject = {
+  id: "proj_00000000-0000-4000-8000-000000000002",
+  name: "beta",
+  rootPath: "/repos/beta",
+  createdAt: "2026-07-20T00:00:01.000Z",
+};
+
+beforeEach(() => {
+  exitMock.mockClear();
+  outputLogMock.mockClear();
+  outputErrorMock.mockClear();
+  getGitRootMock.mockReset();
+  realpathMock.mockReset();
+  storeAddMock.mockReset();
+  storeListMock.mockReset();
+  storeRemoveMock.mockReset();
+
+  realpathMock.mockImplementation(async (inputPath) => String(inputPath));
+  getGitRootMock.mockImplementation(async ({ cwd }) => cwd);
+  storeListMock.mockResolvedValue([]);
+});
+
+afterAll(() => {
+  process.exit = originalProcessExit;
+});
+
+describe("project add", () => {
+  it("registers the canonical Git root", async () => {
+    getGitRootMock.mockResolvedValueOnce("/repos/alpha");
+    storeAddMock.mockResolvedValueOnce({
+      project: alphaProject,
+      added: true,
+    });
+
+    await rejects(
+      async () => await projectAddHandler(["/repos/alpha/packages/cli"]),
+      /Exit with code 0/,
+    );
+
+    deepStrictEqual(getGitRootMock.mock.calls[0], [
+      { cwd: "/repos/alpha/packages/cli" },
+    ]);
+    deepStrictEqual(storeAddMock.mock.calls[0], ["/repos/alpha"]);
+    strictEqual(
+      outputLogMock.mock.calls[0][0],
+      "Added project 'alpha' (/repos/alpha)",
+    );
+  });
+
+  it("reports an idempotent add as existing JSON", async () => {
+    getGitRootMock.mockResolvedValueOnce("/repos/alpha");
+    storeAddMock.mockResolvedValueOnce({
+      project: alphaProject,
+      added: false,
+    });
+
+    await rejects(
+      async () => await projectAddHandler(["/repos/alpha", "--json"]),
+      /Exit with code 0/,
+    );
+
+    deepStrictEqual(JSON.parse(outputLogMock.mock.calls[0][0]), {
+      status: "existing",
+      project: alphaProject,
+    });
+  });
+
+  it("rejects more than one path", async () => {
+    await rejects(
+      async () => await projectAddHandler(["one", "two"]),
+      /Exit with code 3/,
+    );
+
+    strictEqual(
+      outputErrorMock.mock.calls[0][0],
+      "Usage: phantom project add [path] [--json]",
+    );
+    strictEqual(storeAddMock.mock.calls.length, 0);
+  });
+
+  it("reports unknown options as validation errors", async () => {
+    await rejects(
+      async () => await projectAddHandler(["--unknown"]),
+      /Exit with code 3/,
+    );
+
+    strictEqual(exitMock.mock.calls[0][0], 3);
+    strictEqual(storeAddMock.mock.calls.length, 0);
+  });
+});
+
+describe("project list", () => {
+  it("prints a deterministic human-readable list", async () => {
+    storeListMock.mockResolvedValueOnce([
+      betaProject,
+      {
+        ...alphaProject,
+        id: "proj_00000000-0000-4000-8000-000000000003",
+        rootPath: "/repos/alpha-z",
+      },
+      alphaProject,
+    ]);
+
+    await rejects(async () => await projectListHandler([]), /Exit with code 0/);
+
+    deepStrictEqual(
+      outputLogMock.mock.calls.map(([message]) => message),
+      [
+        `alpha (/repos/alpha) [${alphaProject.id}]`,
+        "alpha (/repos/alpha-z) [proj_00000000-0000-4000-8000-000000000003]",
+        `beta (/repos/beta) [${betaProject.id}]`,
+      ],
+    );
+  });
+
+  it("prints the versioned registry as JSON", async () => {
+    storeListMock.mockResolvedValueOnce([betaProject, alphaProject]);
+
+    await rejects(
+      async () => await projectListHandler(["--json"]),
+      /Exit with code 0/,
+    );
+
+    deepStrictEqual(JSON.parse(outputLogMock.mock.calls[0][0]), {
+      version: 1,
+      projects: [alphaProject, betaProject],
+    });
+  });
+
+  it("sorts JSON output by code point instead of the host locale", async () => {
+    const uppercaseProject = {
+      ...alphaProject,
+      id: "proj_00000000-0000-4000-8000-000000000005",
+      name: "Alpha",
+      rootPath: "/repos/uppercase",
+    };
+    const zetaProject = {
+      ...alphaProject,
+      id: "proj_00000000-0000-4000-8000-000000000006",
+      name: "zeta",
+      rootPath: "/repos/zeta",
+    };
+    const umlautProject = {
+      ...alphaProject,
+      id: "proj_00000000-0000-4000-8000-000000000007",
+      name: "äther",
+      rootPath: "/repos/umlaut",
+    };
+    storeListMock.mockResolvedValueOnce([
+      umlautProject,
+      zetaProject,
+      uppercaseProject,
+    ]);
+
+    await rejects(
+      async () => await projectListHandler(["--json"]),
+      /Exit with code 0/,
+    );
+
+    deepStrictEqual(JSON.parse(outputLogMock.mock.calls[0][0]).projects, [
+      uppercaseProject,
+      zetaProject,
+      umlautProject,
+    ]);
+  });
+
+  it("prints only names or paths when requested", async () => {
+    storeListMock.mockResolvedValue([betaProject, alphaProject]);
+
+    await rejects(
+      async () => await projectListHandler(["--names"]),
+      /Exit with code 0/,
+    );
+    deepStrictEqual(
+      outputLogMock.mock.calls.map(([message]) => message),
+      ["alpha", "beta"],
+    );
+
+    outputLogMock.mockClear();
+    await rejects(
+      async () => await projectListHandler(["--paths"]),
+      /Exit with code 0/,
+    );
+    deepStrictEqual(
+      outputLogMock.mock.calls.map(([message]) => message),
+      ["/repos/alpha", "/repos/beta"],
+    );
+  });
+
+  it("rejects conflicting output modes", async () => {
+    await rejects(
+      async () => await projectListHandler(["--json", "--paths"]),
+      /Exit with code 3/,
+    );
+
+    strictEqual(
+      outputErrorMock.mock.calls[0][0],
+      "Only one of --json, --names, or --paths can be specified",
+    );
+    strictEqual(storeListMock.mock.calls.length, 0);
+  });
+
+  it("reports unexpected positionals as validation errors", async () => {
+    await rejects(
+      async () => await projectListHandler(["unexpected"]),
+      /Exit with code 3/,
+    );
+
+    strictEqual(exitMock.mock.calls[0][0], 3);
+    strictEqual(storeListMock.mock.calls.length, 0);
+  });
+
+  it("prints a message for an empty human-readable list", async () => {
+    await rejects(async () => await projectListHandler([]), /Exit with code 0/);
+
+    strictEqual(outputLogMock.mock.calls[0][0], "No projects found.");
+  });
+});
+
+describe("project remove", () => {
+  it("removes a project by id without touching the repository", async () => {
+    storeListMock.mockResolvedValueOnce([alphaProject]);
+    storeRemoveMock.mockResolvedValueOnce(alphaProject);
+
+    await rejects(
+      async () => await projectRemoveHandler([alphaProject.id]),
+      /Exit with code 0/,
+    );
+
+    deepStrictEqual(storeRemoveMock.mock.calls[0], [alphaProject.id]);
+    strictEqual(realpathMock.mock.calls.length, 0);
+    strictEqual(
+      outputLogMock.mock.calls[0][0],
+      "Removed project 'alpha' (/repos/alpha)",
+    );
+  });
+
+  it("prefers an exact id over another project's matching name", async () => {
+    const collidingProject = {
+      ...betaProject,
+      name: alphaProject.id,
+    };
+    storeListMock.mockResolvedValueOnce([alphaProject, collidingProject]);
+    storeRemoveMock.mockResolvedValueOnce(alphaProject);
+
+    await rejects(
+      async () => await projectRemoveHandler([alphaProject.id]),
+      /Exit with code 0/,
+    );
+
+    deepStrictEqual(storeRemoveMock.mock.calls[0], [alphaProject.id]);
+  });
+
+  it("removes a missing repository by its exact stored path", async () => {
+    storeListMock.mockResolvedValueOnce([alphaProject]);
+    storeRemoveMock.mockResolvedValueOnce(alphaProject);
+    realpathMock.mockRejectedValueOnce(new Error("Path does not exist"));
+
+    await rejects(
+      async () => await projectRemoveHandler([alphaProject.rootPath, "--json"]),
+      /Exit with code 0/,
+    );
+
+    strictEqual(realpathMock.mock.calls.length, 0);
+    deepStrictEqual(JSON.parse(outputLogMock.mock.calls[0][0]), {
+      status: "removed",
+      project: alphaProject,
+    });
+  });
+
+  it("canonicalizes an existing path before matching it", async () => {
+    storeListMock.mockResolvedValueOnce([alphaProject]);
+    realpathMock
+      .mockResolvedValueOnce("/repos/alpha/packages/cli")
+      .mockResolvedValueOnce("/repos/alpha");
+    getGitRootMock.mockResolvedValueOnce("/repos/alpha");
+    storeRemoveMock.mockResolvedValueOnce(alphaProject);
+
+    await rejects(
+      async () => await projectRemoveHandler(["./packages/cli"]),
+      /Exit with code 0/,
+    );
+
+    deepStrictEqual(storeRemoveMock.mock.calls[0], [alphaProject.id]);
+  });
+
+  it("requires an id or path when a name is ambiguous", async () => {
+    storeListMock.mockResolvedValueOnce([
+      alphaProject,
+      {
+        ...alphaProject,
+        id: "proj_00000000-0000-4000-8000-000000000004",
+        rootPath: "/other/alpha",
+      },
+    ]);
+
+    await rejects(
+      async () => await projectRemoveHandler(["alpha"]),
+      /Exit with code 3/,
+    );
+
+    strictEqual(
+      outputErrorMock.mock.calls[0][0],
+      "Project 'alpha' is ambiguous; use its id or path",
+    );
+    strictEqual(storeRemoveMock.mock.calls.length, 0);
+  });
+
+  it("returns not found for an unknown selector", async () => {
+    storeListMock.mockResolvedValueOnce([alphaProject]);
+    realpathMock.mockRejectedValueOnce(new Error("Path does not exist"));
+
+    await rejects(
+      async () => await projectRemoveHandler(["missing"]),
+      /Exit with code 2/,
+    );
+
+    strictEqual(
+      outputErrorMock.mock.calls[0][0],
+      "Project 'missing' not found",
+    );
+  });
+
+  it("reports unknown options as validation errors", async () => {
+    await rejects(
+      async () => await projectRemoveHandler(["alpha", "--unknown"]),
+      /Exit with code 3/,
+    );
+
+    strictEqual(exitMock.mock.calls[0][0], 3);
+    strictEqual(storeListMock.mock.calls.length, 0);
+  });
+});

--- a/packages/cli/src/handlers/project.ts
+++ b/packages/cli/src/handlers/project.ts
@@ -1,0 +1,11 @@
+import { projectHelp } from "../help/project.ts";
+import { helpFormatter } from "../help.ts";
+
+export async function projectHandler(args: string[]): Promise<void> {
+  if (args.length === 0) {
+    console.log(helpFormatter.formatCommandHelp(projectHelp));
+    return;
+  }
+
+  throw new Error(`Unknown project subcommand: ${args[0]}`);
+}

--- a/packages/cli/src/help/project.ts
+++ b/packages/cli/src/help/project.ts
@@ -1,0 +1,85 @@
+import type { CommandHelp } from "../help.ts";
+
+export const projectHelp: CommandHelp = {
+  name: "project",
+  description: "Manage registered Git projects",
+  usage: "phantom project <subcommand> [options]",
+  examples: [
+    {
+      description: "Register the current Git repository",
+      command: "phantom project add",
+    },
+    {
+      description: "List registered projects for an AI agent",
+      command: "phantom project list --json",
+    },
+    {
+      description: "Remove a project from the registry",
+      command:
+        "phantom project remove proj_550e8400-e29b-41d4-a716-446655440000",
+    },
+  ],
+  notes: [
+    "Available subcommands: add, list, remove",
+    "Removing a project only updates Phantom's registry; it never deletes the Git repository.",
+  ],
+};
+
+export const projectAddHelp: CommandHelp = {
+  name: "project add",
+  description: "Register a Git repository as a Phantom project",
+  usage: "phantom project add [path] [options]",
+  options: [
+    {
+      name: "json",
+      type: "boolean",
+      description: "Output the result as JSON",
+    },
+  ],
+  notes: [
+    "When path is omitted, the current directory is used.",
+    "Adding an already registered repository succeeds without creating a duplicate.",
+  ],
+};
+
+export const projectListHelp: CommandHelp = {
+  name: "project list",
+  description: "List registered Phantom projects",
+  usage: "phantom project list [options]",
+  options: [
+    {
+      name: "json",
+      type: "boolean",
+      description: "Output a versioned JSON object for automation",
+    },
+    {
+      name: "names",
+      type: "boolean",
+      description: "Output only project names",
+    },
+    {
+      name: "paths",
+      type: "boolean",
+      description: "Output only project root paths",
+    },
+  ],
+  notes: ["Only one output format option can be used at a time."],
+};
+
+export const projectRemoveHelp: CommandHelp = {
+  name: "project remove",
+  description: "Remove a Git project from Phantom's registry",
+  usage: "phantom project remove <id|name|path> [options]",
+  options: [
+    {
+      name: "json",
+      type: "boolean",
+      description: "Output the result as JSON",
+    },
+  ],
+  notes: [
+    "The project can be specified by id, name, or root path.",
+    "If a name matches multiple projects, use an id or path instead.",
+    "This command never deletes the Git repository or its worktrees.",
+  ],
+};

--- a/packages/cli/src/parse-args.ts
+++ b/packages/cli/src/parse-args.ts
@@ -1,0 +1,22 @@
+import { parseArgs, type ParseArgsConfig } from "node:util";
+import { exitCodes, exitWithError } from "./errors.ts";
+
+export function parseArgsOrExit<T extends ParseArgsConfig>(config: T) {
+  try {
+    return parseArgs(config);
+  } catch (error) {
+    if (isParseArgsError(error)) {
+      exitWithError(error.message, exitCodes.validationError);
+    }
+    throw error;
+  }
+}
+
+function isParseArgsError(error: unknown): error is Error & { code: string } {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    typeof error.code === "string" &&
+    error.code.startsWith("ERR_PARSE_ARGS_")
+  );
+}

--- a/packages/cli/src/test-utils/run-zsh-completion.ts
+++ b/packages/cli/src/test-utils/run-zsh-completion.ts
@@ -14,6 +14,7 @@ export const runZshCompletion = (
 ): ZshCompletionResult => {
   const resolvedCurrentWordIndex = Math.max(words.length - 1, 0);
   const wordList = createWordsList(words);
+  const argumentList = createWordsList(words.slice(1, -1));
   const buffer = words.join(" ");
 
   const command = `
@@ -24,8 +25,29 @@ compdef() {
 }
 
 _arguments() {
-  state="command"
-  line=(${wordList})
+  if [[ "$1" == "-C" ]]; then
+    if (( CURRENT <= 2 )); then
+      state="command"
+    else
+      state="args"
+    fi
+    line=(${argumentList})
+    return 0
+  fi
+
+  local spec option
+  for spec in "$@"; do
+    case "$spec" in
+      '1:subcommand:(add list remove)')
+        completions+=(add list remove)
+        ;;
+      --*|'('*--*)
+        option="\${spec%%\\[*}"
+        option="\${option##*)}"
+        completions+=("$option")
+        ;;
+    esac
+  done
   return 0
 }
 

--- a/packages/projects/package.json
+++ b/packages/projects/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@phantompane/projects",
+  "version": "6.3.0-10",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "scripts": {
+    "lint": "oxfmt --check . && oxlint .",
+    "fix": "oxfmt --write . && oxlint --fix .",
+    "typecheck": "tsgo --noEmit",
+    "test": "vitest run --root ../.. packages/projects/src"
+  },
+  "dependencies": {
+    "zod": "^4.4.3"
+  }
+}

--- a/packages/projects/src/index.ts
+++ b/packages/projects/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./store.ts";
+export * from "./types.ts";

--- a/packages/projects/src/store.test.ts
+++ b/packages/projects/src/store.test.ts
@@ -1,0 +1,431 @@
+import { deepStrictEqual, match, rejects, strictEqual } from "node:assert";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  utimes,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, it } from "vitest";
+import { getDefaultProjectsDataDir, ProjectRegistryStore } from "./store.ts";
+import { PROJECT_REGISTRY_VERSION } from "./types.ts";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+async function createTemporaryDirectory(): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), "phantom-projects-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+function createDeferred(): {
+  promise: Promise<void>;
+  resolve: () => void;
+} {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+describe("getDefaultProjectsDataDir", () => {
+  it("uses an absolute XDG state directory", () => {
+    strictEqual(
+      getDefaultProjectsDataDir(
+        { XDG_STATE_HOME: "/xdg/state" },
+        "/users/example",
+      ),
+      "/xdg/state/phantom",
+    );
+  });
+
+  it("uses the home fallback when XDG state is missing or relative", () => {
+    strictEqual(
+      getDefaultProjectsDataDir({}, "/users/example"),
+      "/users/example/.local/state/phantom",
+    );
+    strictEqual(
+      getDefaultProjectsDataDir(
+        { XDG_STATE_HOME: "relative/state" },
+        "/users/example",
+      ),
+      "/users/example/.local/state/phantom",
+    );
+  });
+});
+
+describe("ProjectRegistryStore", () => {
+  it("returns an empty registry when the file does not exist", async () => {
+    const dataDirectory = await createTemporaryDirectory();
+    const store = new ProjectRegistryStore(dataDirectory);
+
+    deepStrictEqual(await store.list(), []);
+  });
+
+  it("rejects malformed JSON, invalid shapes, and unsupported versions", async () => {
+    const dataDirectory = await createTemporaryDirectory();
+    const registryPath = join(dataDirectory, "projects.json");
+    const store = new ProjectRegistryStore(dataDirectory);
+
+    await writeFile(registryPath, "{broken");
+    await rejects(store.list(), /Projects registry contains invalid JSON/);
+
+    await writeFile(registryPath, '{"version":2,"projects":[]}');
+    await rejects(store.list(), /Unsupported projects registry version: 2/);
+
+    await writeFile(registryPath, '{"version":1,"projects":[{}]}');
+    await rejects(store.list(), /Projects registry has an invalid shape/);
+
+    const duplicate = {
+      version: 1,
+      projects: [
+        {
+          id: "proj_550e8400-e29b-41d4-a716-446655440000",
+          name: "phantom",
+          rootPath: "/work/phantom",
+          createdAt: "2026-07-20T00:00:00.000Z",
+        },
+        {
+          id: "proj_550e8400-e29b-41d4-a716-446655440000",
+          name: "other",
+          rootPath: "/work/other",
+          createdAt: "2026-07-20T00:00:00.000Z",
+        },
+      ],
+    };
+    await writeFile(registryPath, JSON.stringify(duplicate));
+    await rejects(store.list(), /Duplicate project id/);
+
+    const nonCanonicalPath = {
+      version: 1,
+      projects: [
+        {
+          ...duplicate.projects[0],
+          rootPath: "/work/client/../phantom",
+        },
+      ],
+    };
+    await writeFile(registryPath, JSON.stringify(nonCanonicalPath));
+    await rejects(store.list(), /Expected a canonical path/);
+
+    const mismatchedName = {
+      version: 1,
+      projects: [
+        {
+          ...duplicate.projects[0],
+          name: "other",
+        },
+      ],
+    };
+    await writeFile(registryPath, JSON.stringify(mismatchedName));
+    await rejects(store.list(), /Expected name to match/);
+  });
+
+  it("adds a versioned project record and writes it privately", async () => {
+    const dataDirectory = await createTemporaryDirectory();
+    const store = new ProjectRegistryStore(dataDirectory);
+
+    const result = await store.add("/work/phantom");
+
+    strictEqual(result.added, true);
+    match(
+      result.project.id,
+      /^proj_[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
+    strictEqual(result.project.name, "phantom");
+    strictEqual(result.project.rootPath, "/work/phantom");
+    match(result.project.createdAt, /^\d{4}-\d{2}-\d{2}T/);
+
+    const persisted = JSON.parse(
+      await readFile(join(dataDirectory, "projects.json"), "utf8"),
+    );
+    strictEqual(persisted.version, PROJECT_REGISTRY_VERSION);
+    deepStrictEqual(persisted.projects, [result.project]);
+
+    if (process.platform !== "win32") {
+      const registryStat = await stat(join(dataDirectory, "projects.json"));
+      strictEqual(registryStat.mode & 0o777, 0o600);
+    }
+  });
+
+  it("adds the same root path idempotently", async () => {
+    const dataDirectory = await createTemporaryDirectory();
+    const store = new ProjectRegistryStore(dataDirectory);
+
+    const first = await store.add("/work/phantom/");
+    const second = await store.add("/work/phantom");
+
+    strictEqual(first.added, true);
+    strictEqual(second.added, false);
+    strictEqual(second.project.id, first.project.id);
+    strictEqual(second.project.createdAt, first.project.createdAt);
+    deepStrictEqual(await store.list(), [first.project]);
+  });
+
+  it("allows projects with the same name at different paths", async () => {
+    const dataDirectory = await createTemporaryDirectory();
+    const store = new ProjectRegistryStore(dataDirectory);
+
+    const first = await store.add("/work/client/phantom");
+    const second = await store.add("/work/upstream/phantom");
+
+    strictEqual(first.project.name, "phantom");
+    strictEqual(second.project.name, "phantom");
+    strictEqual((await store.list()).length, 2);
+  });
+
+  it("requires an absolute, named project root", async () => {
+    const dataDirectory = await createTemporaryDirectory();
+    const store = new ProjectRegistryStore(dataDirectory);
+
+    await rejects(store.add("relative/repo"), /must be absolute/);
+    await rejects(store.add("/"), /must have a name/);
+  });
+
+  it("removes a project by id and reports a missing id", async () => {
+    const dataDirectory = await createTemporaryDirectory();
+    const store = new ProjectRegistryStore(dataDirectory);
+    const { project } = await store.add("/work/phantom");
+
+    deepStrictEqual(await store.remove(project.id), project);
+    strictEqual(await store.remove(project.id), null);
+    deepStrictEqual(await store.list(), []);
+  });
+
+  it("does not lose concurrent updates from separate store instances", async () => {
+    const dataDirectory = await createTemporaryDirectory();
+    const stores = Array.from(
+      { length: 12 },
+      () =>
+        new ProjectRegistryStore(dataDirectory, {
+          lockRetryMs: 1,
+          lockTimeoutMs: 2_000,
+        }),
+    );
+
+    await Promise.all(
+      stores.map((store, index) => store.add(`/work/project-${index}`)),
+    );
+
+    const projects = await stores[0]!.list();
+    strictEqual(projects.length, stores.length);
+    deepStrictEqual(
+      new Set(projects.map((project) => project.rootPath)),
+      new Set(stores.map((_, index) => `/work/project-${index}`)),
+    );
+  });
+
+  it("serializes concurrent add and remove operations", async () => {
+    const dataDirectory = await createTemporaryDirectory();
+    const firstStore = new ProjectRegistryStore(dataDirectory, {
+      lockRetryMs: 1,
+    });
+    const secondStore = new ProjectRegistryStore(dataDirectory, {
+      lockRetryMs: 1,
+    });
+    const existing = await firstStore.add("/work/existing");
+
+    await Promise.all([
+      firstStore.remove(existing.project.id),
+      secondStore.add("/work/new"),
+    ]);
+
+    const projects = await firstStore.list();
+    deepStrictEqual(
+      projects.map((project) => project.rootPath),
+      ["/work/new"],
+    );
+  });
+
+  it("recovers a stale lock owned by a dead process", async () => {
+    const dataDirectory = await createTemporaryDirectory();
+    const lockPath = join(dataDirectory, "projects.lock");
+    await mkdir(lockPath);
+    await writeFile(
+      join(lockPath, "owner.json"),
+      JSON.stringify({
+        token: "abandoned",
+        pid: 2_147_483_647,
+        createdAt: "2000-01-01T00:00:00.000Z",
+      }),
+    );
+    const oldTimestamp = new Date(Date.now() - 60_000);
+    await utimes(lockPath, oldTimestamp, oldTimestamp);
+
+    const store = new ProjectRegistryStore(dataDirectory, {
+      lockRetryMs: 1,
+      lockTimeoutMs: 200,
+      staleLockMs: 10,
+    });
+    const result = await store.add("/work/phantom");
+
+    strictEqual(result.added, true);
+    deepStrictEqual(await store.list(), [result.project]);
+  });
+
+  it("serializes multiple contenders recovering the same stale lock", async () => {
+    const dataDirectory = await createTemporaryDirectory();
+    const lockPath = join(dataDirectory, "projects.lock");
+    await mkdir(lockPath);
+    await writeFile(
+      join(lockPath, "owner.json"),
+      JSON.stringify({
+        token: "abandoned",
+        pid: 2_147_483_647,
+        createdAt: "2000-01-01T00:00:00.000Z",
+      }),
+    );
+    const oldTimestamp = new Date(Date.now() - 60_000);
+    await utimes(lockPath, oldTimestamp, oldTimestamp);
+
+    const options = {
+      lockRetryMs: 1,
+      lockTimeoutMs: 500,
+      staleLockMs: 10,
+    };
+    const firstStore = new ProjectRegistryStore(dataDirectory, options);
+    const secondStore = new ProjectRegistryStore(dataDirectory, options);
+
+    await Promise.all([
+      firstStore.add("/work/first"),
+      secondStore.add("/work/second"),
+    ]);
+
+    strictEqual((await firstStore.list()).length, 2);
+  });
+
+  it("fences a replacement lock during stale recovery", async () => {
+    const dataDirectory = await createTemporaryDirectory();
+    const lockPath = join(dataDirectory, "projects.lock");
+    await mkdir(lockPath);
+    await writeFile(
+      join(lockPath, "owner.json"),
+      JSON.stringify({
+        token: "abandoned",
+        pid: 2_147_483_647,
+        createdAt: "2000-01-01T00:00:00.000Z",
+      }),
+    );
+    const oldTimestamp = new Date(Date.now() - 60_000);
+    await utimes(lockPath, oldTimestamp, oldTimestamp);
+
+    const replacementPrechecked = createDeferred();
+    const allowReplacementAcquire = createDeferred();
+    const replacementAcquired = createDeferred();
+    const allowReplacementPostcheck = createDeferred();
+    const recoveryReady = createDeferred();
+    const allowRecovery = createDeferred();
+    let replacementAcquireCount = 0;
+    let replacementLockCount = 0;
+
+    const replacementStore = new ProjectRegistryStore(dataDirectory, {
+      lockRetryMs: 1,
+      lockTimeoutMs: 2_000,
+      staleLockMs: 10,
+      onBeforeLockAcquire: async () => {
+        if (replacementAcquireCount++ === 0) {
+          replacementPrechecked.resolve();
+          await allowReplacementAcquire.promise;
+        }
+      },
+      onLockAcquired: async () => {
+        if (replacementLockCount++ === 0) {
+          replacementAcquired.resolve();
+          await allowReplacementPostcheck.promise;
+        }
+      },
+    });
+    const recoveringStore = new ProjectRegistryStore(dataDirectory, {
+      lockRetryMs: 1,
+      lockTimeoutMs: 2_000,
+      staleLockMs: 10,
+      onBeforeStaleLockRemoval: async () => {
+        recoveryReady.resolve();
+        await allowRecovery.promise;
+      },
+    });
+
+    const replacementUpdate = replacementStore.add("/work/replacement");
+    await replacementPrechecked.promise;
+    const recoveryUpdate = recoveringStore.add("/work/recovery");
+    await recoveryReady.promise;
+
+    await rm(lockPath, { recursive: true, force: true });
+    allowReplacementAcquire.resolve();
+    await replacementAcquired.promise;
+    allowRecovery.resolve();
+    await recoveryUpdate;
+    allowReplacementPostcheck.resolve();
+    await replacementUpdate;
+
+    deepStrictEqual(
+      new Set(
+        (await recoveringStore.list()).map((project) => project.rootPath),
+      ),
+      new Set(["/work/recovery", "/work/replacement"]),
+    );
+  });
+
+  it("recovers a stale lock after its PID has been reused", async () => {
+    const dataDirectory = await createTemporaryDirectory();
+    const lockPath = join(dataDirectory, "projects.lock");
+    await mkdir(lockPath);
+    await writeFile(
+      join(lockPath, "owner.json"),
+      JSON.stringify({
+        token: "previous-process",
+        pid: process.pid,
+        createdAt: "2000-01-01T00:00:00.000Z",
+        processIdentity: "different-process-start",
+      }),
+    );
+    const oldTimestamp = new Date(Date.now() - 60_000);
+    await utimes(lockPath, oldTimestamp, oldTimestamp);
+
+    const store = new ProjectRegistryStore(dataDirectory, {
+      lockRetryMs: 1,
+      lockTimeoutMs: 500,
+      staleLockMs: 10,
+    });
+    const result = await store.add("/work/phantom");
+
+    strictEqual(result.added, true);
+  });
+
+  it("does not recover a stale-looking lock owned by a live process", async () => {
+    const dataDirectory = await createTemporaryDirectory();
+    const lockPath = join(dataDirectory, "projects.lock");
+    await mkdir(lockPath);
+    await writeFile(
+      join(lockPath, "owner.json"),
+      JSON.stringify({
+        token: "live",
+        pid: process.pid,
+        createdAt: "2000-01-01T00:00:00.000Z",
+      }),
+    );
+    const oldTimestamp = new Date(Date.now() - 60_000);
+    await utimes(lockPath, oldTimestamp, oldTimestamp);
+
+    const store = new ProjectRegistryStore(dataDirectory, {
+      lockRetryMs: 1,
+      lockTimeoutMs: 20,
+      staleLockMs: 10,
+    });
+
+    await rejects(store.add("/work/phantom"), /Timed out waiting/);
+  });
+});

--- a/packages/projects/src/store.ts
+++ b/packages/projects/src/store.ts
@@ -1,0 +1,655 @@
+import { execFile } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import {
+  mkdir,
+  open,
+  readdir,
+  readFile,
+  rename,
+  rm,
+  stat,
+  utimes,
+  writeFile,
+} from "node:fs/promises";
+import { homedir } from "node:os";
+import { basename, isAbsolute, join, resolve } from "node:path";
+import { promisify } from "node:util";
+import {
+  PROJECT_REGISTRY_VERSION,
+  projectRegistryStateSchema,
+  type ProjectRecord,
+  type ProjectRegistryState,
+} from "./types.ts";
+
+const REGISTRY_FILE_NAME = "projects.json";
+const LOCK_DIRECTORY_NAME = "projects.lock";
+const LOCK_OWNER_FILE_NAME = "owner.json";
+const LOCK_RECOVERY_DIRECTORY_NAME = "projects.lock.recovery";
+const DEFAULT_LOCK_TIMEOUT_MS = 5_000;
+const DEFAULT_LOCK_RETRY_MS = 20;
+const DEFAULT_STALE_LOCK_MS = 30_000;
+const execFileAsync = promisify(execFile);
+
+interface LockOwner {
+  token: string;
+  pid: number;
+  createdAt: string;
+  processIdentity: string | null;
+}
+
+export interface ProjectRegistryStoreOptions {
+  lockTimeoutMs?: number;
+  lockRetryMs?: number;
+  staleLockMs?: number;
+  /** @internal Synchronizes lock-race regression tests. */
+  onLockAcquired?: () => void | Promise<void>;
+  /** @internal Synchronizes lock-race regression tests. */
+  onBeforeLockAcquire?: () => void | Promise<void>;
+  /** @internal Synchronizes stale-recovery regression tests. */
+  onBeforeStaleLockRemoval?: () => void | Promise<void>;
+}
+
+export class ProjectRegistryError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "ProjectRegistryError";
+  }
+}
+
+export function getDefaultProjectsDataDir(
+  env: NodeJS.ProcessEnv = process.env,
+  userHome = homedir(),
+): string {
+  const stateHome = env.XDG_STATE_HOME;
+  const baseStateDirectory =
+    stateHome && isAbsolute(stateHome)
+      ? stateHome
+      : join(userHome, ".local", "state");
+  return join(baseStateDirectory, "phantom");
+}
+
+export class ProjectRegistryStore {
+  private readonly dataDir: string;
+  private readonly lockRetryMs: number;
+  private readonly lockTimeoutMs: number;
+  private readonly onBeforeLockAcquire?: () => void | Promise<void>;
+  private readonly onBeforeStaleLockRemoval?: () => void | Promise<void>;
+  private readonly onLockAcquired?: () => void | Promise<void>;
+  private readonly staleLockMs: number;
+
+  constructor(
+    dataDir = getDefaultProjectsDataDir(),
+    options: ProjectRegistryStoreOptions = {},
+  ) {
+    this.dataDir = dataDir;
+    this.lockTimeoutMs = options.lockTimeoutMs ?? DEFAULT_LOCK_TIMEOUT_MS;
+    this.lockRetryMs = options.lockRetryMs ?? DEFAULT_LOCK_RETRY_MS;
+    this.staleLockMs = options.staleLockMs ?? DEFAULT_STALE_LOCK_MS;
+    this.onLockAcquired = options.onLockAcquired;
+    this.onBeforeLockAcquire = options.onBeforeLockAcquire;
+    this.onBeforeStaleLockRemoval = options.onBeforeStaleLockRemoval;
+  }
+
+  async list(): Promise<ProjectRecord[]> {
+    const state = await this.load();
+    return state.projects.map((project) => ({ ...project }));
+  }
+
+  async add(
+    rootPath: string,
+  ): Promise<{ project: ProjectRecord; added: boolean }> {
+    const normalizedRootPath = normalizeRootPath(rootPath);
+    let result: { project: ProjectRecord; added: boolean } | undefined;
+
+    await this.update((state) => {
+      const existingProject = state.projects.find(
+        (project) => project.rootPath === normalizedRootPath,
+      );
+      if (existingProject) {
+        result = { project: existingProject, added: false };
+        return state;
+      }
+
+      const project: ProjectRecord = {
+        id: `proj_${randomUUID()}`,
+        name: basename(normalizedRootPath),
+        rootPath: normalizedRootPath,
+        createdAt: new Date().toISOString(),
+      };
+      result = { project, added: true };
+      return {
+        ...state,
+        projects: [...state.projects, project],
+      };
+    });
+
+    return result!;
+  }
+
+  async remove(id: string): Promise<ProjectRecord | null> {
+    let removedProject: ProjectRecord | null = null;
+
+    await this.update((state) => {
+      const project = state.projects.find((candidate) => candidate.id === id);
+      if (!project) {
+        return state;
+      }
+
+      removedProject = project;
+      return {
+        ...state,
+        projects: state.projects.filter((candidate) => candidate.id !== id),
+      };
+    });
+
+    return removedProject;
+  }
+
+  private async load(): Promise<ProjectRegistryState> {
+    const registryPath = join(this.dataDir, REGISTRY_FILE_NAME);
+    let content: string;
+    try {
+      content = await readFile(registryPath, "utf8");
+    } catch (error) {
+      if (hasErrorCode(error, "ENOENT")) {
+        return createEmptyRegistry();
+      }
+      throw error;
+    }
+
+    let value: unknown;
+    try {
+      value = JSON.parse(content);
+    } catch (error) {
+      throw new ProjectRegistryError(
+        "Projects registry contains invalid JSON",
+        {
+          cause: error,
+        },
+      );
+    }
+
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      throw new ProjectRegistryError("Projects registry is not a JSON object");
+    }
+
+    const version = (value as Record<string, unknown>).version;
+    if (version !== PROJECT_REGISTRY_VERSION) {
+      throw new ProjectRegistryError(
+        `Unsupported projects registry version: ${String(version)}`,
+      );
+    }
+
+    const parsed = projectRegistryStateSchema.safeParse(value);
+    if (!parsed.success) {
+      const issue = parsed.error.issues[0];
+      const location = issue?.path.length ? ` at ${issue.path.join(".")}` : "";
+      throw new ProjectRegistryError(
+        `Projects registry has an invalid shape${location}: ${issue?.message ?? parsed.error.message}`,
+      );
+    }
+
+    return parsed.data;
+  }
+
+  private async update(
+    updater: (
+      state: ProjectRegistryState,
+    ) => ProjectRegistryState | Promise<ProjectRegistryState>,
+  ): Promise<void> {
+    await this.withLock(async () => {
+      const currentState = await this.load();
+      const nextState = await updater({
+        ...currentState,
+        projects: currentState.projects.map((project) => ({ ...project })),
+      });
+      const parsed = projectRegistryStateSchema.safeParse(nextState);
+      if (!parsed.success) {
+        throw new ProjectRegistryError(
+          `Refusing to save an invalid projects registry: ${parsed.error.message}`,
+        );
+      }
+      await this.save(parsed.data);
+    });
+  }
+
+  private async save(state: ProjectRegistryState): Promise<void> {
+    await mkdir(this.dataDir, { recursive: true, mode: 0o700 });
+    const registryPath = join(this.dataDir, REGISTRY_FILE_NAME);
+    const temporaryPath = join(
+      this.dataDir,
+      `.${REGISTRY_FILE_NAME}.tmp-${process.pid}-${randomUUID()}`,
+    );
+    let temporaryFile: Awaited<ReturnType<typeof open>> | undefined;
+
+    try {
+      temporaryFile = await open(temporaryPath, "wx", 0o600);
+      await temporaryFile.writeFile(`${JSON.stringify(state, null, 2)}\n`);
+      await temporaryFile.sync();
+      await temporaryFile.close();
+      temporaryFile = undefined;
+      await rename(temporaryPath, registryPath);
+      await syncDirectory(this.dataDir);
+    } finally {
+      await temporaryFile?.close().catch(() => undefined);
+      await rm(temporaryPath, { force: true }).catch(() => undefined);
+    }
+  }
+
+  private async withLock<T>(operation: () => Promise<T>): Promise<T> {
+    await mkdir(this.dataDir, { recursive: true, mode: 0o700 });
+    const lockPath = join(this.dataDir, LOCK_DIRECTORY_NAME);
+    const recoveryDirectoryPath = join(
+      this.dataDir,
+      LOCK_RECOVERY_DIRECTORY_NAME,
+    );
+    const deadline = Date.now() + this.lockTimeoutMs;
+    let owner: LockOwner | undefined;
+
+    while (true) {
+      if (await this.hasActiveRecoveryMarkers(recoveryDirectoryPath)) {
+        await this.waitForLock(deadline, lockPath, recoveryDirectoryPath);
+        continue;
+      }
+
+      await this.onBeforeLockAcquire?.();
+      const candidate = await createLockOwner();
+      try {
+        await mkdir(lockPath, { mode: 0o700 });
+        try {
+          await writeFile(
+            join(lockPath, LOCK_OWNER_FILE_NAME),
+            `${JSON.stringify(candidate)}\n`,
+            { flag: "wx", mode: 0o600 },
+          );
+        } catch (error) {
+          await this.releaseMainLock(
+            lockPath,
+            candidate.token,
+            recoveryDirectoryPath,
+          );
+          throw error;
+        }
+      } catch (error) {
+        if (!hasErrorCode(error, "EEXIST")) {
+          throw error;
+        }
+
+        if (await this.recoverStaleLock(lockPath, recoveryDirectoryPath)) {
+          continue;
+        }
+        await this.waitForLock(deadline, lockPath, recoveryDirectoryPath);
+        continue;
+      }
+
+      try {
+        await this.onLockAcquired?.();
+      } catch (error) {
+        await this.releaseMainLock(
+          lockPath,
+          candidate.token,
+          recoveryDirectoryPath,
+        );
+        throw error;
+      }
+
+      const recoveryIsActive = await this.hasActiveRecoveryMarkers(
+        recoveryDirectoryPath,
+      );
+      const stillOwnsLock = await isDirectoryOwnedBy(lockPath, candidate.token);
+      if (recoveryIsActive || !stillOwnsLock) {
+        if (stillOwnsLock) {
+          await this.releaseMainLock(
+            lockPath,
+            candidate.token,
+            recoveryDirectoryPath,
+          );
+        }
+        await this.waitForLock(deadline, lockPath, recoveryDirectoryPath);
+        continue;
+      }
+
+      owner = candidate;
+      break;
+    }
+
+    const heartbeat = setInterval(
+      () => {
+        const timestamp = new Date();
+        void utimes(lockPath, timestamp, timestamp).catch(() => undefined);
+      },
+      Math.max(10, Math.floor(this.staleLockMs / 3)),
+    );
+    heartbeat.unref();
+
+    try {
+      return await operation();
+    } finally {
+      clearInterval(heartbeat);
+      await this.releaseMainLock(lockPath, owner.token, recoveryDirectoryPath);
+    }
+  }
+
+  private async recoverStaleLock(
+    lockPath: string,
+    recoveryDirectoryPath: string,
+  ): Promise<boolean> {
+    try {
+      const initialLockStat = await stat(lockPath);
+      if (Date.now() - initialLockStat.mtimeMs <= this.staleLockMs) {
+        return false;
+      }
+    } catch (error) {
+      if (hasErrorCode(error, "ENOENT")) {
+        return true;
+      }
+      throw error;
+    }
+
+    const recoveryOwner = await createLockOwner();
+    const recoveryMarkerPath = join(recoveryDirectoryPath, recoveryOwner.token);
+
+    await mkdir(recoveryDirectoryPath, { recursive: true, mode: 0o700 });
+    await mkdir(recoveryMarkerPath, { mode: 0o700 });
+    try {
+      await writeFile(
+        join(recoveryMarkerPath, LOCK_OWNER_FILE_NAME),
+        `${JSON.stringify(recoveryOwner)}\n`,
+        { flag: "wx", mode: 0o600 },
+      );
+    } catch (error) {
+      await rm(recoveryMarkerPath, { recursive: true, force: true });
+      throw error;
+    }
+
+    try {
+      return await this.recoverStaleLockWithMarker(
+        lockPath,
+        recoveryMarkerPath,
+        recoveryOwner.token,
+      );
+    } finally {
+      await releaseOwnedDirectory(recoveryMarkerPath, recoveryOwner.token);
+    }
+  }
+
+  private async recoverStaleLockWithMarker(
+    lockPath: string,
+    recoveryMarkerPath: string,
+    recoveryToken: string,
+  ): Promise<boolean> {
+    let lockStat;
+    try {
+      lockStat = await stat(lockPath);
+    } catch (error) {
+      if (hasErrorCode(error, "ENOENT")) {
+        return true;
+      }
+      throw error;
+    }
+
+    if (Date.now() - lockStat.mtimeMs <= this.staleLockMs) {
+      return false;
+    }
+
+    const owner = await readLockOwner(lockPath);
+    if (owner && (await isLockOwnerAlive(owner))) {
+      return false;
+    }
+
+    await this.onBeforeStaleLockRemoval?.();
+    if (!(await isDirectoryOwnedBy(recoveryMarkerPath, recoveryToken))) {
+      return false;
+    }
+
+    const stalePath = `${lockPath}.stale-${randomUUID()}`;
+    try {
+      await rename(lockPath, stalePath);
+    } catch (error) {
+      if (hasErrorCode(error, "ENOENT")) {
+        return true;
+      }
+      throw error;
+    }
+    await rm(stalePath, { recursive: true, force: true });
+    return true;
+  }
+
+  private async hasActiveRecoveryMarkers(
+    recoveryDirectoryPath: string,
+  ): Promise<boolean> {
+    await mkdir(recoveryDirectoryPath, { recursive: true, mode: 0o700 });
+    const entries = await readdir(recoveryDirectoryPath, {
+      withFileTypes: true,
+    });
+
+    for (const entry of entries) {
+      const markerPath = join(recoveryDirectoryPath, entry.name);
+      let markerStat;
+      try {
+        markerStat = await stat(markerPath);
+      } catch (error) {
+        if (hasErrorCode(error, "ENOENT")) {
+          continue;
+        }
+        throw error;
+      }
+
+      if (Date.now() - markerStat.mtimeMs <= this.staleLockMs) {
+        return true;
+      }
+
+      const markerOwner = entry.isDirectory()
+        ? await readLockOwner(markerPath)
+        : null;
+      if (markerOwner && (await isLockOwnerAlive(markerOwner))) {
+        return true;
+      }
+
+      await rm(markerPath, { recursive: true, force: true });
+    }
+
+    return (await readdir(recoveryDirectoryPath)).length > 0;
+  }
+
+  private async releaseMainLock(
+    lockPath: string,
+    lockToken: string,
+    recoveryDirectoryPath: string,
+  ): Promise<void> {
+    const releaseOwner = await createLockOwner();
+    const releaseMarkerPath = join(recoveryDirectoryPath, releaseOwner.token);
+
+    await mkdir(recoveryDirectoryPath, { recursive: true, mode: 0o700 });
+    await mkdir(releaseMarkerPath, { mode: 0o700 });
+    try {
+      await writeFile(
+        join(releaseMarkerPath, LOCK_OWNER_FILE_NAME),
+        `${JSON.stringify(releaseOwner)}\n`,
+        { flag: "wx", mode: 0o600 },
+      );
+
+      if (await isDirectoryOwnedBy(lockPath, lockToken)) {
+        await rm(lockPath, { recursive: true, force: true });
+      }
+    } finally {
+      await releaseOwnedDirectory(releaseMarkerPath, releaseOwner.token);
+    }
+  }
+
+  private async waitForLock(
+    deadline: number,
+    lockPath: string,
+    recoveryDirectoryPath: string,
+  ): Promise<void> {
+    if (Date.now() >= deadline) {
+      throw new ProjectRegistryError(
+        `Timed out waiting for projects registry lock at ${lockPath}. ` +
+          `Inspect ${recoveryDirectoryPath} for abandoned recovery markers.`,
+      );
+    }
+    await delay(this.lockRetryMs);
+  }
+}
+
+function createEmptyRegistry(): ProjectRegistryState {
+  return {
+    version: PROJECT_REGISTRY_VERSION,
+    projects: [],
+  };
+}
+
+function normalizeRootPath(rootPath: string): string {
+  if (!isAbsolute(rootPath)) {
+    throw new ProjectRegistryError("Project root path must be absolute");
+  }
+  const normalizedRootPath = resolve(rootPath);
+  if (!basename(normalizedRootPath)) {
+    throw new ProjectRegistryError("Project root path must have a name");
+  }
+  return normalizedRootPath;
+}
+
+async function createLockOwner(): Promise<LockOwner> {
+  return {
+    token: randomUUID(),
+    pid: process.pid,
+    createdAt: new Date().toISOString(),
+    processIdentity: await currentProcessIdentity,
+  };
+}
+
+async function readLockOwner(lockPath: string): Promise<LockOwner | null> {
+  try {
+    const value: unknown = JSON.parse(
+      await readFile(join(lockPath, LOCK_OWNER_FILE_NAME), "utf8"),
+    );
+    if (
+      !value ||
+      typeof value !== "object" ||
+      typeof (value as LockOwner).token !== "string" ||
+      !Number.isSafeInteger((value as LockOwner).pid) ||
+      (value as LockOwner).pid <= 0 ||
+      typeof (value as LockOwner).createdAt !== "string" ||
+      !(
+        (value as Partial<LockOwner>).processIdentity === undefined ||
+        (value as Partial<LockOwner>).processIdentity === null ||
+        typeof (value as Partial<LockOwner>).processIdentity === "string"
+      )
+    ) {
+      return null;
+    }
+    return {
+      ...(value as LockOwner),
+      processIdentity: (value as Partial<LockOwner>).processIdentity ?? null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function isLockOwnerAlive(owner: LockOwner): Promise<boolean> {
+  if (!isProcessAlive(owner.pid)) {
+    return false;
+  }
+  if (!owner.processIdentity) {
+    return true;
+  }
+
+  const identity = await readProcessIdentity(owner.pid);
+  return identity === null || identity === owner.processIdentity;
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return hasErrorCode(error, "EPERM");
+  }
+}
+
+async function readProcessIdentity(pid: number): Promise<string | null> {
+  if (!Number.isSafeInteger(pid) || pid <= 0) {
+    return null;
+  }
+
+  if (process.platform === "linux") {
+    try {
+      const processStat = await readFile(`/proc/${pid}/stat`, "utf8");
+      const commandEnd = processStat.lastIndexOf(")");
+      if (commandEnd !== -1) {
+        const fields = processStat
+          .slice(commandEnd + 1)
+          .trim()
+          .split(/\s+/);
+        const startTime = fields[19];
+        if (startTime) {
+          return `linux:${startTime}`;
+        }
+      }
+    } catch {
+      return null;
+    }
+  }
+
+  try {
+    const { stdout } = await execFileAsync(
+      "ps",
+      ["-o", "lstart=", "-p", String(pid)],
+      {
+        encoding: "utf8",
+        env: { ...process.env, LC_ALL: "C" },
+      },
+    );
+    const startTime = stdout.trim();
+    return startTime ? `${process.platform}:${startTime}` : null;
+  } catch {
+    return null;
+  }
+}
+
+async function isDirectoryOwnedBy(
+  directoryPath: string,
+  token: string,
+): Promise<boolean> {
+  return (await readLockOwner(directoryPath))?.token === token;
+}
+
+async function releaseOwnedDirectory(
+  directoryPath: string,
+  token: string,
+): Promise<void> {
+  if (!(await isDirectoryOwnedBy(directoryPath, token))) {
+    return;
+  }
+  await rm(directoryPath, { recursive: true, force: true });
+}
+
+async function syncDirectory(directoryPath: string): Promise<void> {
+  const directory = await open(directoryPath, "r");
+  try {
+    await directory.sync();
+  } catch (error) {
+    if (!hasErrorCode(error, "EINVAL") && !hasErrorCode(error, "ENOTSUP")) {
+      throw error;
+    }
+  } finally {
+    await directory.close();
+  }
+}
+
+function hasErrorCode(error: unknown, code: string): boolean {
+  return (
+    error !== null &&
+    typeof error === "object" &&
+    "code" in error &&
+    error.code === code
+  );
+}
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+const currentProcessIdentity = readProcessIdentity(process.pid);

--- a/packages/projects/src/types.ts
+++ b/packages/projects/src/types.ts
@@ -1,0 +1,80 @@
+import { basename, isAbsolute, resolve } from "node:path";
+import { z } from "zod";
+
+export const PROJECT_REGISTRY_VERSION = 1 as const;
+
+const isoTimestampSchema = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/)
+  .refine(
+    (value) =>
+      !Number.isNaN(Date.parse(value)) &&
+      new Date(value).toISOString() === value,
+    "Expected a valid ISO timestamp",
+  );
+
+export const projectRecordSchema = z
+  .object({
+    id: z
+      .string()
+      .regex(
+        /^proj_[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+      ),
+    name: z.string().min(1),
+    rootPath: z
+      .string()
+      .min(1)
+      .refine(isAbsolute, "Expected an absolute path")
+      .refine(
+        (rootPath) => resolve(rootPath) === rootPath,
+        "Expected a canonical path",
+      )
+      .refine(
+        (rootPath) => basename(rootPath).length > 0,
+        "Expected a named path",
+      ),
+    createdAt: isoTimestampSchema,
+  })
+  .strict()
+  .superRefine((project, context) => {
+    if (project.name !== basename(project.rootPath)) {
+      context.addIssue({
+        code: "custom",
+        path: ["name"],
+        message: "Expected name to match the root path basename",
+      });
+    }
+  });
+
+export const projectRegistryStateSchema = z
+  .object({
+    version: z.literal(PROJECT_REGISTRY_VERSION),
+    projects: z.array(projectRecordSchema),
+  })
+  .strict()
+  .superRefine((state, context) => {
+    const ids = new Set<string>();
+    const rootPaths = new Set<string>();
+
+    for (const [index, project] of state.projects.entries()) {
+      if (ids.has(project.id)) {
+        context.addIssue({
+          code: "custom",
+          path: ["projects", index, "id"],
+          message: "Duplicate project id",
+        });
+      }
+      if (rootPaths.has(project.rootPath)) {
+        context.addIssue({
+          code: "custom",
+          path: ["projects", index, "rootPath"],
+          message: "Duplicate project root path",
+        });
+      }
+      ids.add(project.id);
+      rootPaths.add(project.rootPath);
+    }
+  });
+
+export type ProjectRecord = z.infer<typeof projectRecordSchema>;
+export type ProjectRegistryState = z.infer<typeof projectRegistryStateSchema>;

--- a/packages/projects/tsconfig.json
+++ b/packages/projects/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       '@phantompane/process':
         specifier: workspace:*
         version: link:../process
+      '@phantompane/projects':
+        specifier: workspace:*
+        version: link:../projects
       '@phantompane/tmux':
         specifier: workspace:*
         version: link:../tmux
@@ -161,6 +164,12 @@ importers:
       '@phantompane/utils':
         specifier: workspace:*
         version: link:../utils
+
+  packages/projects:
+    dependencies:
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
 
   packages/tmux:
     dependencies:


### PR DESCRIPTION
## Summary

- add a versioned global project registry backed by `$XDG_STATE_HOME/phantom/projects.json` or the XDG-compatible home fallback
- add `phantom project add`, `phantom project list`, and `phantom project remove` with human-readable and agent-friendly JSON output
- canonicalize linked worktrees to their common Git repository so repeated registration is idempotent
- add atomic, concurrency-safe persistence with stale-lock recovery and schema validation
- add Bash, Zsh, and Fish completions, command documentation, unit tests, and E2E coverage

## Why

Phantom needs a native repository inventory before agents can autonomously create and manage worktrees across projects. This restores project management as an independent CLI capability after the experimental Web state was removed, without bringing back the Web UI or chat integration.

## Behavior and safety

- adding the same Git repository or any of its linked worktrees returns the existing project
- repositories with the same directory name remain distinct and can be addressed by ID or path
- list output is deterministic; `--json`, `--names`, and `--paths` are mutually exclusive
- removing a project deletes only its registry record and never deletes the repository, branch, or worktrees
- registry writes are validated, fsynced, atomically renamed, and protected against concurrent-process lost updates

## Scope

ghq discovery is intentionally not included in this pull request. It will be designed as a separate, configurable project source that feeds the same canonical registry model.

## Versioning

No existing package version was changed in this pull request. The new internal package starts at the current workspace version; future version updates remain owned by the GitHub Actions version-bump workflow.

## Validation

- `pnpm install --frozen-lockfile --offline`
- `pnpm ready` (35/35 tasks)
- CLI unit tests (129/129)
- project registry tests (16/16)
- `pnpm build --force`
- Bash completion tests (9/9)
- Zsh completion tests (6/6)
- Fish completion tests (8/8)
- packaged CLI smoke test for project add/list/remove
- linked-worktree registration smoke test
- independent 100-process concurrent-add stress test retained all 100 unique projects
- three focused implementation reviews found no remaining Must or Should issues

## Environment note

The local nested Codex environment drops stdout and stderr from child CLI processes, which also breaks the existing E2E output assertions. The new E2E test is included for GitHub Actions; locally, the built and packaged CLI completed the equivalent add/list/remove flow successfully.
