### PR TITLE
feat: discover ghq projects

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -343,7 +343,7 @@ phantom ai feature-auth
 
 ## Project Registry
 
-Phantom maintains an independent, global registry of Git repositories. It is available from any directory, so people and AI agents can find projects before choosing where to work.
+Phantom maintains an independent, global registry of Git repositories. It is available from any directory, so people and AI agents can find projects before choosing where to work. When [ghq](https://github.com/x-motemen/ghq) is installed, Phantom also discovers repositories managed by ghq by default.
 
 The registry is stored at `$XDG_STATE_HOME/phantom/projects.json` when `XDG_STATE_HOME` is an absolute path. If it is unset or relative, Phantom uses `~/.local/state/phantom/projects.json`.
 
@@ -390,7 +390,7 @@ JSON output reports whether the project was newly added or already registered:
 
 ### project list
 
-List registered projects. Projects are sorted by name, then by root path.
+List registered projects and repositories discovered through ghq. Projects are sorted by name, then by root path. A repository present in both sources appears once, with the explicit Phantom registry record taking precedence.
 
 ```bash
 phantom project list [options]
@@ -398,7 +398,7 @@ phantom project list [options]
 
 **Options:**
 
-- `--json` - Output the versioned registry as JSON
+- `--json` - Output the versioned project catalog as JSON
 - `--names` - Output only project names, one per line
 - `--paths` - Output only project root paths, one per line
 
@@ -407,7 +407,7 @@ The output options are mutually exclusive.
 **Examples:**
 
 ```bash
-# Show each project's name, root path, and id
+# Show each project's name, root path, and source
 phantom project list
 
 # Print paths for a shell script
@@ -419,17 +419,25 @@ phantom project list --json
 
 ```json
 {
-  "version": 1,
+  "version": 2,
   "projects": [
     {
       "id": "proj_550e8400-e29b-41d4-a716-446655440000",
       "name": "example",
       "rootPath": "/home/user/src/example",
-      "createdAt": "2026-07-20T12:00:00.000Z"
+      "createdAt": "2026-07-20T12:00:00.000Z",
+      "source": "registry"
+    },
+    {
+      "source": "ghq",
+      "name": "another-project",
+      "rootPath": "/home/user/repo/github.com/example/another-project"
     }
   ]
 }
 ```
+
+ghq is optional. If its executable is not installed, `project list` returns the registered projects without an error. If ghq is installed but discovery fails, `project list` still exits successfully and returns the native registry entries; it writes a warning only to stderr, so `--json` stdout remains a valid version 2 project catalog. Set `phantom.ghqDiscovery` to `false` to disable ghq discovery explicitly.
 
 ### project remove
 
@@ -465,7 +473,7 @@ phantom project remove proj_550e8400-e29b-41d4-a716-446655440000 --json
 }
 ```
 
-Removing a project only removes its registry record. It does not delete the Git repository, branches, or worktrees.
+Removing a project only removes its registry record. It does not delete the Git repository, branches, or worktrees. If the same repository is managed by ghq, it remains visible as a discovered project.
 
 ## Preferences
 
@@ -476,6 +484,7 @@ Configure defaults for Phantom commands using global git config. Preferences are
 - `worktreesDirectory` - where to store worktrees (relative to the Git repository root; defaults to `.git/phantom/worktrees`)
 - `directoryNameSeparator` - replaces `/` in worktree directory names only (defaults to `/`, which keeps nested directories)
 - `keepBranch` - keeps the branch when deleting a worktree (defaults to `false`)
+- `ghqDiscovery` - discovers ghq-managed repositories as projects (defaults to `true`)
 
 Set them once to avoid exporting environment variables each time.
 
@@ -489,6 +498,7 @@ phantom preferences get ai
 phantom preferences get worktreesDirectory
 phantom preferences get directoryNameSeparator
 phantom preferences get keepBranch
+phantom preferences get ghqDiscovery
 ```
 
 ### preferences set
@@ -510,6 +520,9 @@ phantom preferences set directoryNameSeparator "-"
 
 # Keep branches when deleting worktrees by default
 phantom preferences set keepBranch true
+
+# List only projects explicitly registered with Phantom
+phantom preferences set ghqDiscovery false
 ```
 
 ### preferences remove
@@ -522,6 +535,7 @@ phantom preferences remove ai
 phantom preferences remove worktreesDirectory
 phantom preferences remove directoryNameSeparator
 phantom preferences remove keepBranch
+phantom preferences remove ghqDiscovery
 ```
 
 **Notes:**
@@ -531,6 +545,7 @@ phantom preferences remove keepBranch
 - `worktreesDirectory` should be set relative to the Git repository root (default: `.git/phantom/worktrees`)
 - `directoryNameSeparator` only changes the directory path; the worktree/branch name remains unchanged
 - `keepBranch` accepts `true` or `false` and applies to both `phantom delete` and MCP delete requests when the request omits an explicit override
+- `ghqDiscovery` accepts `true` or `false`; removing it restores the default of enabling discovery
 
 ## GitHub Integration
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -225,6 +225,7 @@ Use `phantom preferences` for per-user defaults stored in `git config --global` 
 - `worktreesDirectory`: Personal default worktree directory relative to the Git repository root
 - `directoryNameSeparator`: Personal default separator for flattening worktree directory names on disk
 - `keepBranch`: Keep branches by default when deleting worktrees through `phantom delete` or MCP
+- `ghqDiscovery`: Discover ghq-managed repositories in `phantom project list` (defaults to `true`)
 
 ### `keepBranch`
 
@@ -247,6 +248,20 @@ phantom preferences remove keepBranch
 
 - Valid values are `true` and `false`
 - CLI and MCP delete operations both use this preference when no explicit `keepBranch` override is provided
+
+### `ghqDiscovery`
+
+When [ghq](https://github.com/x-motemen/ghq) is installed, `phantom project list` discovers its repositories automatically. The native Phantom registry remains independent, and an explicitly registered repository takes precedence when the same Git root is also returned by ghq.
+
+```bash
+# Disable ghq project discovery
+phantom preferences set ghqDiscovery false
+
+# Restore the default behavior
+phantom preferences remove ghqDiscovery
+```
+
+If ghq is not installed, project listing continues with Phantom's native registry without an error. If ghq is installed but discovery fails, project listing is a partial success: the command exits successfully, returns native registry entries, and writes a warning only to stderr. In `--json` mode, stdout remains a valid version 2 project catalog.
 
 ### preDelete.commands
 

--- a/e2e/src/project.test.ts
+++ b/e2e/src/project.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert";
-import { join } from "node:path";
+import { chmod, mkdir, writeFile } from "node:fs/promises";
+import { delimiter, join } from "node:path";
 import { afterEach, beforeEach, it } from "vitest";
 import {
   describeE2E,
@@ -31,6 +32,20 @@ describeE2E("phantom project e2e", () => {
       ...repo.env,
       XDG_STATE_HOME: join(repo.rootDir, "state"),
     };
+    const disableDiscoveryResult = await runCommand(
+      "git",
+      ["config", "--global", "phantom.ghqDiscovery", "false"],
+      {
+        cwd: repo.rootDir,
+        env: projectEnv,
+      },
+    );
+    assert.strictEqual(
+      disableDiscoveryResult.exitCode,
+      0,
+      disableDiscoveryResult.stderr,
+    );
+
     const addResult = await runCommand(
       "phantom",
       ["project", "add", repo.repoDir, "--json"],
@@ -87,8 +102,8 @@ describeE2E("phantom project e2e", () => {
 
     assert.strictEqual(listResult.exitCode, 0, listResult.stderr);
     assert.deepStrictEqual(JSON.parse(listResult.stdout), {
-      version: 1,
-      projects: [added.project],
+      version: 2,
+      projects: [{ ...added.project, source: "registry" }],
     });
 
     const removeResult = await runCommand(
@@ -116,7 +131,7 @@ describeE2E("phantom project e2e", () => {
     );
     assert.strictEqual(emptyListResult.exitCode, 0, emptyListResult.stderr);
     assert.deepStrictEqual(JSON.parse(emptyListResult.stdout), {
-      version: 1,
+      version: 2,
       projects: [],
     });
 
@@ -131,4 +146,134 @@ describeE2E("phantom project e2e", () => {
     assert.strictEqual(gitResult.exitCode, 0, gitResult.stderr);
     assert.strictEqual(gitResult.stdout, "true");
   });
+
+  it.skipIf(process.platform === "win32")(
+    "discovers ghq projects by default and allows disabling discovery",
+    async () => {
+      const binDirectory = join(repo.rootDir, "bin");
+      const ghqPath = join(binDirectory, "ghq");
+      await mkdir(binDirectory, { recursive: true });
+      await writeFile(
+        ghqPath,
+        [
+          "#!/bin/sh",
+          'if [ "$1" != "list" ] || [ "$2" != "--full-path" ]; then',
+          "  exit 2",
+          "fi",
+          'printf "%s\\n" "$PHANTOM_TEST_GHQ_PROJECT"',
+          "",
+        ].join("\n"),
+      );
+      await chmod(ghqPath, 0o755);
+
+      const projectEnv = {
+        ...repo.env,
+        PATH: `${binDirectory}${delimiter}${repo.env.PATH ?? ""}`,
+        PHANTOM_TEST_GHQ_PROJECT: repo.repoDir,
+        XDG_STATE_HOME: join(repo.rootDir, "state"),
+      };
+      const discoveredList = await runCommand(
+        "phantom",
+        ["project", "list", "--json"],
+        {
+          cwd: repo.rootDir,
+          env: projectEnv,
+        },
+      );
+
+      assert.strictEqual(discoveredList.exitCode, 0, discoveredList.stderr);
+      assert.deepStrictEqual(JSON.parse(discoveredList.stdout), {
+        version: 2,
+        projects: [
+          {
+            source: "ghq",
+            name: "repo",
+            rootPath: repo.repoDir,
+          },
+        ],
+      });
+
+      const disableResult = await runCommand(
+        "phantom",
+        ["preferences", "set", "ghqDiscovery", "false"],
+        {
+          cwd: repo.rootDir,
+          env: projectEnv,
+        },
+      );
+      assert.strictEqual(disableResult.exitCode, 0, disableResult.stderr);
+
+      const disabledList = await runCommand(
+        "phantom",
+        ["project", "list", "--json"],
+        {
+          cwd: repo.rootDir,
+          env: projectEnv,
+        },
+      );
+      assert.strictEqual(disabledList.exitCode, 0, disabledList.stderr);
+      assert.deepStrictEqual(JSON.parse(disabledList.stdout), {
+        version: 2,
+        projects: [],
+      });
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "returns registered projects and warns on stderr when ghq discovery fails",
+    async () => {
+      const binDirectory = join(repo.rootDir, "bin");
+      const ghqPath = join(binDirectory, "ghq");
+      await mkdir(binDirectory, { recursive: true });
+      await writeFile(
+        ghqPath,
+        [
+          "#!/bin/sh",
+          'printf "%s\\n" "simulated ghq failure" >&2',
+          "exit 17",
+          "",
+        ].join("\n"),
+      );
+      await chmod(ghqPath, 0o755);
+
+      const projectEnv = {
+        ...repo.env,
+        PATH: `${binDirectory}${delimiter}${repo.env.PATH ?? ""}`,
+        XDG_STATE_HOME: join(repo.rootDir, "state"),
+      };
+      const addResult = await runCommand(
+        "phantom",
+        ["project", "add", repo.repoDir, "--json"],
+        {
+          cwd: repo.rootDir,
+          env: projectEnv,
+        },
+      );
+
+      assert.strictEqual(addResult.exitCode, 0, addResult.stderr);
+      const added = JSON.parse(addResult.stdout) as {
+        project: ProjectRecord;
+      };
+
+      const listResult = await runCommand(
+        "phantom",
+        ["project", "list", "--json"],
+        {
+          cwd: repo.rootDir,
+          env: projectEnv,
+        },
+      );
+
+      assert.strictEqual(listResult.exitCode, 0, listResult.stderr);
+      assert.deepStrictEqual(JSON.parse(listResult.stdout), {
+        version: 2,
+        projects: [{ ...added.project, source: "registry" }],
+      });
+      assert.doesNotMatch(listResult.stdout, /Warning:/);
+      assert.match(
+        listResult.stderr,
+        /Warning: Failed to discover ghq repositories:.*simulated ghq failure/s,
+      );
+    },
+  );
 });

--- a/packages/cli/src/bin/phantom.ts
+++ b/packages/cli/src/bin/phantom.ts
@@ -159,7 +159,7 @@ const commands: Command[] = [
   },
   {
     name: "project",
-    description: "Manage registered Git projects",
+    description: "Manage and discover Git projects",
     handler: projectHandler,
     help: projectHelp,
     subcommands: [
@@ -171,7 +171,7 @@ const commands: Command[] = [
       },
       {
         name: "list",
-        description: "List registered Git projects",
+        description: "List registered and discovered Git projects",
         handler: projectListHandler,
         help: projectListHelp,
       },

--- a/packages/cli/src/completions/phantom-bash.ts
+++ b/packages/cli/src/completions/phantom-bash.ts
@@ -305,19 +305,19 @@ _phantom_completion() {
                 return 0
             elif [[ \${words[2]} == "get" ]]; then
                 if [[ \${cword} -eq 3 ]]; then
-                    local keys="editor ai worktreesDirectory directoryNameSeparator keepBranch"
+                    local keys="editor ai worktreesDirectory directoryNameSeparator keepBranch ghqDiscovery"
                     COMPREPLY=( $(compgen -W "\${keys}" -- "\${cur}") )
                     return 0
                 fi
             elif [[ \${words[2]} == "set" ]]; then
                 if [[ \${cword} -eq 3 ]]; then
-                    local keys="editor ai worktreesDirectory directoryNameSeparator keepBranch"
+                    local keys="editor ai worktreesDirectory directoryNameSeparator keepBranch ghqDiscovery"
                     COMPREPLY=( $(compgen -W "\${keys}" -- "\${cur}") )
                     return 0
                 fi
             elif [[ \${words[2]} == "remove" ]]; then
                 if [[ \${cword} -eq 3 ]]; then
-                    local keys="editor ai worktreesDirectory directoryNameSeparator keepBranch"
+                    local keys="editor ai worktreesDirectory directoryNameSeparator keepBranch ghqDiscovery"
                     COMPREPLY=( $(compgen -W "\${keys}" -- "\${cur}") )
                     return 0
                 fi

--- a/packages/cli/src/completions/phantom-fish.ts
+++ b/packages/cli/src/completions/phantom-fish.ts
@@ -103,7 +103,7 @@ complete -c phantom -n "__phantom_using_command" -a "exec" -d "Execute a command
 complete -c phantom -n "__phantom_using_command" -a "edit" -d "Open a worktree in your configured editor"
 complete -c phantom -n "__phantom_using_command" -a "ai" -d "Launch your configured AI coding assistant in a worktree"
 complete -c phantom -n "__phantom_using_command" -a "shell" -d "Open an interactive shell in a worktree directory"
-complete -c phantom -n "__phantom_using_command" -a "project" -d "Manage registered Git projects"
+complete -c phantom -n "__phantom_using_command" -a "project" -d "Manage and discover Git projects"
 complete -c phantom -n "__phantom_using_command" -a "preferences" -d "Manage editor/ai/worktreesDirectory/directoryNameSeparator preferences (stored in git config --global)"
 complete -c phantom -n "__phantom_using_command" -a "github" -d "GitHub integration commands"
 complete -c phantom -n "__phantom_using_command" -a "gh" -d "GitHub integration commands (alias)"
@@ -171,19 +171,19 @@ complete -c phantom -n "__phantom_using_command edit; and __fish_seen_subcommand
 complete -c phantom -n "__phantom_using_command ai" -a "(__phantom_list_worktrees)"
 
 # project command
-complete -c phantom -n "__phantom_using_command project; and not __fish_seen_subcommand_from add list remove" -a "add list remove" -d "Manage registered Git projects"
+complete -c phantom -n "__phantom_using_command project; and not __fish_seen_subcommand_from add list remove" -a "add list remove" -d "Manage and discover Git projects"
 complete -c phantom -n "__phantom_using_command project; and __fish_seen_subcommand_from add" -l json -d "Output the registration result as JSON"
 complete -c phantom -n "__phantom_using_command project; and __fish_seen_subcommand_from add" -a "(__fish_complete_directories)" -d "Git repository directory"
-complete -c phantom -n "__phantom_using_command project; and __fish_seen_subcommand_from list; and not __phantom_project_list_has_output_mode" -l json -d "Output the registry as JSON"
+complete -c phantom -n "__phantom_using_command project; and __fish_seen_subcommand_from list; and not __phantom_project_list_has_output_mode" -l json -d "Output the v2 project catalog as JSON"
 complete -c phantom -n "__phantom_using_command project; and __fish_seen_subcommand_from list; and not __phantom_project_list_has_output_mode" -l names -d "Output only project names"
 complete -c phantom -n "__phantom_using_command project; and __fish_seen_subcommand_from list; and not __phantom_project_list_has_output_mode" -l paths -d "Output only project root paths"
 complete -c phantom -n "__phantom_using_command project; and __fish_seen_subcommand_from remove" -l json -d "Output the removal result as JSON"
 
 # preferences command
 complete -c phantom -n "__phantom_using_command preferences" -a "get set remove" -d "Manage preferences"
-complete -c phantom -n "__phantom_using_command preferences get" -a "editor ai worktreesDirectory directoryNameSeparator keepBranch" -d "Preference key"
-complete -c phantom -n "__phantom_using_command preferences set" -a "editor ai worktreesDirectory directoryNameSeparator keepBranch" -d "Preference key"
-complete -c phantom -n "__phantom_using_command preferences remove" -a "editor ai worktreesDirectory directoryNameSeparator keepBranch" -d "Preference key"
+complete -c phantom -n "__phantom_using_command preferences get" -a "editor ai worktreesDirectory directoryNameSeparator keepBranch ghqDiscovery" -d "Preference key"
+complete -c phantom -n "__phantom_using_command preferences set" -a "editor ai worktreesDirectory directoryNameSeparator keepBranch ghqDiscovery" -d "Preference key"
+complete -c phantom -n "__phantom_using_command preferences remove" -a "editor ai worktreesDirectory directoryNameSeparator keepBranch ghqDiscovery" -d "Preference key"
 
 # shell command options
 complete -c phantom -n "__phantom_using_command shell" -l fzf -d "Use fzf for interactive selection"

--- a/packages/cli/src/completions/phantom-zsh.ts
+++ b/packages/cli/src/completions/phantom-zsh.ts
@@ -15,7 +15,7 @@ _phantom() {
         'edit:Open a worktree in your configured editor'
         'ai:Launch your configured AI coding assistant in a worktree'
         'shell:Open an interactive shell in a worktree directory'
-        'project:Manage registered Git projects'
+        'project:Manage and discover Git projects'
         'preferences:Manage editor/ai/worktreesDirectory/directoryNameSeparator preferences (git config --global)'
         'github:GitHub integration commands'
         'gh:GitHub integration commands (alias)'
@@ -124,7 +124,7 @@ _phantom() {
                             '1::path:_files -/'
                     elif [[ \${line[2]} == "list" ]]; then
                         _arguments \
-                            '(--names --paths)--json[Output the registry as JSON]' \
+                            '(--names --paths)--json[Output the v2 project catalog as JSON]' \
                             '(--json --paths)--names[Output only project names]' \
                             '(--json --names)--paths[Output only project root paths]'
                     elif [[ \${line[2]} == "remove" ]]; then
@@ -136,7 +136,7 @@ _phantom() {
                 preferences)
                     _arguments \
                         '1:subcommand:(get set remove)' \
-                        '2:key:(editor ai worktreesDirectory directoryNameSeparator keepBranch)'
+                        '2:key:(editor ai worktreesDirectory directoryNameSeparator keepBranch ghqDiscovery)'
                     ;;
                 completion)
                     _arguments \

--- a/packages/cli/src/completions/phantom.bash
+++ b/packages/cli/src/completions/phantom.bash
@@ -305,19 +305,19 @@ _phantom_completion() {
                 return 0
             elif [[ ${words[2]} == "get" ]]; then
                 if [[ ${cword} -eq 3 ]]; then
-                    local keys="editor ai worktreesDirectory directoryNameSeparator keepBranch"
+                    local keys="editor ai worktreesDirectory directoryNameSeparator keepBranch ghqDiscovery"
                     COMPREPLY=( $(compgen -W "${keys}" -- "${cur}") )
                     return 0
                 fi
             elif [[ ${words[2]} == "set" ]]; then
                 if [[ ${cword} -eq 3 ]]; then
-                    local keys="editor ai worktreesDirectory directoryNameSeparator keepBranch"
+                    local keys="editor ai worktreesDirectory directoryNameSeparator keepBranch ghqDiscovery"
                     COMPREPLY=( $(compgen -W "${keys}" -- "${cur}") )
                     return 0
                 fi
             elif [[ ${words[2]} == "remove" ]]; then
                 if [[ ${cword} -eq 3 ]]; then
-                    local keys="editor ai worktreesDirectory directoryNameSeparator keepBranch"
+                    local keys="editor ai worktreesDirectory directoryNameSeparator keepBranch ghqDiscovery"
                     COMPREPLY=( $(compgen -W "${keys}" -- "${cur}") )
                     return 0
                 fi

--- a/packages/cli/src/completions/phantom.bash.test.shell.ts
+++ b/packages/cli/src/completions/phantom.bash.test.shell.ts
@@ -119,6 +119,18 @@ _filedir() {
     ok(completions.includes("demo-repository/"));
   });
 
+  it("completes the ghqDiscovery preference", () => {
+    const { completions, result } = runBashCompletion(completionScriptPath, [
+      "phantom",
+      "preferences",
+      "set",
+      "ghqD",
+    ]);
+
+    strictEqual(result.status, 0, result.stderr);
+    ok(completions.includes("ghqDiscovery"));
+  });
+
   it("completes exec command arguments with the target command's completion", () => {
     const setupScript = `
 _dummy_complete() {

--- a/packages/cli/src/completions/phantom.fish
+++ b/packages/cli/src/completions/phantom.fish
@@ -103,7 +103,7 @@ complete -c phantom -n "__phantom_using_command" -a "exec" -d "Execute a command
 complete -c phantom -n "__phantom_using_command" -a "edit" -d "Open a worktree in your configured editor"
 complete -c phantom -n "__phantom_using_command" -a "ai" -d "Launch your configured AI coding assistant in a worktree"
 complete -c phantom -n "__phantom_using_command" -a "shell" -d "Open an interactive shell in a worktree directory"
-complete -c phantom -n "__phantom_using_command" -a "project" -d "Manage registered Git projects"
+complete -c phantom -n "__phantom_using_command" -a "project" -d "Manage and discover Git projects"
 complete -c phantom -n "__phantom_using_command" -a "preferences" -d "Manage editor/ai/worktreesDirectory/directoryNameSeparator preferences (stored in git config --global)"
 complete -c phantom -n "__phantom_using_command" -a "github" -d "GitHub integration commands"
 complete -c phantom -n "__phantom_using_command" -a "gh" -d "GitHub integration commands (alias)"
@@ -171,19 +171,19 @@ complete -c phantom -n "__phantom_using_command edit; and __fish_seen_subcommand
 complete -c phantom -n "__phantom_using_command ai" -a "(__phantom_list_worktrees)"
 
 # project command
-complete -c phantom -n "__phantom_using_command project; and not __fish_seen_subcommand_from add list remove" -a "add list remove" -d "Manage registered Git projects"
+complete -c phantom -n "__phantom_using_command project; and not __fish_seen_subcommand_from add list remove" -a "add list remove" -d "Manage and discover Git projects"
 complete -c phantom -n "__phantom_using_command project; and __fish_seen_subcommand_from add" -l json -d "Output the registration result as JSON"
 complete -c phantom -n "__phantom_using_command project; and __fish_seen_subcommand_from add" -a "(__fish_complete_directories)" -d "Git repository directory"
-complete -c phantom -n "__phantom_using_command project; and __fish_seen_subcommand_from list; and not __phantom_project_list_has_output_mode" -l json -d "Output the registry as JSON"
+complete -c phantom -n "__phantom_using_command project; and __fish_seen_subcommand_from list; and not __phantom_project_list_has_output_mode" -l json -d "Output the v2 project catalog as JSON"
 complete -c phantom -n "__phantom_using_command project; and __fish_seen_subcommand_from list; and not __phantom_project_list_has_output_mode" -l names -d "Output only project names"
 complete -c phantom -n "__phantom_using_command project; and __fish_seen_subcommand_from list; and not __phantom_project_list_has_output_mode" -l paths -d "Output only project root paths"
 complete -c phantom -n "__phantom_using_command project; and __fish_seen_subcommand_from remove" -l json -d "Output the removal result as JSON"
 
 # preferences command
 complete -c phantom -n "__phantom_using_command preferences" -a "get set remove" -d "Manage preferences"
-complete -c phantom -n "__phantom_using_command preferences get" -a "editor ai worktreesDirectory directoryNameSeparator keepBranch" -d "Preference key"
-complete -c phantom -n "__phantom_using_command preferences set" -a "editor ai worktreesDirectory directoryNameSeparator keepBranch" -d "Preference key"
-complete -c phantom -n "__phantom_using_command preferences remove" -a "editor ai worktreesDirectory directoryNameSeparator keepBranch" -d "Preference key"
+complete -c phantom -n "__phantom_using_command preferences get" -a "editor ai worktreesDirectory directoryNameSeparator keepBranch ghqDiscovery" -d "Preference key"
+complete -c phantom -n "__phantom_using_command preferences set" -a "editor ai worktreesDirectory directoryNameSeparator keepBranch ghqDiscovery" -d "Preference key"
+complete -c phantom -n "__phantom_using_command preferences remove" -a "editor ai worktreesDirectory directoryNameSeparator keepBranch ghqDiscovery" -d "Preference key"
 
 # shell command options
 complete -c phantom -n "__phantom_using_command shell" -l fzf -d "Use fzf for interactive selection"

--- a/packages/cli/src/completions/phantom.fish.test.shell.ts
+++ b/packages/cli/src/completions/phantom.fish.test.shell.ts
@@ -103,6 +103,18 @@ describe("phantom.fish completion", () => {
     }
   });
 
+  it("completes the ghqDiscovery preference", () => {
+    const { completions, result } = runFishCompletion(completionScriptPath, [
+      "phantom",
+      "preferences",
+      "set",
+      "ghqD",
+    ]);
+
+    strictEqual(result.status, 0, result.stderr);
+    ok(completions.includes("ghqDiscovery"));
+  });
+
   it("passes exec completions through to the invoked command", () => {
     const setupScript = `
 complete -c dummycmd -l from-dummy -d "Dummy option"

--- a/packages/cli/src/completions/phantom.zsh
+++ b/packages/cli/src/completions/phantom.zsh
@@ -15,7 +15,7 @@ _phantom() {
         'edit:Open a worktree in your configured editor'
         'ai:Launch your configured AI coding assistant in a worktree'
         'shell:Open an interactive shell in a worktree directory'
-        'project:Manage registered Git projects'
+        'project:Manage and discover Git projects'
         'preferences:Manage editor/ai/worktreesDirectory/directoryNameSeparator preferences (git config --global)'
         'github:GitHub integration commands'
         'gh:GitHub integration commands (alias)'
@@ -124,7 +124,7 @@ _phantom() {
                             '1::path:_files -/'
                     elif [[ ${line[2]} == "list" ]]; then
                         _arguments \
-                            '(--names --paths)--json[Output the registry as JSON]' \
+                            '(--names --paths)--json[Output the v2 project catalog as JSON]' \
                             '(--json --paths)--names[Output only project names]' \
                             '(--json --names)--paths[Output only project root paths]'
                     elif [[ ${line[2]} == "remove" ]]; then
@@ -136,7 +136,7 @@ _phantom() {
                 preferences)
                     _arguments \
                         '1:subcommand:(get set remove)' \
-                        '2:key:(editor ai worktreesDirectory directoryNameSeparator keepBranch)'
+                        '2:key:(editor ai worktreesDirectory directoryNameSeparator keepBranch ghqDiscovery)'
                     ;;
                 completion)
                     _arguments \

--- a/packages/cli/src/completions/phantom.zsh.test.shell.ts
+++ b/packages/cli/src/completions/phantom.zsh.test.shell.ts
@@ -90,4 +90,16 @@ describe("phantom.zsh completion", () => {
       ok(completions.includes("--json"));
     }
   });
+
+  it("completes the ghqDiscovery preference", () => {
+    const { completions, result } = runZshCompletion(completionScriptPath, [
+      "phantom",
+      "preferences",
+      "set",
+      "ghqD",
+    ]);
+
+    strictEqual(result.status, 0, result.stderr);
+    ok(completions.includes("ghqDiscovery"));
+  });
 });

--- a/packages/cli/src/handlers/preferences-get.test.ts
+++ b/packages/cli/src/handlers/preferences-get.test.ts
@@ -89,7 +89,7 @@ describe("preferencesGetHandler", () => {
 
     await rejects(
       async () => await preferencesGetHandler(["unknown"]),
-      /Exit with code 3: Unknown preference 'unknown'\. Supported keys: editor, ai, worktreesDirectory, directoryNameSeparator, keepBranch/,
+      /Exit with code 3: Unknown preference 'unknown'\. Supported keys: editor, ai, worktreesDirectory, directoryNameSeparator, keepBranch, ghqDiscovery/,
     );
 
     strictEqual(exitMock.mock.calls[0][0], 3);
@@ -170,6 +170,21 @@ describe("preferencesGetHandler", () => {
     strictEqual(exitMock.mock.calls[0][0], 0);
   });
 
+  it("prints ghqDiscovery preference when set", async () => {
+    resetMocks();
+    loadPreferencesMock.mockImplementation(async () => ({
+      ghqDiscovery: false,
+    }));
+
+    await rejects(
+      async () => await preferencesGetHandler(["ghqDiscovery"]),
+      /Process exit with code 0/,
+    );
+
+    strictEqual(consoleLogMock.mock.calls[0][0], "false");
+    strictEqual(exitMock.mock.calls[0][0], 0);
+  });
+
   it("warns when preference is unset", async () => {
     resetMocks();
     loadPreferencesMock.mockImplementation(async () => ({}));
@@ -242,6 +257,21 @@ describe("preferencesGetHandler", () => {
     strictEqual(
       consoleLogMock.mock.calls[0][0],
       "Preference 'keepBranch' is not set (git config --global phantom.keepBranch)",
+    );
+  });
+
+  it("warns when ghqDiscovery preference is unset", async () => {
+    resetMocks();
+    loadPreferencesMock.mockImplementation(async () => ({}));
+
+    await rejects(
+      async () => await preferencesGetHandler(["ghqDiscovery"]),
+      /Process exit with code 0/,
+    );
+
+    strictEqual(
+      consoleLogMock.mock.calls[0][0],
+      "Preference 'ghqDiscovery' is not set (git config --global phantom.ghqDiscovery)",
     );
   });
 });

--- a/packages/cli/src/handlers/preferences-remove.test.ts
+++ b/packages/cli/src/handlers/preferences-remove.test.ts
@@ -82,7 +82,7 @@ describe("preferencesRemoveHandler", () => {
 
     await rejects(
       async () => await preferencesRemoveHandler(["unknown"]),
-      /Exit with code 3: Unknown preference 'unknown'\. Supported keys: editor, ai, worktreesDirectory, directoryNameSeparator, keepBranch/,
+      /Exit with code 3: Unknown preference 'unknown'\. Supported keys: editor, ai, worktreesDirectory, directoryNameSeparator, keepBranch, ghqDiscovery/,
     );
 
     strictEqual(exitMock.mock.calls[0][0], 3);
@@ -177,6 +177,23 @@ describe("preferencesRemoveHandler", () => {
     strictEqual(
       consoleLogMock.mock.calls[0][0],
       "Removed phantom.keepBranch from global git config",
+    );
+    strictEqual(exitMock.mock.calls[0][0], 0);
+  });
+
+  it("unsets ghqDiscovery preference via git config --global", async () => {
+    resetMocks();
+    configUnsetMock.mockImplementation(async () => undefined);
+
+    await rejects(
+      async () => await preferencesRemoveHandler(["ghqDiscovery"]),
+      /Process exit with code 0/,
+    );
+
+    strictEqual(configUnsetMock.mock.calls[0][0].key, "phantom.ghqDiscovery");
+    strictEqual(
+      consoleLogMock.mock.calls[0][0],
+      "Removed phantom.ghqDiscovery from global git config",
     );
     strictEqual(exitMock.mock.calls[0][0], 0);
   });

--- a/packages/cli/src/handlers/preferences-set.test.ts
+++ b/packages/cli/src/handlers/preferences-set.test.ts
@@ -82,7 +82,7 @@ describe("preferencesSetHandler", () => {
 
     await rejects(
       async () => await preferencesSetHandler(["unknown", "value"]),
-      /Exit with code 3: Unknown preference 'unknown'\. Supported keys: editor, ai, worktreesDirectory, directoryNameSeparator, keepBranch/,
+      /Exit with code 3: Unknown preference 'unknown'\. Supported keys: editor, ai, worktreesDirectory, directoryNameSeparator, keepBranch, ghqDiscovery/,
     );
 
     strictEqual(exitMock.mock.calls[0][0], 3);
@@ -218,6 +218,32 @@ describe("preferencesSetHandler", () => {
     await rejects(
       async () => await preferencesSetHandler(["keepBranch", "yes"]),
       /Exit with code 3: Preference 'keepBranch' must be 'true' or 'false'/,
+    );
+  });
+
+  it("sets ghqDiscovery preference via git config --global", async () => {
+    resetMocks();
+    configSetMock.mockImplementation(async () => undefined);
+
+    await rejects(
+      async () => await preferencesSetHandler(["ghqDiscovery", "false"]),
+      /Process exit with code 0/,
+    );
+
+    strictEqual(configSetMock.mock.calls[0][0].key, "phantom.ghqDiscovery");
+    strictEqual(configSetMock.mock.calls[0][0].value, "false");
+    strictEqual(
+      consoleLogMock.mock.calls[0][0],
+      "Set phantom.ghqDiscovery (global) to 'false'",
+    );
+  });
+
+  it("rejects invalid ghqDiscovery preference values", async () => {
+    resetMocks();
+
+    await rejects(
+      async () => await preferencesSetHandler(["ghqDiscovery", "yes"]),
+      /Exit with code 3: Preference 'ghqDiscovery' must be 'true' or 'false'/,
     );
   });
 });

--- a/packages/cli/src/handlers/project-add.ts
+++ b/packages/cli/src/handlers/project-add.ts
@@ -1,7 +1,7 @@
-import { realpath } from "node:fs/promises";
-import { resolve } from "node:path";
-import { getGitRoot } from "@phantompane/git";
-import { ProjectRegistryStore } from "@phantompane/projects";
+import {
+  ProjectRegistryStore,
+  resolveProjectRootPath,
+} from "@phantompane/projects";
 import { exitCodes, exitWithError, exitWithSuccess } from "../errors.ts";
 import { output } from "../output.ts";
 import { parseArgsOrExit } from "../parse-args.ts";
@@ -51,12 +51,4 @@ export async function projectAddHandler(args: string[] = []): Promise<void> {
   }
 
   exitWithSuccess();
-}
-
-export async function resolveProjectRootPath(
-  inputPath: string,
-): Promise<string> {
-  const resolvedPath = await realpath(resolve(inputPath));
-  const gitRoot = await getGitRoot({ cwd: resolvedPath });
-  return await realpath(gitRoot);
 }

--- a/packages/cli/src/handlers/project-list.ts
+++ b/packages/cli/src/handlers/project-list.ts
@@ -1,8 +1,5 @@
-import {
-  PROJECT_REGISTRY_VERSION,
-  ProjectRegistryStore,
-  type ProjectRecord,
-} from "@phantompane/projects";
+import { loadPreferences } from "@phantompane/preferences";
+import { listProjectCatalog } from "@phantompane/projects";
 import { exitCodes, exitWithError, exitWithSuccess } from "../errors.ts";
 import { output } from "../output.ts";
 import { parseArgsOrExit } from "../parse-args.ts";
@@ -36,14 +33,21 @@ export async function projectListHandler(args: string[] = []): Promise<void> {
     );
   }
 
-  const projects = sortProjects(await new ProjectRegistryStore().list());
+  const preferences = await loadPreferences();
+  const catalog = await listProjectCatalog({
+    includeGhq: preferences.ghqDiscovery !== false,
+  });
+
+  for (const warning of catalog.warnings) {
+    output.warn(`Warning: ${warning}`);
+  }
 
   if (values.json) {
     output.log(
       JSON.stringify(
         {
-          version: PROJECT_REGISTRY_VERSION,
-          projects,
+          version: catalog.version,
+          projects: catalog.projects,
         },
         null,
         2,
@@ -52,39 +56,24 @@ export async function projectListHandler(args: string[] = []): Promise<void> {
     exitWithSuccess();
   }
 
-  if (projects.length === 0) {
+  if (catalog.projects.length === 0) {
     if (!values.names && !values.paths) {
       output.log("No projects found.");
     }
     exitWithSuccess();
   }
 
-  for (const project of projects) {
+  for (const project of catalog.projects) {
     if (values.names) {
       output.log(project.name);
     } else if (values.paths) {
       output.log(project.rootPath);
+    } else if (project.source === "ghq") {
+      output.log(`${project.name} (${project.rootPath}) [ghq]`);
     } else {
       output.log(`${project.name} (${project.rootPath}) [${project.id}]`);
     }
   }
 
   exitWithSuccess();
-}
-
-function sortProjects(projects: ProjectRecord[]): ProjectRecord[] {
-  return [...projects].sort((left, right) => {
-    const nameComparison = compareStrings(left.name, right.name);
-    return nameComparison || compareStrings(left.rootPath, right.rootPath);
-  });
-}
-
-function compareStrings(left: string, right: string): number {
-  if (left < right) {
-    return -1;
-  }
-  if (left > right) {
-    return 1;
-  }
-  return 0;
 }

--- a/packages/cli/src/handlers/project-remove.ts
+++ b/packages/cli/src/handlers/project-remove.ts
@@ -1,11 +1,11 @@
 import {
   ProjectRegistryStore,
+  resolveProjectRootPath,
   type ProjectRecord,
 } from "@phantompane/projects";
 import { exitCodes, exitWithError, exitWithSuccess } from "../errors.ts";
 import { output } from "../output.ts";
 import { parseArgsOrExit } from "../parse-args.ts";
-import { resolveProjectRootPath } from "./project-add.ts";
 
 export async function projectRemoveHandler(args: string[] = []): Promise<void> {
   const { positionals, values } = parseArgsOrExit({

--- a/packages/cli/src/handlers/project.test.ts
+++ b/packages/cli/src/handlers/project.test.ts
@@ -4,8 +4,10 @@ import { afterAll, beforeEach, describe, it, vi } from "vitest";
 const exitMock = vi.fn();
 const outputLogMock = vi.fn();
 const outputErrorMock = vi.fn();
-const getGitRootMock = vi.fn();
-const realpathMock = vi.fn();
+const outputWarnMock = vi.fn();
+const listProjectCatalogMock = vi.fn();
+const loadPreferencesMock = vi.fn();
+const resolveProjectRootPathMock = vi.fn();
 const storeAddMock = vi.fn();
 const storeListMock = vi.fn();
 const storeRemoveMock = vi.fn();
@@ -17,16 +19,9 @@ process.exit = (code): never => {
   throw new Error(`Exit with code ${code ?? 0}`);
 };
 
-vi.doMock("node:fs/promises", () => ({
-  realpath: realpathMock,
-}));
-
-vi.doMock("@phantompane/git", () => ({
-  getGitRoot: getGitRootMock,
-}));
-
 vi.doMock("@phantompane/projects", () => ({
-  PROJECT_REGISTRY_VERSION: 1,
+  listProjectCatalog: listProjectCatalogMock,
+  resolveProjectRootPath: resolveProjectRootPathMock,
   ProjectRegistryStore: class {
     add = storeAddMock;
     list = storeListMock;
@@ -34,10 +29,15 @@ vi.doMock("@phantompane/projects", () => ({
   },
 }));
 
+vi.doMock("@phantompane/preferences", () => ({
+  loadPreferences: loadPreferencesMock,
+}));
+
 vi.doMock("../output.ts", () => ({
   output: {
     log: outputLogMock,
     error: outputErrorMock,
+    warn: outputWarnMock,
   },
 }));
 
@@ -63,14 +63,21 @@ beforeEach(() => {
   exitMock.mockClear();
   outputLogMock.mockClear();
   outputErrorMock.mockClear();
-  getGitRootMock.mockReset();
-  realpathMock.mockReset();
+  outputWarnMock.mockClear();
+  listProjectCatalogMock.mockReset();
+  loadPreferencesMock.mockReset();
+  resolveProjectRootPathMock.mockReset();
   storeAddMock.mockReset();
   storeListMock.mockReset();
   storeRemoveMock.mockReset();
 
-  realpathMock.mockImplementation(async (inputPath) => String(inputPath));
-  getGitRootMock.mockImplementation(async ({ cwd }) => cwd);
+  resolveProjectRootPathMock.mockImplementation(async (inputPath) => inputPath);
+  listProjectCatalogMock.mockResolvedValue({
+    version: 2,
+    projects: [],
+    warnings: [],
+  });
+  loadPreferencesMock.mockResolvedValue({});
   storeListMock.mockResolvedValue([]);
 });
 
@@ -80,7 +87,7 @@ afterAll(() => {
 
 describe("project add", () => {
   it("registers the canonical Git root", async () => {
-    getGitRootMock.mockResolvedValueOnce("/repos/alpha");
+    resolveProjectRootPathMock.mockResolvedValueOnce("/repos/alpha");
     storeAddMock.mockResolvedValueOnce({
       project: alphaProject,
       added: true,
@@ -91,8 +98,8 @@ describe("project add", () => {
       /Exit with code 0/,
     );
 
-    deepStrictEqual(getGitRootMock.mock.calls[0], [
-      { cwd: "/repos/alpha/packages/cli" },
+    deepStrictEqual(resolveProjectRootPathMock.mock.calls[0], [
+      "/repos/alpha/packages/cli",
     ]);
     deepStrictEqual(storeAddMock.mock.calls[0], ["/repos/alpha"]);
     strictEqual(
@@ -102,7 +109,7 @@ describe("project add", () => {
   });
 
   it("reports an idempotent add as existing JSON", async () => {
-    getGitRootMock.mockResolvedValueOnce("/repos/alpha");
+    resolveProjectRootPathMock.mockResolvedValueOnce("/repos/alpha");
     storeAddMock.mockResolvedValueOnce({
       project: alphaProject,
       added: false,
@@ -144,16 +151,22 @@ describe("project add", () => {
 });
 
 describe("project list", () => {
-  it("prints a deterministic human-readable list", async () => {
-    storeListMock.mockResolvedValueOnce([
-      betaProject,
-      {
-        ...alphaProject,
-        id: "proj_00000000-0000-4000-8000-000000000003",
-        rootPath: "/repos/alpha-z",
-      },
-      alphaProject,
-    ]);
+  it("prints the catalog in human-readable form", async () => {
+    const secondAlpha = {
+      ...alphaProject,
+      id: "proj_00000000-0000-4000-8000-000000000003",
+      rootPath: "/repos/alpha-z",
+      source: "registry" as const,
+    };
+    listProjectCatalogMock.mockResolvedValueOnce({
+      version: 2,
+      projects: [
+        { ...alphaProject, source: "registry" },
+        secondAlpha,
+        { ...betaProject, source: "registry" },
+      ],
+      warnings: [],
+    });
 
     await rejects(async () => await projectListHandler([]), /Exit with code 0/);
 
@@ -167,8 +180,15 @@ describe("project list", () => {
     );
   });
 
-  it("prints the versioned registry as JSON", async () => {
-    storeListMock.mockResolvedValueOnce([betaProject, alphaProject]);
+  it("prints the versioned project catalog as JSON", async () => {
+    listProjectCatalogMock.mockResolvedValueOnce({
+      version: 2,
+      projects: [
+        { ...alphaProject, source: "registry" },
+        { ...betaProject, source: "registry" },
+      ],
+      warnings: [],
+    });
 
     await rejects(
       async () => await projectListHandler(["--json"]),
@@ -176,50 +196,23 @@ describe("project list", () => {
     );
 
     deepStrictEqual(JSON.parse(outputLogMock.mock.calls[0][0]), {
-      version: 1,
-      projects: [alphaProject, betaProject],
+      version: 2,
+      projects: [
+        { ...alphaProject, source: "registry" },
+        { ...betaProject, source: "registry" },
+      ],
     });
   });
 
-  it("sorts JSON output by code point instead of the host locale", async () => {
-    const uppercaseProject = {
-      ...alphaProject,
-      id: "proj_00000000-0000-4000-8000-000000000005",
-      name: "Alpha",
-      rootPath: "/repos/uppercase",
-    };
-    const zetaProject = {
-      ...alphaProject,
-      id: "proj_00000000-0000-4000-8000-000000000006",
-      name: "zeta",
-      rootPath: "/repos/zeta",
-    };
-    const umlautProject = {
-      ...alphaProject,
-      id: "proj_00000000-0000-4000-8000-000000000007",
-      name: "äther",
-      rootPath: "/repos/umlaut",
-    };
-    storeListMock.mockResolvedValueOnce([
-      umlautProject,
-      zetaProject,
-      uppercaseProject,
-    ]);
-
-    await rejects(
-      async () => await projectListHandler(["--json"]),
-      /Exit with code 0/,
-    );
-
-    deepStrictEqual(JSON.parse(outputLogMock.mock.calls[0][0]).projects, [
-      uppercaseProject,
-      zetaProject,
-      umlautProject,
-    ]);
-  });
-
   it("prints only names or paths when requested", async () => {
-    storeListMock.mockResolvedValue([betaProject, alphaProject]);
+    listProjectCatalogMock.mockResolvedValue({
+      version: 2,
+      projects: [
+        { ...alphaProject, source: "registry" },
+        { ...betaProject, source: "registry" },
+      ],
+      warnings: [],
+    });
 
     await rejects(
       async () => await projectListHandler(["--names"]),
@@ -251,7 +244,7 @@ describe("project list", () => {
       outputErrorMock.mock.calls[0][0],
       "Only one of --json, --names, or --paths can be specified",
     );
-    strictEqual(storeListMock.mock.calls.length, 0);
+    strictEqual(listProjectCatalogMock.mock.calls.length, 0);
   });
 
   it("reports unexpected positionals as validation errors", async () => {
@@ -261,13 +254,111 @@ describe("project list", () => {
     );
 
     strictEqual(exitMock.mock.calls[0][0], 3);
-    strictEqual(storeListMock.mock.calls.length, 0);
+    strictEqual(listProjectCatalogMock.mock.calls.length, 0);
   });
 
   it("prints a message for an empty human-readable list", async () => {
     await rejects(async () => await projectListHandler([]), /Exit with code 0/);
 
     strictEqual(outputLogMock.mock.calls[0][0], "No projects found.");
+  });
+
+  it("marks ghq projects in human-readable output", async () => {
+    listProjectCatalogMock.mockResolvedValueOnce({
+      version: 2,
+      projects: [
+        { ...alphaProject, source: "registry" },
+        {
+          source: "ghq",
+          name: "beta",
+          rootPath: "/repos/beta",
+        },
+      ],
+      warnings: [],
+    });
+
+    await rejects(async () => await projectListHandler([]), /Exit with code 0/);
+
+    deepStrictEqual(
+      outputLogMock.mock.calls.map(([message]) => message),
+      [`alpha (/repos/alpha) [${alphaProject.id}]`, "beta (/repos/beta) [ghq]"],
+    );
+  });
+
+  it("marks ghq projects in JSON output", async () => {
+    listProjectCatalogMock.mockResolvedValueOnce({
+      version: 2,
+      projects: [
+        {
+          source: "ghq",
+          name: "beta",
+          rootPath: "/repos/beta",
+        },
+      ],
+      warnings: [],
+    });
+
+    await rejects(
+      async () => await projectListHandler(["--json"]),
+      /Exit with code 0/,
+    );
+
+    deepStrictEqual(JSON.parse(outputLogMock.mock.calls[0][0]), {
+      version: 2,
+      projects: [
+        {
+          source: "ghq",
+          name: "beta",
+          rootPath: "/repos/beta",
+        },
+      ],
+    });
+  });
+
+  it("skips ghq discovery when disabled", async () => {
+    loadPreferencesMock.mockResolvedValueOnce({ ghqDiscovery: false });
+    listProjectCatalogMock.mockResolvedValueOnce({
+      version: 2,
+      projects: [{ ...alphaProject, source: "registry" }],
+      warnings: [],
+    });
+
+    await rejects(async () => await projectListHandler([]), /Exit with code 0/);
+
+    deepStrictEqual(listProjectCatalogMock.mock.calls[0], [
+      { includeGhq: false },
+    ]);
+    deepStrictEqual(
+      outputLogMock.mock.calls.map(([message]) => message),
+      [`alpha (/repos/alpha) [${alphaProject.id}]`],
+    );
+  });
+
+  it("prints catalog warnings without failing the list", async () => {
+    listProjectCatalogMock.mockResolvedValueOnce({
+      version: 2,
+      projects: [{ ...alphaProject, source: "registry" }],
+      warnings: ["Failed to discover ghq repositories: ghq list failed"],
+    });
+
+    await rejects(async () => await projectListHandler([]), /Exit with code 0/);
+
+    strictEqual(
+      outputWarnMock.mock.calls[0][0],
+      "Warning: Failed to discover ghq repositories: ghq list failed",
+    );
+    deepStrictEqual(
+      outputLogMock.mock.calls.map(([message]) => message),
+      [`alpha (/repos/alpha) [${alphaProject.id}]`],
+    );
+  });
+
+  it("enables ghq discovery by default", async () => {
+    await rejects(async () => await projectListHandler([]), /Exit with code 0/);
+
+    deepStrictEqual(listProjectCatalogMock.mock.calls[0], [
+      { includeGhq: true },
+    ]);
   });
 });
 
@@ -282,7 +373,7 @@ describe("project remove", () => {
     );
 
     deepStrictEqual(storeRemoveMock.mock.calls[0], [alphaProject.id]);
-    strictEqual(realpathMock.mock.calls.length, 0);
+    strictEqual(resolveProjectRootPathMock.mock.calls.length, 0);
     strictEqual(
       outputLogMock.mock.calls[0][0],
       "Removed project 'alpha' (/repos/alpha)",
@@ -308,14 +399,13 @@ describe("project remove", () => {
   it("removes a missing repository by its exact stored path", async () => {
     storeListMock.mockResolvedValueOnce([alphaProject]);
     storeRemoveMock.mockResolvedValueOnce(alphaProject);
-    realpathMock.mockRejectedValueOnce(new Error("Path does not exist"));
 
     await rejects(
       async () => await projectRemoveHandler([alphaProject.rootPath, "--json"]),
       /Exit with code 0/,
     );
 
-    strictEqual(realpathMock.mock.calls.length, 0);
+    strictEqual(resolveProjectRootPathMock.mock.calls.length, 0);
     deepStrictEqual(JSON.parse(outputLogMock.mock.calls[0][0]), {
       status: "removed",
       project: alphaProject,
@@ -324,10 +414,7 @@ describe("project remove", () => {
 
   it("canonicalizes an existing path before matching it", async () => {
     storeListMock.mockResolvedValueOnce([alphaProject]);
-    realpathMock
-      .mockResolvedValueOnce("/repos/alpha/packages/cli")
-      .mockResolvedValueOnce("/repos/alpha");
-    getGitRootMock.mockResolvedValueOnce("/repos/alpha");
+    resolveProjectRootPathMock.mockResolvedValueOnce("/repos/alpha");
     storeRemoveMock.mockResolvedValueOnce(alphaProject);
 
     await rejects(
@@ -336,6 +423,9 @@ describe("project remove", () => {
     );
 
     deepStrictEqual(storeRemoveMock.mock.calls[0], [alphaProject.id]);
+    deepStrictEqual(resolveProjectRootPathMock.mock.calls[0], [
+      "./packages/cli",
+    ]);
   });
 
   it("requires an id or path when a name is ambiguous", async () => {
@@ -362,7 +452,9 @@ describe("project remove", () => {
 
   it("returns not found for an unknown selector", async () => {
     storeListMock.mockResolvedValueOnce([alphaProject]);
-    realpathMock.mockRejectedValueOnce(new Error("Path does not exist"));
+    resolveProjectRootPathMock.mockRejectedValueOnce(
+      new Error("Path does not exist"),
+    );
 
     await rejects(
       async () => await projectRemoveHandler(["missing"]),

--- a/packages/cli/src/help/preferences.ts
+++ b/packages/cli/src/help/preferences.ts
@@ -36,6 +36,10 @@ export const preferencesHelp: CommandHelp = {
         "Keep branches by default when deleting worktrees with phantom delete or MCP",
     },
     {
+      command: "phantom preferences set ghqDiscovery false",
+      description: "Disable automatic project discovery through ghq",
+    },
+    {
       command: "phantom preferences remove editor",
       description: "Remove the editor preference (fallback to env/default)",
     },
@@ -53,6 +57,7 @@ export const preferencesHelp: CommandHelp = {
     "  worktreesDirectory - path relative to the Git repo root for storing worktrees (defaults to .git/phantom/worktrees)",
     "  directoryNameSeparator - replaces '/' in worktree directory names only (defaults to / for nested directories)",
     "  keepBranch - keeps the branch when deleting a worktree (defaults to false)",
+    "  ghqDiscovery - discovers ghq-managed repositories as projects (defaults to true)",
   ],
 };
 
@@ -83,9 +88,13 @@ export const preferencesGetHelp: CommandHelp = {
       command: "phantom preferences get keepBranch",
       description: "Show whether delete keeps branches by default",
     },
+    {
+      command: "phantom preferences get ghqDiscovery",
+      description: "Show whether ghq project discovery is enabled",
+    },
   ],
   notes: [
-    "Supported keys: editor, ai, worktreesDirectory, directoryNameSeparator, keepBranch",
+    "Supported keys: editor, ai, worktreesDirectory, directoryNameSeparator, keepBranch, ghqDiscovery",
   ],
 };
 
@@ -118,12 +127,17 @@ export const preferencesSetHelp: CommandHelp = {
       command: "phantom preferences set keepBranch true",
       description: "Keep branches when deleting worktrees by default",
     },
+    {
+      command: "phantom preferences set ghqDiscovery false",
+      description: "Disable automatic project discovery through ghq",
+    },
   ],
   notes: [
-    "Supported keys: editor, ai, worktreesDirectory, directoryNameSeparator, keepBranch",
+    "Supported keys: editor, ai, worktreesDirectory, directoryNameSeparator, keepBranch, ghqDiscovery",
     "For worktreesDirectory, provide a path relative to the Git repository root; defaults to .git/phantom/worktrees when unset",
     "For directoryNameSeparator, '/' keeps nested directories; any other string replaces '/' only in the directory path",
     "For keepBranch, use true to preserve branches on delete or false to keep the default branch deletion behavior",
+    "For ghqDiscovery, use false to list only projects registered directly with Phantom",
   ],
 };
 
@@ -155,8 +169,12 @@ export const preferencesRemoveHelp: CommandHelp = {
       description:
         "Restore the default behavior of deleting branches with worktrees",
     },
+    {
+      command: "phantom preferences remove ghqDiscovery",
+      description: "Restore the default behavior of discovering ghq projects",
+    },
   ],
   notes: [
-    "Supported keys: editor, ai, worktreesDirectory, directoryNameSeparator, keepBranch",
+    "Supported keys: editor, ai, worktreesDirectory, directoryNameSeparator, keepBranch, ghqDiscovery",
   ],
 };

--- a/packages/cli/src/help/project.ts
+++ b/packages/cli/src/help/project.ts
@@ -2,7 +2,7 @@ import type { CommandHelp } from "../help.ts";
 
 export const projectHelp: CommandHelp = {
   name: "project",
-  description: "Manage registered Git projects",
+  description: "Manage and discover Git projects",
   usage: "phantom project <subcommand> [options]",
   examples: [
     {
@@ -10,7 +10,7 @@ export const projectHelp: CommandHelp = {
       command: "phantom project add",
     },
     {
-      description: "List registered projects for an AI agent",
+      description: "List available projects for an AI agent",
       command: "phantom project list --json",
     },
     {
@@ -44,7 +44,7 @@ export const projectAddHelp: CommandHelp = {
 
 export const projectListHelp: CommandHelp = {
   name: "project list",
-  description: "List registered Phantom projects",
+  description: "List registered and discovered Phantom projects",
   usage: "phantom project list [options]",
   options: [
     {
@@ -63,7 +63,11 @@ export const projectListHelp: CommandHelp = {
       description: "Output only project root paths",
     },
   ],
-  notes: ["Only one output format option can be used at a time."],
+  notes: [
+    "Only one output format option can be used at a time.",
+    "Repositories managed by ghq are discovered automatically unless the ghqDiscovery preference is false.",
+    "ghq is optional; when it is not installed, only registered projects are listed.",
+  ],
 };
 
 export const projectRemoveHelp: CommandHelp = {
@@ -81,5 +85,6 @@ export const projectRemoveHelp: CommandHelp = {
     "The project can be specified by id, name, or root path.",
     "If a name matches multiple projects, use an id or path instead.",
     "This command never deletes the Git repository or its worktrees.",
+    "A repository discovered through ghq remains visible after its registry record is removed.",
   ],
 };

--- a/packages/cli/src/test-utils/run-zsh-completion.ts
+++ b/packages/cli/src/test-utils/run-zsh-completion.ts
@@ -35,11 +35,13 @@ _arguments() {
     return 0
   fi
 
-  local spec option
+  local spec option choices
   for spec in "$@"; do
     case "$spec" in
-      '1:subcommand:(add list remove)')
-        completions+=(add list remove)
+      [0-9]*:*:\\(*\\))
+        choices="\${spec##*:\\(}"
+        choices="\${choices%\\)}"
+        completions+=(\${(z)choices})
         ;;
       --*|'('*--*)
         option="\${spec%%\\[*}"

--- a/packages/git/src/libs/get-git-root.test.ts
+++ b/packages/git/src/libs/get-git-root.test.ts
@@ -38,6 +38,10 @@ describe("getGitRoot", () => {
         stderr: "",
       })
       .mockResolvedValueOnce({
+        stdout: "false",
+        stderr: "",
+      })
+      .mockResolvedValueOnce({
         stdout: "/repo/.git/phantom/worktrees/feature",
         stderr: "",
       });
@@ -48,8 +52,33 @@ describe("getGitRoot", () => {
 
     strictEqual(result, "/repo/.git/phantom/worktrees/feature");
     deepStrictEqual(executeGitCommandMock.mock.calls[1], [
+      ["rev-parse", "--is-bare-repository"],
+      { cwd: "/repo/.git/phantom/worktrees/feature/src" },
+    ]);
+    deepStrictEqual(executeGitCommandMock.mock.calls[2], [
       ["rev-parse", "--show-toplevel"],
       { cwd: "/repo/.git/phantom/worktrees/feature/src" },
+    ]);
+  });
+
+  it("returns the common directory for a bare repository", async () => {
+    resetMocks();
+    executeGitCommandMock
+      .mockResolvedValueOnce({
+        stdout: ".",
+        stderr: "",
+      })
+      .mockResolvedValueOnce({
+        stdout: "true",
+        stderr: "",
+      });
+
+    const result = await getGitRoot({ cwd: "/repos/example.git" });
+
+    strictEqual(result, "/repos/example.git");
+    deepStrictEqual(executeGitCommandMock.mock.calls, [
+      [["rev-parse", "--git-common-dir"], { cwd: "/repos/example.git" }],
+      [["rev-parse", "--is-bare-repository"], { cwd: "/repos/example.git" }],
     ]);
   });
 });

--- a/packages/git/src/libs/get-git-root.test.ts
+++ b/packages/git/src/libs/get-git-root.test.ts
@@ -53,7 +53,7 @@ describe("getGitRoot", () => {
     strictEqual(result, "/repo/.git/phantom/worktrees/feature");
     deepStrictEqual(executeGitCommandMock.mock.calls[1], [
       ["rev-parse", "--is-bare-repository"],
-      { cwd: "/repo/.git/phantom/worktrees/feature/src" },
+      { cwd: "/repo/.git/worktrees/feature" },
     ]);
     deepStrictEqual(executeGitCommandMock.mock.calls[2], [
       ["rev-parse", "--show-toplevel"],
@@ -78,6 +78,27 @@ describe("getGitRoot", () => {
     strictEqual(result, "/repos/example.git");
     deepStrictEqual(executeGitCommandMock.mock.calls, [
       [["rev-parse", "--git-common-dir"], { cwd: "/repos/example.git" }],
+      [["rev-parse", "--is-bare-repository"], { cwd: "/repos/example.git" }],
+    ]);
+  });
+
+  it("returns the bare common directory for a linked worktree", async () => {
+    resetMocks();
+    executeGitCommandMock
+      .mockResolvedValueOnce({
+        stdout: "/repos/example.git",
+        stderr: "",
+      })
+      .mockResolvedValueOnce({
+        stdout: "true",
+        stderr: "",
+      });
+
+    const result = await getGitRoot({ cwd: "/repos/example-worktree" });
+
+    strictEqual(result, "/repos/example.git");
+    deepStrictEqual(executeGitCommandMock.mock.calls, [
+      [["rev-parse", "--git-common-dir"], { cwd: "/repos/example-worktree" }],
       [["rev-parse", "--is-bare-repository"], { cwd: "/repos/example.git" }],
     ]);
   });

--- a/packages/git/src/libs/get-git-root.ts
+++ b/packages/git/src/libs/get-git-root.ts
@@ -20,12 +20,13 @@ export async function getGitRoot(
     return resolve(cwd, dirname(stdout));
   }
 
+  const commonDirectory = resolve(cwd, stdout);
   const { stdout: isBareRepository } = await executeGitCommand(
     ["rev-parse", "--is-bare-repository"],
-    { cwd },
+    { cwd: commonDirectory },
   );
   if (isBareRepository === "true") {
-    return resolve(cwd, stdout);
+    return commonDirectory;
   }
 
   const { stdout: toplevel } = await executeGitCommand(

--- a/packages/git/src/libs/get-git-root.ts
+++ b/packages/git/src/libs/get-git-root.ts
@@ -20,6 +20,14 @@ export async function getGitRoot(
     return resolve(cwd, dirname(stdout));
   }
 
+  const { stdout: isBareRepository } = await executeGitCommand(
+    ["rev-parse", "--is-bare-repository"],
+    { cwd },
+  );
+  if (isBareRepository === "true") {
+    return resolve(cwd, stdout);
+  }
+
   const { stdout: toplevel } = await executeGitCommand(
     ["rev-parse", "--show-toplevel"],
     { cwd },

--- a/packages/preferences/src/keys.test.ts
+++ b/packages/preferences/src/keys.test.ts
@@ -16,21 +16,28 @@ describe("preference keys", () => {
       "worktreesDirectory",
       "directoryNameSeparator",
       "keepBranch",
+      "ghqDiscovery",
     ]);
   });
 
   it("recognizes valid keys", () => {
     strictEqual(isPreferenceKey("editor"), true);
+    strictEqual(isPreferenceKey("ghqDiscovery"), true);
     strictEqual(isPreferenceKey("unknown"), false);
   });
 
   it("returns git config keys", () => {
     strictEqual(getPreferenceConfigKey("keepBranch"), "phantom.keepBranch");
+    strictEqual(getPreferenceConfigKey("ghqDiscovery"), "phantom.ghqDiscovery");
   });
 
   it("reads string and boolean values", () => {
     strictEqual(getPreferenceValue({ editor: "code" }, "editor"), "code");
     strictEqual(getPreferenceValue({ keepBranch: true }, "keepBranch"), "true");
+    strictEqual(
+      getPreferenceValue({ ghqDiscovery: false }, "ghqDiscovery"),
+      "false",
+    );
   });
 
   it("validates keepBranch values", () => {
@@ -38,6 +45,14 @@ describe("preference keys", () => {
     strictEqual(
       validatePreferenceValue("keepBranch", "yes"),
       "Preference 'keepBranch' must be 'true' or 'false'",
+    );
+  });
+
+  it("validates ghqDiscovery values", () => {
+    strictEqual(validatePreferenceValue("ghqDiscovery", "false"), null);
+    strictEqual(
+      validatePreferenceValue("ghqDiscovery", "yes"),
+      "Preference 'ghqDiscovery' must be 'true' or 'false'",
     );
   });
 });

--- a/packages/preferences/src/keys.ts
+++ b/packages/preferences/src/keys.ts
@@ -4,6 +4,7 @@ export const supportedPreferenceKeys = [
   "worktreesDirectory",
   "directoryNameSeparator",
   "keepBranch",
+  "ghqDiscovery",
 ] as const;
 
 export type PreferenceKey = (typeof supportedPreferenceKeys)[number];
@@ -14,6 +15,7 @@ export interface Preferences {
   worktreesDirectory?: string;
   directoryNameSeparator?: string;
   keepBranch?: boolean;
+  ghqDiscovery?: boolean;
 }
 
 export function isPreferenceKey(value: string): value is PreferenceKey {
@@ -39,8 +41,12 @@ export function validatePreferenceValue(
   key: PreferenceKey,
   value: string,
 ): string | null {
-  if (key === "keepBranch" && value !== "true" && value !== "false") {
-    return "Preference 'keepBranch' must be 'true' or 'false'";
+  if (
+    (key === "keepBranch" || key === "ghqDiscovery") &&
+    value !== "true" &&
+    value !== "false"
+  ) {
+    return `Preference '${key}' must be 'true' or 'false'`;
   }
 
   return null;

--- a/packages/preferences/src/loader.test.ts
+++ b/packages/preferences/src/loader.test.ts
@@ -18,7 +18,7 @@ describe("loadPreferences", () => {
     resetMocks();
     configGetRegexpMock.mockImplementation(
       async () =>
-        "phantom.editor\ncode\u0000phantom.ai\nclaude\u0000phantom.worktreesdirectory\n../phantom-worktrees\u0000phantom.directorynameseparator\n-\u0000phantom.keepbranch\ntrue\u0000",
+        "phantom.editor\ncode\u0000phantom.ai\nclaude\u0000phantom.worktreesdirectory\n../phantom-worktrees\u0000phantom.directorynameseparator\n-\u0000phantom.keepbranch\ntrue\u0000phantom.ghqdiscovery\nfalse\u0000",
     );
 
     const preferences = await loadPreferences();
@@ -29,6 +29,7 @@ describe("loadPreferences", () => {
       worktreesDirectory: "../phantom-worktrees",
       directoryNameSeparator: "-",
       keepBranch: true,
+      ghqDiscovery: false,
     });
     deepStrictEqual(configGetRegexpMock.mock.calls[0][0], {
       pattern: "^phantom\\.",
@@ -41,7 +42,7 @@ describe("loadPreferences", () => {
     resetMocks();
     configGetRegexpMock.mockImplementation(
       async () =>
-        "phantom.unknown\nvalue\u0000phantom.editor\nvim\u0000phantom.ai\ncodex\u0000phantom.worktreesdirectory\n../phantom\u0000phantom.directorynameseparator\n_\u0000phantom.keepbranch\nfalse\u0000",
+        "phantom.unknown\nvalue\u0000phantom.editor\nvim\u0000phantom.ai\ncodex\u0000phantom.worktreesdirectory\n../phantom\u0000phantom.directorynameseparator\n_\u0000phantom.keepbranch\nfalse\u0000phantom.ghqdiscovery\ntrue\u0000",
     );
 
     const preferences = await loadPreferences();
@@ -52,6 +53,7 @@ describe("loadPreferences", () => {
       worktreesDirectory: "../phantom",
       directoryNameSeparator: "_",
       keepBranch: false,
+      ghqDiscovery: true,
     });
   });
 
@@ -68,7 +70,7 @@ describe("loadPreferences", () => {
     resetMocks();
     configGetRegexpMock.mockImplementation(
       async () =>
-        "phantom.editor\nvim\u0000phantom.editor\ncode\u0000phantom.ai\nclaude\u0000phantom.ai\ncursor\u0000phantom.worktreesdirectory\n../phantom-custom\u0000phantom.worktreesdirectory\n../phantom-worktrees\u0000phantom.directorynameseparator\n_\u0000phantom.directorynameseparator\n-\u0000phantom.keepbranch\nfalse\u0000phantom.keepbranch\ntrue\u0000",
+        "phantom.editor\nvim\u0000phantom.editor\ncode\u0000phantom.ai\nclaude\u0000phantom.ai\ncursor\u0000phantom.worktreesdirectory\n../phantom-custom\u0000phantom.worktreesdirectory\n../phantom-worktrees\u0000phantom.directorynameseparator\n_\u0000phantom.directorynameseparator\n-\u0000phantom.keepbranch\nfalse\u0000phantom.keepbranch\ntrue\u0000phantom.ghqdiscovery\nfalse\u0000phantom.ghqdiscovery\ntrue\u0000",
     );
 
     const preferences = await loadPreferences();
@@ -78,20 +80,27 @@ describe("loadPreferences", () => {
     equal(preferences.worktreesDirectory, "../phantom-worktrees");
     equal(preferences.directoryNameSeparator, "-");
     equal(preferences.keepBranch, true);
+    equal(preferences.ghqDiscovery, true);
   });
 
   it("parses preference keys regardless of git config key casing", async () => {
-    equal(
-      parsePreferences(
-        "phantom.Editor\nvim\u0000phantom.AI\nclaude\u0000phantom.WorktreesDirectory\n../phantom-wt\u0000phantom.DirectoryNameSeparator\n_\u0000phantom.KeepBranch\ntrue\u0000",
-      ).editor,
-      "vim",
+    const preferences = parsePreferences(
+      "phantom.Editor\nvim\u0000phantom.AI\nclaude\u0000phantom.WorktreesDirectory\n../phantom-wt\u0000phantom.DirectoryNameSeparator\n_\u0000phantom.KeepBranch\ntrue\u0000phantom.GhqDiscovery\nfalse\u0000",
     );
+
+    equal(preferences.editor, "vim");
+    equal(preferences.ghqDiscovery, false);
   });
 
   it("ignores invalid keepBranch preference values", () => {
     const preferences = parsePreferences("phantom.keepbranch\nyes\u0000");
 
     equal(preferences.keepBranch, undefined);
+  });
+
+  it("ignores invalid ghqDiscovery preference values", () => {
+    const preferences = parsePreferences("phantom.ghqdiscovery\nenabled\u0000");
+
+    equal(preferences.ghqDiscovery, undefined);
   });
 });

--- a/packages/preferences/src/loader.ts
+++ b/packages/preferences/src/loader.ts
@@ -16,6 +16,7 @@ const preferencesSchema = z
     worktreesDirectory: z.string().optional(),
     directoryNameSeparator: z.string().optional(),
     keepBranch: z.boolean().optional(),
+    ghqDiscovery: z.boolean().optional(),
   })
   .passthrough();
 
@@ -55,6 +56,9 @@ export function parsePreferences(output: string): Preferences {
       preferences.directoryNameSeparator = value;
     } else if (strippedKey === "keepbranch") {
       preferences.keepBranch =
+        value === "true" ? true : value === "false" ? false : undefined;
+    } else if (strippedKey === "ghqdiscovery") {
+      preferences.ghqDiscovery =
         value === "true" ? true : value === "false" ? false : undefined;
     }
   }

--- a/packages/projects/package.json
+++ b/packages/projects/package.json
@@ -12,6 +12,7 @@
     "test": "vitest run --root ../.. packages/projects/src"
   },
   "dependencies": {
+    "@phantompane/git": "workspace:*",
     "zod": "^4.4.3"
   }
 }

--- a/packages/projects/src/catalog.test.ts
+++ b/packages/projects/src/catalog.test.ts
@@ -1,4 +1,9 @@
+import { execFile } from "node:child_process";
 import { deepStrictEqual, strictEqual } from "node:assert";
+import { mkdtemp, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
 import { describe, it } from "vitest";
 import {
   DEFAULT_ROOT_RESOLUTION_CONCURRENCY,
@@ -10,6 +15,8 @@ import {
 } from "./catalog.ts";
 import { GhqDiscoveryError } from "./ghq.ts";
 import type { ProjectRecord } from "./types.ts";
+
+const execFileAsync = promisify(execFile);
 
 function project(
   name: string,
@@ -101,6 +108,37 @@ describe("listProjectCatalog", () => {
       },
     ]);
     deepStrictEqual(result.warnings, []);
+  });
+
+  it("discovers bare ghq repositories", async () => {
+    const temporaryDirectory = await mkdtemp(
+      join(tmpdir(), "phantom-ghq-bare-"),
+    );
+    const bareRoot = join(temporaryDirectory, "example.git");
+
+    try {
+      await execFileAsync("git", ["init", "--bare", bareRoot]);
+      const canonicalRoot = await realpath(bareRoot);
+
+      const result = await listProjectCatalog({
+        store: createStore([]),
+        discoverGhqRepositories: async () => ({
+          available: true,
+          rootPaths: [bareRoot],
+        }),
+      });
+
+      deepStrictEqual(result.projects, [
+        {
+          source: "ghq",
+          name: "example.git",
+          rootPath: canonicalRoot,
+        },
+      ]);
+      deepStrictEqual(result.warnings, []);
+    } finally {
+      await rm(temporaryDirectory, { recursive: true, force: true });
+    }
   });
 
   it("skips invalid roots and canonicalizes ghq candidates with bounded concurrency", async () => {

--- a/packages/projects/src/catalog.test.ts
+++ b/packages/projects/src/catalog.test.ts
@@ -110,21 +110,43 @@ describe("listProjectCatalog", () => {
     deepStrictEqual(result.warnings, []);
   });
 
-  it("discovers bare ghq repositories", async () => {
+  it("deduplicates a bare ghq repository and its linked worktree", async () => {
     const temporaryDirectory = await mkdtemp(
       join(tmpdir(), "phantom-ghq-bare-"),
     );
+    const seedRoot = join(temporaryDirectory, "seed");
     const bareRoot = join(temporaryDirectory, "example.git");
+    const linkedRoot = join(temporaryDirectory, "linked");
 
     try {
-      await execFileAsync("git", ["init", "--bare", bareRoot]);
+      await execFileAsync("git", ["init", seedRoot]);
+      await execFileAsync("git", [
+        "-C",
+        seedRoot,
+        "-c",
+        "user.name=Phantom Test",
+        "-c",
+        "user.email=phantom@example.com",
+        "commit",
+        "--allow-empty",
+        "-m",
+        "Initial commit",
+      ]);
+      await execFileAsync("git", ["clone", "--bare", seedRoot, bareRoot]);
+      await execFileAsync("git", [
+        "-C",
+        bareRoot,
+        "worktree",
+        "add",
+        linkedRoot,
+      ]);
       const canonicalRoot = await realpath(bareRoot);
 
       const result = await listProjectCatalog({
         store: createStore([]),
         discoverGhqRepositories: async () => ({
           available: true,
-          rootPaths: [bareRoot],
+          rootPaths: [linkedRoot, bareRoot],
         }),
       });
 

--- a/packages/projects/src/catalog.test.ts
+++ b/packages/projects/src/catalog.test.ts
@@ -1,0 +1,240 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "vitest";
+import {
+  DEFAULT_ROOT_RESOLUTION_CONCURRENCY,
+  listProjectCatalog,
+  PROJECT_LIST_VERSION,
+  type GhqRepositoryDiscoverer,
+  type ProjectCatalogStore,
+  type ProjectRootResolver,
+} from "./catalog.ts";
+import { GhqDiscoveryError } from "./ghq.ts";
+import type { ProjectRecord } from "./types.ts";
+
+function project(
+  name: string,
+  rootPath: string,
+  idSuffix: string,
+): ProjectRecord {
+  return {
+    id: `proj_550e8400-e29b-41d4-a716-44665544${idSuffix}`,
+    name,
+    rootPath,
+    createdAt: "2026-07-20T00:00:00.000Z",
+  };
+}
+
+function createStore(projects: ProjectRecord[]): ProjectCatalogStore {
+  return {
+    async list() {
+      return projects;
+    },
+  };
+}
+
+describe("listProjectCatalog", () => {
+  it("exports a list format version separate from registry storage", async () => {
+    strictEqual(PROJECT_LIST_VERSION, 2);
+
+    const result = await listProjectCatalog({
+      includeGhq: false,
+      store: createStore([]),
+    });
+
+    strictEqual(result.version, PROJECT_LIST_VERSION);
+  });
+
+  it("lists only registered projects when ghq discovery is disabled", async () => {
+    let discoveryCalls = 0;
+    const discoverGhqRepositories: GhqRepositoryDiscoverer = async () => {
+      discoveryCalls += 1;
+      return { available: true, rootPaths: ["/repos/ghq"] };
+    };
+
+    const result = await listProjectCatalog({
+      includeGhq: false,
+      store: createStore([
+        project("zeta", "/repos/zeta", "0001"),
+        project("alpha", "/repos/alpha", "0002"),
+      ]),
+      discoverGhqRepositories,
+    });
+
+    strictEqual(discoveryCalls, 0);
+    deepStrictEqual(
+      result.projects.map(({ name, rootPath, source }) => ({
+        name,
+        rootPath,
+        source,
+      })),
+      [
+        { name: "alpha", rootPath: "/repos/alpha", source: "registry" },
+        { name: "zeta", rootPath: "/repos/zeta", source: "registry" },
+      ],
+    );
+    deepStrictEqual(result.warnings, []);
+  });
+
+  it("merges transient ghq projects while registered roots win", async () => {
+    const registeredAlpha = project("alpha", "/repos/alpha", "0001");
+    const result = await listProjectCatalog({
+      store: createStore([registeredAlpha]),
+      discoverGhqRepositories: async () => ({
+        available: true,
+        rootPaths: ["/ghq/alpha", "/ghq/client/shared", "/ghq/upstream/shared"],
+      }),
+      resolveRootPath: async (rootPath) =>
+        rootPath === "/ghq/alpha" ? "/repos/alpha" : rootPath,
+    });
+
+    deepStrictEqual(result.projects, [
+      { ...registeredAlpha, source: "registry" },
+      {
+        source: "ghq",
+        name: "shared",
+        rootPath: "/ghq/client/shared",
+      },
+      {
+        source: "ghq",
+        name: "shared",
+        rootPath: "/ghq/upstream/shared",
+      },
+    ]);
+    deepStrictEqual(result.warnings, []);
+  });
+
+  it("skips invalid roots and canonicalizes ghq candidates with bounded concurrency", async () => {
+    const calls: string[] = [];
+    let activeCalls = 0;
+    let maximumActiveCalls = 0;
+    const resolveRootPath: ProjectRootResolver = async (rootPath) => {
+      calls.push(rootPath);
+      activeCalls += 1;
+      maximumActiveCalls = Math.max(maximumActiveCalls, activeCalls);
+      await Promise.resolve();
+      activeCalls -= 1;
+
+      if (rootPath === "/ghq/invalid") {
+        throw new Error("not a Git repository");
+      }
+      if (rootPath.endsWith("/duplicate")) {
+        return "/repos/canonical";
+      }
+      return rootPath;
+    };
+
+    const result = await listProjectCatalog({
+      store: createStore([]),
+      discoverGhqRepositories: async () => ({
+        available: true,
+        rootPaths: [
+          "/ghq/invalid",
+          "/ghq/first/duplicate",
+          "/ghq/second/duplicate",
+          "/repos/zeta",
+        ],
+      }),
+      resolveRootPath,
+      rootResolutionConcurrency: 2,
+    });
+
+    deepStrictEqual(calls, [
+      "/ghq/invalid",
+      "/ghq/first/duplicate",
+      "/ghq/second/duplicate",
+      "/repos/zeta",
+    ]);
+    strictEqual(maximumActiveCalls, 2);
+    deepStrictEqual(result.projects, [
+      {
+        source: "ghq",
+        name: "canonical",
+        rootPath: "/repos/canonical",
+      },
+      { source: "ghq", name: "zeta", rootPath: "/repos/zeta" },
+    ]);
+  });
+
+  it("uses a finite default concurrency and preserves deterministic ordering", async () => {
+    let activeCalls = 0;
+    let maximumActiveCalls = 0;
+    const resolveRootPath: ProjectRootResolver = async (rootPath) => {
+      activeCalls += 1;
+      maximumActiveCalls = Math.max(maximumActiveCalls, activeCalls);
+      await Promise.resolve();
+      activeCalls -= 1;
+      return rootPath;
+    };
+    const candidatePaths = Array.from(
+      { length: DEFAULT_ROOT_RESOLUTION_CONCURRENCY + 3 },
+      (_, index) => `/repos/project-${String(index).padStart(2, "0")}`,
+    ).reverse();
+
+    const result = await listProjectCatalog({
+      store: createStore([]),
+      discoverGhqRepositories: async () => ({
+        available: true,
+        rootPaths: candidatePaths,
+      }),
+      resolveRootPath,
+    });
+
+    strictEqual(maximumActiveCalls, DEFAULT_ROOT_RESOLUTION_CONCURRENCY);
+    deepStrictEqual(
+      result.projects.map((entry) => entry.rootPath),
+      [...candidatePaths].sort(),
+    );
+  });
+
+  it("keeps registered projects and returns a warning when ghq fails", async () => {
+    const registered = project("alpha", "/repos/alpha", "0001");
+    const commandError = new GhqDiscoveryError(
+      "Failed to discover ghq repositories: command failed",
+    );
+
+    const result = await listProjectCatalog({
+      store: createStore([registered]),
+      discoverGhqRepositories: async () => {
+        throw commandError;
+      },
+    });
+
+    deepStrictEqual(result.projects, [{ ...registered, source: "registry" }]);
+    deepStrictEqual(result.warnings, [
+      "Failed to discover ghq repositories: command failed",
+    ]);
+  });
+
+  it("keeps registered projects and returns a warning when ghq times out", async () => {
+    const registered = project("alpha", "/repos/alpha", "0001");
+    const timeoutError = new GhqDiscoveryError(
+      "Failed to discover ghq repositories: timed out after 5000 ms",
+    );
+
+    const result = await listProjectCatalog({
+      store: createStore([registered]),
+      discoverGhqRepositories: async () => {
+        throw timeoutError;
+      },
+    });
+
+    deepStrictEqual(result.projects, [{ ...registered, source: "registry" }]);
+    deepStrictEqual(result.warnings, [timeoutError.message]);
+  });
+
+  it("does not warn when ghq is unavailable", async () => {
+    const result = await listProjectCatalog({
+      store: createStore([]),
+      discoverGhqRepositories: async () => ({
+        available: false,
+        rootPaths: [],
+      }),
+    });
+
+    deepStrictEqual(result, {
+      version: PROJECT_LIST_VERSION,
+      projects: [],
+      warnings: [],
+    });
+  });
+});

--- a/packages/projects/src/catalog.test.ts
+++ b/packages/projects/src/catalog.test.ts
@@ -1,6 +1,6 @@
 import { execFile } from "node:child_process";
 import { deepStrictEqual, strictEqual } from "node:assert";
-import { mkdtemp, realpath, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
@@ -114,32 +114,50 @@ describe("listProjectCatalog", () => {
     const temporaryDirectory = await mkdtemp(
       join(tmpdir(), "phantom-ghq-bare-"),
     );
+    const homeRoot = join(temporaryDirectory, "home");
     const seedRoot = join(temporaryDirectory, "seed");
     const bareRoot = join(temporaryDirectory, "example.git");
     const linkedRoot = join(temporaryDirectory, "linked");
+    const globalGitConfig = join(homeRoot, ".gitconfig");
+    const gitEnvironment: NodeJS.ProcessEnv = {
+      ...process.env,
+      GIT_CONFIG_GLOBAL: globalGitConfig,
+      GIT_CONFIG_NOSYSTEM: "1",
+      HOME: homeRoot,
+      XDG_CONFIG_HOME: join(homeRoot, ".config"),
+    };
+    const gitOptions = { env: gitEnvironment };
 
     try {
-      await execFileAsync("git", ["init", seedRoot]);
-      await execFileAsync("git", [
-        "-C",
-        seedRoot,
-        "-c",
-        "user.name=Phantom Test",
-        "-c",
-        "user.email=phantom@example.com",
-        "commit",
-        "--allow-empty",
-        "-m",
-        "Initial commit",
-      ]);
-      await execFileAsync("git", ["clone", "--bare", seedRoot, bareRoot]);
-      await execFileAsync("git", [
-        "-C",
-        bareRoot,
-        "worktree",
-        "add",
-        linkedRoot,
-      ]);
+      await mkdir(homeRoot, { recursive: true });
+      await writeFile(globalGitConfig, "");
+      await execFileAsync("git", ["init", seedRoot], gitOptions);
+      await execFileAsync(
+        "git",
+        [
+          "-C",
+          seedRoot,
+          "-c",
+          "user.name=Phantom Test",
+          "-c",
+          "user.email=phantom@example.com",
+          "commit",
+          "--allow-empty",
+          "-m",
+          "Initial commit",
+        ],
+        gitOptions,
+      );
+      await execFileAsync(
+        "git",
+        ["clone", "--bare", seedRoot, bareRoot],
+        gitOptions,
+      );
+      await execFileAsync(
+        "git",
+        ["-C", bareRoot, "worktree", "add", linkedRoot],
+        gitOptions,
+      );
       const canonicalRoot = await realpath(bareRoot);
 
       const result = await listProjectCatalog({

--- a/packages/projects/src/catalog.ts
+++ b/packages/projects/src/catalog.ts
@@ -1,0 +1,159 @@
+import { basename } from "node:path";
+import { discoverGhqRepositories, type GhqDiscoveryResult } from "./ghq.ts";
+import { resolveProjectRootPath } from "./resolve-root.ts";
+import { ProjectRegistryStore } from "./store.ts";
+import type { ProjectRecord } from "./types.ts";
+
+export const PROJECT_LIST_VERSION = 2 as const;
+export const DEFAULT_ROOT_RESOLUTION_CONCURRENCY = 4;
+
+export type ProjectListEntry =
+  | (ProjectRecord & { source: "registry" })
+  | {
+      source: "ghq";
+      name: string;
+      rootPath: string;
+    };
+
+export interface ProjectCatalogResult {
+  version: typeof PROJECT_LIST_VERSION;
+  projects: ProjectListEntry[];
+  warnings: string[];
+}
+
+export interface ProjectCatalogStore {
+  list(): Promise<ProjectRecord[]>;
+}
+
+export type GhqRepositoryDiscoverer = () => Promise<GhqDiscoveryResult>;
+export type ProjectRootResolver = (rootPath: string) => Promise<string>;
+
+export interface ProjectCatalogOptions {
+  includeGhq?: boolean;
+  store?: ProjectCatalogStore;
+  discoverGhqRepositories?: GhqRepositoryDiscoverer;
+  resolveRootPath?: ProjectRootResolver;
+  rootResolutionConcurrency?: number;
+}
+
+export async function listProjectCatalog(
+  options: ProjectCatalogOptions = {},
+): Promise<ProjectCatalogResult> {
+  const store = options.store ?? new ProjectRegistryStore();
+  const registeredProjects = await store.list();
+  const projects: ProjectListEntry[] = registeredProjects.map((project) => ({
+    ...project,
+    source: "registry",
+  }));
+  const warnings: string[] = [];
+
+  if (options.includeGhq !== false) {
+    const discover = options.discoverGhqRepositories ?? discoverGhqRepositories;
+    let discovery: GhqDiscoveryResult | undefined;
+    try {
+      discovery = await discover();
+    } catch (error) {
+      warnings.push(toWarningMessage(error));
+    }
+
+    if (discovery?.available) {
+      const resolveRootPath = options.resolveRootPath ?? resolveProjectRootPath;
+      const knownRootPaths = new Set(
+        registeredProjects.map((project) => project.rootPath),
+      );
+      const resolvedRootPaths = await resolveCandidateRootPaths(
+        discovery.rootPaths,
+        resolveRootPath,
+        options.rootResolutionConcurrency ??
+          DEFAULT_ROOT_RESOLUTION_CONCURRENCY,
+      );
+
+      for (const rootPath of resolvedRootPaths) {
+        if (rootPath === undefined) {
+          continue;
+        }
+
+        if (knownRootPaths.has(rootPath)) {
+          continue;
+        }
+
+        knownRootPaths.add(rootPath);
+        projects.push({
+          source: "ghq",
+          name: basename(rootPath),
+          rootPath,
+        });
+      }
+    }
+  }
+
+  return {
+    version: PROJECT_LIST_VERSION,
+    projects: sortProjects(projects),
+    warnings,
+  };
+}
+
+async function resolveCandidateRootPaths(
+  candidatePaths: readonly string[],
+  resolveRootPath: ProjectRootResolver,
+  concurrency: number,
+): Promise<Array<string | undefined>> {
+  const resolvedRootPaths = Array.from(
+    { length: candidatePaths.length },
+    (): string | undefined => undefined,
+  );
+  const workerCount = Math.min(
+    candidatePaths.length,
+    normalizeConcurrency(concurrency),
+  );
+  let nextIndex = 0;
+
+  async function resolveNext(): Promise<void> {
+    while (nextIndex < candidatePaths.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+
+      try {
+        resolvedRootPaths[index] = await resolveRootPath(candidatePaths[index]);
+      } catch {
+        resolvedRootPaths[index] = undefined;
+      }
+    }
+  }
+
+  await Promise.all(Array.from({ length: workerCount }, () => resolveNext()));
+  return resolvedRootPaths;
+}
+
+function normalizeConcurrency(concurrency: number): number {
+  if (!Number.isFinite(concurrency) || concurrency < 1) {
+    return 1;
+  }
+  return Math.floor(concurrency);
+}
+
+function sortProjects(projects: ProjectListEntry[]): ProjectListEntry[] {
+  return [...projects].sort((left, right) => {
+    const nameComparison = compareStrings(left.name, right.name);
+    return nameComparison || compareStrings(left.rootPath, right.rootPath);
+  });
+}
+
+function compareStrings(left: string, right: string): number {
+  if (left < right) {
+    return -1;
+  }
+  if (left > right) {
+    return 1;
+  }
+  return 0;
+}
+
+function toWarningMessage(error: unknown): string {
+  if (error instanceof Error && error.message.trim()) {
+    return error.message.trim();
+  }
+  const message = String(error).trim();
+  return message || "Failed to discover ghq repositories";
+}

--- a/packages/projects/src/ghq.test.ts
+++ b/packages/projects/src/ghq.test.ts
@@ -1,0 +1,150 @@
+import { deepStrictEqual, rejects, strictEqual } from "node:assert";
+import { describe, it } from "vitest";
+import {
+  DEFAULT_GHQ_DISCOVERY_TIMEOUT_MS,
+  discoverGhqRepositories,
+  GhqDiscoveryError,
+  type GhqCommandRunner,
+  type GhqCommandOptions,
+} from "./ghq.ts";
+
+describe("discoverGhqRepositories", () => {
+  it("runs ghq list --full-path with a finite timeout and returns normalized absolute paths", async () => {
+    const calls: Array<{
+      command: string;
+      args: readonly string[];
+      options: GhqCommandOptions;
+    }> = [];
+    const commandRunner: GhqCommandRunner = async (command, args, options) => {
+      calls.push({ command, args, options });
+      return {
+        stdout:
+          "/work/github.com/example/alpha/\n/work/github.com/example/beta\n",
+        stderr: "",
+      };
+    };
+
+    const result = await discoverGhqRepositories({ commandRunner });
+
+    deepStrictEqual(calls, [
+      {
+        command: "ghq",
+        args: ["list", "--full-path"],
+        options: { timeoutMs: DEFAULT_GHQ_DISCOVERY_TIMEOUT_MS },
+      },
+    ]);
+    deepStrictEqual(result, {
+      available: true,
+      rootPaths: [
+        "/work/github.com/example/alpha",
+        "/work/github.com/example/beta",
+      ],
+    });
+  });
+
+  it("passes a custom timeout to the command runner", async () => {
+    let receivedOptions: GhqCommandOptions | undefined;
+    const commandRunner: GhqCommandRunner = async (
+      _command,
+      _args,
+      options,
+    ) => {
+      receivedOptions = options;
+      return { stdout: "", stderr: "" };
+    };
+
+    await discoverGhqRepositories({
+      commandRunner,
+      timeoutMs: 250,
+    });
+
+    deepStrictEqual(receivedOptions, { timeoutMs: 250 });
+  });
+
+  it("ignores blank lines and deterministically deduplicates normalized paths", async () => {
+    const commandRunner: GhqCommandRunner = async () => ({
+      stdout:
+        "\n  /work/zeta  \r\n/work/alpha/../beta/\n/work/beta\n\t\n/work/zeta\n",
+      stderr: "",
+    });
+
+    const result = await discoverGhqRepositories({ commandRunner });
+
+    deepStrictEqual(result, {
+      available: true,
+      rootPaths: ["/work/beta", "/work/zeta"],
+    });
+  });
+
+  it("reports ghq as unavailable when the executable is not found", async () => {
+    const commandRunner: GhqCommandRunner = async () => {
+      throw Object.assign(new Error("spawn ghq ENOENT"), { code: "ENOENT" });
+    };
+
+    deepStrictEqual(await discoverGhqRepositories({ commandRunner }), {
+      available: false,
+      rootPaths: [],
+    });
+  });
+
+  it("wraps nonzero command failures in GhqDiscoveryError", async () => {
+    const commandFailure = Object.assign(new Error("Command failed"), {
+      code: 2,
+      stderr: "ghq: unknown option --full-path\n",
+    });
+    const commandRunner: GhqCommandRunner = async () => {
+      throw commandFailure;
+    };
+
+    await rejects(
+      discoverGhqRepositories({ commandRunner }),
+      (error: unknown) => {
+        strictEqual(error instanceof GhqDiscoveryError, true);
+        if (!(error instanceof GhqDiscoveryError)) {
+          return false;
+        }
+        strictEqual(
+          error.message,
+          "Failed to discover ghq repositories: ghq: unknown option --full-path",
+        );
+        strictEqual(error.exitCode, 2);
+        strictEqual(error.stderr, "ghq: unknown option --full-path");
+        strictEqual(error.cause, commandFailure);
+        return true;
+      },
+    );
+  });
+
+  it("wraps timeout failures in GhqDiscoveryError", async () => {
+    const timeoutFailure = Object.assign(
+      new Error("Command failed: ghq list --full-path"),
+      {
+        code: null,
+        killed: true,
+        signal: "SIGTERM",
+        stderr: "",
+      },
+    );
+    const commandRunner: GhqCommandRunner = async () => {
+      throw timeoutFailure;
+    };
+
+    await rejects(
+      discoverGhqRepositories({ commandRunner, timeoutMs: 10 }),
+      (error: unknown) => {
+        strictEqual(error instanceof GhqDiscoveryError, true);
+        if (!(error instanceof GhqDiscoveryError)) {
+          return false;
+        }
+        strictEqual(
+          error.message,
+          "Failed to discover ghq repositories: timed out after 10 ms",
+        );
+        strictEqual(error.exitCode, undefined);
+        strictEqual(error.stderr, "");
+        strictEqual(error.cause, timeoutFailure);
+        return true;
+      },
+    );
+  });
+});

--- a/packages/projects/src/ghq.ts
+++ b/packages/projects/src/ghq.ts
@@ -1,0 +1,149 @@
+import { execFile } from "node:child_process";
+import { normalize, resolve } from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const GHQ_COMMAND = "ghq";
+const GHQ_LIST_ARGUMENTS = ["list", "--full-path"] as const;
+export const DEFAULT_GHQ_DISCOVERY_TIMEOUT_MS = 5_000;
+
+export interface GhqCommandResult {
+  stdout: string;
+  stderr: string;
+}
+
+export interface GhqCommandOptions {
+  timeoutMs: number;
+}
+
+export type GhqCommandRunner = (
+  command: string,
+  args: readonly string[],
+  options: GhqCommandOptions,
+) => Promise<GhqCommandResult>;
+
+export interface GhqDiscoveryOptions {
+  commandRunner?: GhqCommandRunner;
+  timeoutMs?: number;
+}
+
+export interface GhqDiscoveryResult {
+  available: boolean;
+  rootPaths: string[];
+}
+
+export class GhqDiscoveryError extends Error {
+  readonly exitCode: number | string | undefined;
+  readonly stderr: string;
+
+  constructor(
+    message: string,
+    options: {
+      cause?: unknown;
+      exitCode?: number | string;
+      stderr?: string;
+    } = {},
+  ) {
+    super(message, { cause: options.cause });
+    this.name = "GhqDiscoveryError";
+    this.exitCode = options.exitCode;
+    this.stderr = options.stderr ?? "";
+  }
+}
+
+export async function discoverGhqRepositories(
+  options: GhqDiscoveryOptions = {},
+): Promise<GhqDiscoveryResult> {
+  const commandRunner = options.commandRunner ?? runCommand;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_GHQ_DISCOVERY_TIMEOUT_MS;
+
+  try {
+    const { stdout } = await commandRunner(GHQ_COMMAND, GHQ_LIST_ARGUMENTS, {
+      timeoutMs,
+    });
+    return {
+      available: true,
+      rootPaths: parseRootPaths(stdout),
+    };
+  } catch (error) {
+    if (getErrorCode(error) === "ENOENT") {
+      return {
+        available: false,
+        rootPaths: [],
+      };
+    }
+
+    const stderr = getErrorStderr(error);
+    const detail = wasKilled(error)
+      ? `timed out after ${timeoutMs} ms`
+      : stderr ||
+        (error instanceof Error ? error.message.trim() : String(error).trim());
+    throw new GhqDiscoveryError(
+      detail
+        ? `Failed to discover ghq repositories: ${detail}`
+        : "Failed to discover ghq repositories",
+      {
+        cause: error,
+        exitCode: getErrorCode(error),
+        stderr,
+      },
+    );
+  }
+}
+
+async function runCommand(
+  command: string,
+  args: readonly string[],
+  options: GhqCommandOptions,
+): Promise<GhqCommandResult> {
+  const { stdout, stderr } = await execFileAsync(command, [...args], {
+    encoding: "utf8",
+    timeout: options.timeoutMs,
+  });
+  return { stdout, stderr };
+}
+
+function parseRootPaths(stdout: string): string[] {
+  return [
+    ...new Set(
+      stdout
+        .split(/\r?\n/u)
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0)
+        .map((rootPath) => normalize(resolve(rootPath))),
+    ),
+  ].sort();
+}
+
+function getErrorCode(error: unknown): number | string | undefined {
+  if (
+    error !== null &&
+    typeof error === "object" &&
+    "code" in error &&
+    (typeof error.code === "number" || typeof error.code === "string")
+  ) {
+    return error.code;
+  }
+  return undefined;
+}
+
+function getErrorStderr(error: unknown): string {
+  if (
+    error !== null &&
+    typeof error === "object" &&
+    "stderr" in error &&
+    typeof error.stderr === "string"
+  ) {
+    return error.stderr.trim();
+  }
+  return "";
+}
+
+function wasKilled(error: unknown): boolean {
+  return (
+    error !== null &&
+    typeof error === "object" &&
+    "killed" in error &&
+    error.killed === true
+  );
+}

--- a/packages/projects/src/index.ts
+++ b/packages/projects/src/index.ts
@@ -1,2 +1,5 @@
+export * from "./catalog.ts";
+export * from "./ghq.ts";
+export * from "./resolve-root.ts";
 export * from "./store.ts";
 export * from "./types.ts";

--- a/packages/projects/src/resolve-root.test.ts
+++ b/packages/projects/src/resolve-root.test.ts
@@ -1,0 +1,70 @@
+import { deepStrictEqual, rejects, strictEqual } from "node:assert";
+import { mkdir, mkdtemp, realpath, rm, symlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, it, vi } from "vitest";
+
+const getGitRootMock = vi.fn();
+
+vi.doMock("@phantompane/git", () => ({
+  getGitRoot: getGitRootMock,
+}));
+
+const { resolveProjectRootPath } = await import("./resolve-root.ts");
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  getGitRootMock.mockReset();
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+async function createTemporaryDirectory(): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), "phantom-project-root-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+describe("resolveProjectRootPath", () => {
+  it("realpaths the input before resolving the common Git root", async () => {
+    const directory = await createTemporaryDirectory();
+    const repositoryPath = join(directory, "repository");
+    const nestedPath = join(repositoryPath, "packages", "projects");
+    const inputLink = join(directory, "input-link");
+    await mkdir(nestedPath, { recursive: true });
+    await symlink(nestedPath, inputLink);
+    getGitRootMock.mockResolvedValue(repositoryPath);
+
+    const result = await resolveProjectRootPath(inputLink);
+
+    strictEqual(result, await realpath(repositoryPath));
+    deepStrictEqual(getGitRootMock.mock.calls, [
+      [{ cwd: await realpath(nestedPath) }],
+    ]);
+  });
+
+  it("realpaths the Git common root returned by getGitRoot", async () => {
+    const directory = await createTemporaryDirectory();
+    const repositoryPath = join(directory, "repository");
+    const repositoryLink = join(directory, "repository-link");
+    await mkdir(repositoryPath);
+    await symlink(repositoryPath, repositoryLink);
+    getGitRootMock.mockResolvedValue(repositoryLink);
+
+    strictEqual(
+      await resolveProjectRootPath(repositoryPath),
+      await realpath(repositoryPath),
+    );
+  });
+
+  it("rejects paths that cannot be resolved", async () => {
+    const directory = await createTemporaryDirectory();
+
+    await rejects(resolveProjectRootPath(join(directory, "missing")), /ENOENT/);
+    strictEqual(getGitRootMock.mock.calls.length, 0);
+  });
+});

--- a/packages/projects/src/resolve-root.ts
+++ b/packages/projects/src/resolve-root.ts
@@ -1,0 +1,11 @@
+import { realpath } from "node:fs/promises";
+import { resolve } from "node:path";
+import { getGitRoot } from "@phantompane/git";
+
+export async function resolveProjectRootPath(
+  inputPath: string,
+): Promise<string> {
+  const resolvedPath = await realpath(resolve(inputPath));
+  const gitRoot = await getGitRoot({ cwd: resolvedPath });
+  return await realpath(gitRoot);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,6 +167,9 @@ importers:
 
   packages/projects:
     dependencies:
+      '@phantompane/git':
+        specifier: workspace:*
+        version: link:../git
       zod:
         specifier: ^4.4.3
         version: 4.4.3


### PR DESCRIPTION
## Summary

- discover repositories from `ghq list --full-path` and merge them into the project catalog without persisting them in Phantom's native registry
- add the global `phantom.ghqDiscovery` preference, enabled by default and configurable through the existing preferences CLI
- return a version 2 project-list schema with explicit `registry` and `ghq` sources while keeping registered projects authoritative
- add a finite ghq subprocess timeout, bounded Git-root resolution concurrency, shell completions, documentation, unit tests, and packaged E2E coverage

## Why

The native project registry introduced in #668 gives Phantom a stable, explicit inventory. Many local development environments already organize repositories through ghq, so Phantom should also be able to discover those repositories without copying them into its own storage or making ghq a hard dependency.

## Behavior and safety

- ghq entries are discovered dynamically; listing projects never writes them into the native registry
- linked worktrees and duplicate ghq paths are canonicalized to their common Git repository root, including worktrees backed by bare repositories
- when the same root exists in both sources, the native registry record wins
- removing a registered project still removes only its registry record; a ghq-managed repository can remain visible as a discovered entry
- a missing ghq executable is silently treated as unavailable
- other ghq failures and the 5-second timeout return registry results with exit code 0, emit a warning only on stderr, and keep JSON stdout parseable
- Git-root resolution uses bounded concurrency and preserves deterministic output
- `phantom preferences set ghqDiscovery false` disables discovery and restores registry-only listing

## JSON output

`phantom project list --json` now returns catalog schema version 2. Every entry includes a `source` discriminator. Registry entries retain `id` and `createdAt`; transient ghq entries contain only `source`, `name`, and `rootPath`.

## Versioning

No package version was changed in this pull request. Version updates remain owned by the GitHub Actions version-bump workflow.

## Validation

- `pnpm ready` (35/35 tasks)
- `pnpm ready:check` (35/35 tasks)
- `pnpm build`
- Git package tests (46/46)
- project package tests (34/34)
- CLI unit tests (138/138)
- packaged CLI E2E tests (17/17), including discovery disablement and stderr-only failure fallback
- Bash completion tests (10/10)
- Zsh completion tests (7/7)
- actual ghq smoke test against the local catalog, including linked-worktree deduplication
- real-Git regression coverage for a bare repository and its linked worktree, isolated from global and system Git configuration
- independent correctness and UX/test reviews found no remaining Must or Should issues

## Environment note

Fish is not installed in the local development environment. Its generated and static completion definitions were checked for consistency, and GitHub Actions runs the Fish-specific test suite.
