### PR TITLE
feat: list projects through MCP

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -65,9 +65,56 @@ phantom mcp serve
 
 ## Available MCP Commands
 
-The Phantom MCP server exposes four main tools:
+The Phantom MCP server exposes five main tools:
 
-### 1. `phantom_create_worktree`
+### 1. `phantom_list_projects`
+
+Lists projects registered directly with Phantom and repositories discovered
+through ghq. The response is a versioned project catalog containing each
+project's `source` and canonical `rootPath`. ghq discovery follows the
+`phantom.ghqDiscovery` preference.
+
+**Parameters:** None
+
+**Example:**
+
+```typescript
+{
+  "tool": "phantom_list_projects",
+  "arguments": {}
+}
+```
+
+**Response:**
+
+```json
+{
+  "version": 2,
+  "projects": [
+    {
+      "source": "registry",
+      "id": "proj_00000000-0000-4000-8000-000000000001",
+      "name": "phantom",
+      "rootPath": "/home/user/repo/github.com/phantompane/phantom",
+      "createdAt": "2026-07-20T00:00:00.000Z"
+    },
+    {
+      "source": "ghq",
+      "name": "another-project",
+      "rootPath": "/home/user/repo/github.com/example/another-project"
+    }
+  ],
+  "warnings": [],
+  "note": "Use rootPath to identify a project."
+}
+```
+
+Registered projects include stable `id` and `createdAt` fields. Projects
+discovered from ghq are read in real time and only include `source`, `name`, and
+`rootPath`; they are not copied into Phantom's registry. A ghq discovery failure
+is reported in `warnings` without discarding registered projects.
+
+### 2. `phantom_create_worktree`
 
 Creates a new Git worktree.
 
@@ -88,7 +135,7 @@ Creates a new Git worktree.
 }
 ```
 
-### 2. `phantom_list_worktrees`
+### 3. `phantom_list_worktrees`
 
 Lists all Git worktrees (phantoms).
 
@@ -103,7 +150,7 @@ Lists all Git worktrees (phantoms).
 }
 ```
 
-### 3. `phantom_delete_worktree`
+### 4. `phantom_delete_worktree`
 
 Deletes a Git worktree (phantom).
 
@@ -128,7 +175,7 @@ If `keepBranch` is omitted, Phantom falls back to the user's `phantom.keepBranch
 }
 ```
 
-### 4. `phantom_github_checkout`
+### 5. `phantom_github_checkout`
 
 Checkout a GitHub issue or pull request by number into a new worktree.
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -15,7 +15,9 @@
   "dependencies": {
     "@phantompane/core": "workspace:*",
     "@phantompane/git": "workspace:*",
+    "@phantompane/preferences": "workspace:*",
     "@phantompane/process": "workspace:*",
+    "@phantompane/projects": "workspace:*",
     "@phantompane/utils": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "zod": "^4.4.3"

--- a/packages/mcp/src/index.test.ts
+++ b/packages/mcp/src/index.test.ts
@@ -19,6 +19,7 @@ const { createMcpServer } = await import("./index.ts");
 
 it("exposes and returns the structured project catalog over MCP", async () => {
   const expected = {
+    schemaVersion: 1,
     version: 2,
     projects: [
       {
@@ -57,6 +58,7 @@ it("exposes and returns the structured project catalog over MCP", async () => {
     strictEqual(listedTool.annotations?.readOnlyHint, true);
     strictEqual(listedTool.outputSchema?.type, "object");
     deepStrictEqual(listedTool.outputSchema?.required, [
+      "schemaVersion",
       "version",
       "projects",
       "warnings",

--- a/packages/mcp/src/index.test.ts
+++ b/packages/mcp/src/index.test.ts
@@ -1,0 +1,86 @@
+import { deepStrictEqual, ok, strictEqual } from "node:assert";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { it, vi } from "vitest";
+
+const listProjectCatalogMock = vi.fn();
+const loadPreferencesMock = vi.fn();
+
+vi.doMock("@phantompane/preferences", () => ({
+  loadPreferences: loadPreferencesMock,
+}));
+
+vi.doMock("@phantompane/projects", () => ({
+  PROJECT_LIST_VERSION: 2,
+  listProjectCatalog: listProjectCatalogMock,
+}));
+
+const { createMcpServer } = await import("./index.ts");
+
+it("exposes and returns the structured project catalog over MCP", async () => {
+  const expected = {
+    version: 2,
+    projects: [
+      {
+        source: "ghq",
+        name: "phantom",
+        rootPath: "/repos/phantom",
+      },
+    ],
+    warnings: [],
+    note: "Use rootPath to identify a project.",
+  };
+  loadPreferencesMock.mockResolvedValue({});
+  listProjectCatalogMock.mockResolvedValue({
+    version: expected.version,
+    projects: expected.projects,
+    warnings: expected.warnings,
+  });
+
+  const server = createMcpServer();
+  const client = new Client({
+    name: "phantom-mcp-test-client",
+    version: "1.0.0",
+  });
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  try {
+    const listedTools = await client.listTools();
+    const listedTool = listedTools.tools.find(
+      (tool) => tool.name === "phantom_list_projects",
+    );
+    ok(listedTool);
+    strictEqual(listedTool.annotations?.readOnlyHint, true);
+    strictEqual(listedTool.outputSchema?.type, "object");
+    deepStrictEqual(listedTool.outputSchema?.required, [
+      "version",
+      "projects",
+      "warnings",
+      "note",
+    ]);
+
+    const result = await client.callTool({
+      name: "phantom_list_projects",
+      arguments: {},
+    });
+    deepStrictEqual(result.structuredContent, expected);
+
+    if (!("content" in result) || !Array.isArray(result.content)) {
+      throw new Error("Expected immediate tool content");
+    }
+    const [content] = result.content;
+    ok(content);
+    strictEqual(content.type, "text");
+    if (content.type !== "text") {
+      throw new Error("Expected text content");
+    }
+    deepStrictEqual(JSON.parse(content.text), expected);
+  } finally {
+    await client.close();
+    await server.close();
+  }
+});

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -4,32 +4,49 @@ import packageJson from "../package.json" with { type: "json" };
 import { createWorktreeTool } from "./tools/create-worktree.ts";
 import { deleteWorktreeTool } from "./tools/delete-worktree.ts";
 import { githubCheckoutTool } from "./tools/github-checkout.ts";
+import { listProjectsTool } from "./tools/list-projects.ts";
 import { listWorktreesTool } from "./tools/list-worktrees.ts";
 
-const server = new McpServer({
-  name: "Phantom MCP Server",
-  version: packageJson.version,
-});
+export function createMcpServer() {
+  const server = new McpServer({
+    name: "Phantom MCP Server",
+    version: packageJson.version,
+  });
 
-// Define all tools
-const tools = [
-  createWorktreeTool,
-  listWorktreesTool,
-  deleteWorktreeTool,
-  githubCheckoutTool,
-];
-
-// Register tools
-for (const tool of tools) {
-  server.tool(
-    tool.name,
-    tool.description,
-    tool.inputSchema.shape,
-    tool.handler,
+  server.registerTool(
+    listProjectsTool.name,
+    {
+      description: listProjectsTool.description,
+      inputSchema: listProjectsTool.inputSchema.shape,
+      outputSchema: listProjectsTool.outputSchema.shape,
+      annotations: {
+        readOnlyHint: true,
+      },
+    },
+    listProjectsTool.handler,
   );
+
+  const tools = [
+    createWorktreeTool,
+    listWorktreesTool,
+    deleteWorktreeTool,
+    githubCheckoutTool,
+  ];
+
+  for (const tool of tools) {
+    server.tool(
+      tool.name,
+      tool.description,
+      tool.inputSchema.shape,
+      tool.handler,
+    );
+  }
+
+  return server;
 }
 
 export async function serve() {
+  const server = createMcpServer();
   const transport = new StdioServerTransport();
   await server.connect(transport);
 

--- a/packages/mcp/src/tools/list-projects.test.ts
+++ b/packages/mcp/src/tools/list-projects.test.ts
@@ -48,6 +48,7 @@ describe("listProjectsTool", () => {
     deepStrictEqual(Object.keys(listProjectsTool.inputSchema.shape), []);
     strictEqual(listProjectsTool.outputSchema instanceof z.ZodObject, true);
     deepStrictEqual(Object.keys(listProjectsTool.outputSchema.shape), [
+      "schemaVersion",
       "version",
       "projects",
       "warnings",
@@ -82,6 +83,7 @@ describe("listProjectsTool", () => {
       [{ includeGhq: true }],
     ]);
     const expected = {
+      schemaVersion: 1,
       version: 2,
       projects,
       warnings: [],

--- a/packages/mcp/src/tools/list-projects.test.ts
+++ b/packages/mcp/src/tools/list-projects.test.ts
@@ -1,0 +1,137 @@
+import { deepStrictEqual, rejects, strictEqual } from "node:assert";
+import { beforeEach, describe, it, vi } from "vitest";
+import { z } from "zod";
+
+const listProjectCatalogMock = vi.fn();
+const loadPreferencesMock = vi.fn();
+
+vi.doMock("@phantompane/preferences", () => ({
+  loadPreferences: loadPreferencesMock,
+}));
+
+vi.doMock("@phantompane/projects", () => ({
+  PROJECT_LIST_VERSION: 2,
+  listProjectCatalog: listProjectCatalogMock,
+}));
+
+const { listProjectsTool } = await import("./list-projects.ts");
+
+const handlerExtra = {} as never;
+
+function getTextContent(result: {
+  content: Array<{ type: "text"; text: string } | { type: string }>;
+}) {
+  const [content] = result.content;
+  strictEqual(content.type, "text");
+
+  if (content.type !== "text") {
+    throw new Error("Expected text content");
+  }
+
+  return (content as { type: "text"; text: string }).text;
+}
+
+describe("listProjectsTool", () => {
+  beforeEach(() => {
+    listProjectCatalogMock.mockReset();
+    loadPreferencesMock.mockReset();
+    loadPreferencesMock.mockResolvedValue({});
+  });
+
+  it("has project discovery metadata and an empty input schema", () => {
+    strictEqual(listProjectsTool.name, "phantom_list_projects");
+    strictEqual(
+      listProjectsTool.description,
+      "List registered and discovered Git projects",
+    );
+    strictEqual(listProjectsTool.inputSchema instanceof z.ZodObject, true);
+    deepStrictEqual(Object.keys(listProjectsTool.inputSchema.shape), []);
+    strictEqual(listProjectsTool.outputSchema instanceof z.ZodObject, true);
+    deepStrictEqual(Object.keys(listProjectsTool.outputSchema.shape), [
+      "version",
+      "projects",
+      "warnings",
+      "note",
+    ]);
+  });
+
+  it("returns the versioned project catalog", async () => {
+    const projects = [
+      {
+        source: "registry",
+        id: "proj_00000000-0000-4000-8000-000000000001",
+        name: "alpha",
+        rootPath: "/repos/alpha",
+        createdAt: "2026-07-20T00:00:00.000Z",
+      },
+      {
+        source: "ghq",
+        name: "beta",
+        rootPath: "/repos/beta",
+      },
+    ];
+    listProjectCatalogMock.mockResolvedValue({
+      version: 2,
+      projects,
+      warnings: [],
+    });
+
+    const result = await listProjectsTool.handler({}, handlerExtra);
+
+    deepStrictEqual(listProjectCatalogMock.mock.calls, [
+      [{ includeGhq: true }],
+    ]);
+    const expected = {
+      version: 2,
+      projects,
+      warnings: [],
+      note: "Use rootPath to identify a project.",
+    };
+    deepStrictEqual(JSON.parse(getTextContent(result)), expected);
+    deepStrictEqual(result.structuredContent, expected);
+    strictEqual(
+      listProjectsTool.outputSchema.safeParse(expected).success,
+      true,
+    );
+  });
+
+  it("honors the ghq discovery preference", async () => {
+    loadPreferencesMock.mockResolvedValue({ ghqDiscovery: false });
+    listProjectCatalogMock.mockResolvedValue({
+      version: 2,
+      projects: [],
+      warnings: [],
+    });
+
+    await listProjectsTool.handler({}, handlerExtra);
+
+    deepStrictEqual(listProjectCatalogMock.mock.calls, [
+      [{ includeGhq: false }],
+    ]);
+  });
+
+  it("returns ghq discovery warnings without failing", async () => {
+    listProjectCatalogMock.mockResolvedValue({
+      version: 2,
+      projects: [],
+      warnings: ["Failed to discover ghq repositories: command failed"],
+    });
+
+    const result = await listProjectsTool.handler({}, handlerExtra);
+
+    deepStrictEqual(JSON.parse(getTextContent(result)).warnings, [
+      "Failed to discover ghq repositories: command failed",
+    ]);
+  });
+
+  it("propagates native project registry failures", async () => {
+    listProjectCatalogMock.mockRejectedValue(
+      new Error("Failed to read project registry"),
+    );
+
+    await rejects(
+      async () => await listProjectsTool.handler({}, handlerExtra),
+      /Failed to read project registry/,
+    );
+  });
+});

--- a/packages/mcp/src/tools/list-projects.ts
+++ b/packages/mcp/src/tools/list-projects.ts
@@ -1,0 +1,72 @@
+import { loadPreferences } from "@phantompane/preferences";
+import {
+  listProjectCatalog,
+  PROJECT_LIST_VERSION,
+} from "@phantompane/projects";
+import { z } from "zod";
+import type { StructuredTool } from "./types.ts";
+
+const schema = z.object({});
+
+const registryProjectSchema = z
+  .object({
+    source: z.literal("registry"),
+    id: z.string(),
+    name: z.string(),
+    rootPath: z.string().describe("Canonical absolute Git repository path"),
+    createdAt: z.string().describe("ISO 8601 registration timestamp"),
+  })
+  .strict();
+
+const ghqProjectSchema = z
+  .object({
+    source: z.literal("ghq"),
+    name: z.string(),
+    rootPath: z.string().describe("Canonical absolute Git repository path"),
+  })
+  .strict();
+
+export const listProjectsOutputSchema = z
+  .object({
+    version: z.literal(PROJECT_LIST_VERSION),
+    projects: z.array(
+      z.discriminatedUnion("source", [registryProjectSchema, ghqProjectSchema]),
+    ),
+    warnings: z
+      .array(z.string())
+      .describe("Non-fatal project discovery warnings"),
+    note: z.string(),
+  })
+  .strict();
+
+export const listProjectsTool: StructuredTool<
+  typeof schema,
+  typeof listProjectsOutputSchema
+> = {
+  name: "phantom_list_projects",
+  description: "List registered and discovered Git projects",
+  inputSchema: schema,
+  outputSchema: listProjectsOutputSchema,
+  handler: async () => {
+    const preferences = await loadPreferences();
+    const catalog = await listProjectCatalog({
+      includeGhq: preferences.ghqDiscovery !== false,
+    });
+    const structuredContent = {
+      version: catalog.version,
+      projects: catalog.projects,
+      warnings: catalog.warnings,
+      note: "Use rootPath to identify a project.",
+    } satisfies z.infer<typeof listProjectsOutputSchema>;
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(structuredContent, null, 2),
+        },
+      ],
+      structuredContent,
+    };
+  },
+};

--- a/packages/mcp/src/tools/list-projects.ts
+++ b/packages/mcp/src/tools/list-projects.ts
@@ -28,6 +28,7 @@ const ghqProjectSchema = z
 
 export const listProjectsOutputSchema = z
   .object({
+    schemaVersion: z.literal(1),
     version: z.literal(PROJECT_LIST_VERSION),
     projects: z.array(
       z.discriminatedUnion("source", [registryProjectSchema, ghqProjectSchema]),
@@ -53,6 +54,7 @@ export const listProjectsTool: StructuredTool<
       includeGhq: preferences.ghqDiscovery !== false,
     });
     const structuredContent = {
+      schemaVersion: 1,
       version: catalog.version,
       projects: catalog.projects,
       warnings: catalog.warnings,

--- a/packages/mcp/src/tools/types.ts
+++ b/packages/mcp/src/tools/types.ts
@@ -7,3 +7,10 @@ export interface Tool<TSchema extends z.ZodObject> {
   inputSchema: TSchema;
   handler: ToolCallback<TSchema>;
 }
+
+export interface StructuredTool<
+  TInputSchema extends z.ZodObject,
+  TOutputSchema extends z.ZodObject,
+> extends Tool<TInputSchema> {
+  outputSchema: TOutputSchema;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,9 +136,15 @@ importers:
       '@phantompane/git':
         specifier: workspace:*
         version: link:../git
+      '@phantompane/preferences':
+        specifier: workspace:*
+        version: link:../preferences
       '@phantompane/process':
         specifier: workspace:*
         version: link:../process
+      '@phantompane/projects':
+        specifier: workspace:*
+        version: link:../projects
       '@phantompane/utils':
         specifier: workspace:*
         version: link:../utils


### PR DESCRIPTION
Summary

Expose a read-only phantom_list_projects tool on the Phantom MCP server that returns the existing Catalog v2 via structuredContent, while preserving the JSON text content for compatibility. This enables agents to select a project from a neutral cwd before later worktree-scoped operations.

What changed
- Added MCP structuredContent for project listing and kept equivalent JSON text content
- Introduced MCP envelope schemaVersion: 1 to phantom_list_projects (separate from Catalog version)
- Kept Catalog v2 contract intact: version, projects (registry | ghq), warnings, note; rootPath is the canonical project identifier
- Ensured ghq is live discovery only; we never copy ghq results into the native registry; non-fatal ghq errors are surfaced in warnings without dropping registry projects
- Registered phantom_list_projects as read-only (annotations.readOnlyHint)
- Followed onto latest main via a merge and re-ran tests against current deps (including MCP SDK 1.30.0)

MCP contract
- Tool name: phantom_list_projects
- Input: {}
- Output (structuredContent):
  - schemaVersion: 1
  - version: 2 (Catalog v2)
  - projects: discriminated union by source ("registry" | "ghq")
  - warnings: string[] (non-fatal discovery issues)
  - note: guidance to use rootPath for identification
- JSON text content mirrors structuredContent for backwards compatibility

Validation
- pnpm ready: lint, typecheck, and tests all green locally
- MCP protocol tests validate:
  - Tool is listed with outputSchema and readOnly hint
  - structuredContent matches schema
  - JSON text content serializes the same payload
- Stdio server clean shutdown handlers (SIGINT/SIGTERM) exercised via server wiring; no changes required

Not in scope (unchanged)
- No changes to existing MCP worktree tools (inputs, public schemas, defaults)
- No CLI cwd behavior changes
- No security changes (phantom_delete_worktree remains as-is; separate PR tracks that)
- No Web UI changes; no widening into create/delete/inspect worktrees or MCP contract v2

How to verify
- pnpm ready
- Run unit tests in packages/mcp (tool listing + structuredContent assertions)
- Optional: start server via `pnpm phantom mcp serve` and call phantom_list_projects; verify outputSchema and structuredContent presence; send SIGINT to confirm clean shutdown

Notes
- Branch is updated to latest main (via merge) so CI will validate against current dependencies.